### PR TITLE
Fix humidifier regression

### DIFF
--- a/custom_components/connectlife/humidifier.py
+++ b/custom_components/connectlife/humidifier.py
@@ -106,8 +106,8 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
                 self._attr_supported_features |= HumidifierEntityFeature.MODES
                 self._attr_mode = None
             elif target == TARGET_HUMIDITY:
-                self._attr_min_humidity = data_dictionary[status].climate.min_value
-                self._attr_max_humidity = data_dictionary[status].climate.max_value
+                self._attr_min_humidity = data_dictionary[status].humidifier.min_value
+                self._attr_max_humidity = data_dictionary[status].humidifier.max_value
 
         self.update_state()
 


### PR DESCRIPTION
Humidifier was broken in version 0.7.0 due to a copy&paste error in PR #34.