### PR TITLE
Set value service

### DIFF
--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -16,6 +16,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
         self.device_id = appliance.device_id
+        self.puid = appliance.puid
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, appliance.device_id)},
             model=appliance.device_feature_name,

--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -5,6 +5,6 @@
   "config_flow": true,
   "documentation": "https://github.com/oyvindwe/connectlife-ha",
   "iot_class": "cloud_polling",
-  "requirements": ["connectlife==0.0.5"],
+  "requirements": ["connectlife @ git+https://github.com/oyvindwe/connectlife.git@write-properties"],
   "version": "0.0.6"
 }

--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -5,6 +5,6 @@
   "config_flow": true,
   "documentation": "https://github.com/oyvindwe/connectlife-ha",
   "iot_class": "cloud_polling",
-  "requirements": ["connectlife @ git+https://github.com/oyvindwe/connectlife.git@write-properties"],
-  "version": "0.0.6"
+  "requirements": ["connectlife==0.2.0"],
+  "version": "0.1.0"
 }

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -67,4 +67,4 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
     async def async_set_value(self, value: int) -> None:
         """Set value for this sensor."""
         _LOGGER.debug("Setting %s to %d", self.status, value)
-        await self.coordinator.api.update_appliance(self.device_id, {self.status: str(value)})
+        await self.coordinator.api.update_appliance(self.puid, {self.status: str(value)})

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -1,11 +1,12 @@
 """Provides a sensor for ConnectLife."""
 
 import logging
-
+import voluptuous as vol
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import config_validation as cv, entity_platform, service
 
 from .const import (
     DOMAIN,
@@ -13,6 +14,8 @@ from .const import (
 from .coordinator import ConnectLifeCoordinator
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
+
+SERVICE_SET_VALUE = "set_value"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,13 +26,18 @@ async def async_setup_entry(
         async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up ConnectLife sensors."""
-
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-
     for appliance in coordinator.appliances.values():
         async_add_entities(
             ConnectLifeStatusSensor(coordinator, appliance, s) for s in appliance.status_list
         )
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_SET_VALUE,
+        {vol.Required("value"): cv.positive_int},
+        "async_set_value",
+    )
 
 
 class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
@@ -46,7 +54,8 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
 
     @callback
     def update_state(self):
-        self._attr_native_value = self.coordinator.appliances[self.device_id].status_list[self.status]
+        if self.status in self.coordinator.appliances[self.device_id].status_list:
+            self._attr_native_value = self.coordinator.appliances[self.device_id].status_list[self.status]
         self._attr_available = self.coordinator.appliances[self.device_id]._offline_state == 1
 
     @callback
@@ -54,3 +63,8 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         self.update_state()
         self.async_write_ha_state()
+
+    async def async_set_value(self, value: int) -> None:
+        """Set value for this sensor."""
+        _LOGGER.debug("Setting %s to %d", self.status, value)
+        await self.coordinator.api.update_appliance(self.device_id, {self.status: str(value)})

--- a/custom_components/connectlife/services.yaml
+++ b/custom_components/connectlife/services.yaml
@@ -1,0 +1,12 @@
+set_value:
+  target:
+    entity:
+      integration: connectlifte
+      domain: sensor
+  fields:
+    value:
+      required: true
+      selector:
+        number:
+          min: 0
+

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -16,5 +16,17 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "services": {
+    "set_value": {
+      "name": "Set value",
+      "description": "Sets a value for the status. Use with care.",
+      "fields": {
+        "value": {
+          "name": "Value",
+          "description": "Value to set."
+        }
+      }
+    }
   }
 }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -17,5 +17,17 @@
                 }
             }
         }
+    },
+    "services": {
+        "set_value": {
+            "name": "Set value",
+            "description": "Sets a value for the status. Use with care.",
+            "fields": {
+                "value": {
+                    "name": "Value",
+                    "description": "Value to set."
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Service to set value on a ConnectLife status entity.

Note that there is no validation if the value is supported, or if the property is writeable.

Fixes #1 