### PR TITLE
Fix target entities for service set_value

### DIFF
--- a/custom_components/connectlife/services.yaml
+++ b/custom_components/connectlife/services.yaml
@@ -1,7 +1,7 @@
 set_value:
   target:
     entity:
-      integration: connectlifte
+      integration: connectlife
       domain: sensor
   fields:
     value:


### PR DESCRIPTION
Fixes the issue that connectlife entities did not show up when using service `set_value` in the developer tools UI.