### PR TITLE
Added device 009-128 (air conditioner)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -5,7 +5,6 @@ climate:
       t_eco: 1
       t_fan_speed: 0 # auto
     - preset: mute
-      icon: mdi:volume-variant-off
       t_power: 1
       t_fan_mute: 1
       t_fan_speed: 0 # auto
@@ -77,3 +76,17 @@ properties:
         2: cool
         3: dry
         4: auto
+  - property: f_votage
+    sensor:
+      device_class: voltage
+      unit: V
+  - property: f_cool_qvalue
+    icon: mdi:snowflake
+    sensor:
+      unit: BTU/hr
+      state_class: measurement
+  - property: f_heat_qvalue
+    icon: mdi:weather-sunny
+    sensor:
+      unit: BTU/hr
+      state_class: measurement

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -1,0 +1,80 @@
+climate:
+  presets:
+    - preset: eco
+      t_power: 1
+      t_eco: 1
+      t_fan_speed: 0 # auto
+    - preset: quiet cooling
+      icon: mdi:volume-variant-off
+      t_power: 1
+      t_fan_mute: 1
+      t_fan_speed: 0 # auto
+      t_work_mode: 2
+properties:
+  - property: f_temp_in
+    climate:
+      target: current_temperature
+  - property: t_eco
+    icon: mdi:leaf
+    switch:
+      device_class: switch
+  - property: t_fan_mute
+    icon: mdi:volume-variant-off
+    switch:
+      device_class: switch
+  - property: t_fan_speed
+    climate:
+      target: fan_mode
+      options:
+        0: auto
+        5: low
+        6: middle_low
+        7: medium
+        8: middle_high
+        9: high
+  - property: t_power
+    climate:
+      target: is_on
+  - property: t_sleep
+    icon: mdi:sleep
+    select:
+      options:
+        0: "off"
+        1: general
+        2: for_old
+        3: for_young
+        4: for_kid
+  - property: t_super
+    icon: mdi:run-fast
+    switch:
+      device_class: switch
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
+  - property: t_temp
+    climate:
+      target: target_temperature
+      min_value:
+        celsius: 16
+        fahrenheit: 61
+      max_value:
+        celsius: 32
+        fahrenheit: 90
+  - property: t_temp_type
+    climate:
+      target: temperature_unit
+      options:
+        0: celsius
+        1: fahrenheit
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        1: heat
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -4,12 +4,11 @@ climate:
       t_power: 1
       t_eco: 1
       t_fan_speed: 0 # auto
-    - preset: quiet cooling
+    - preset: mute
       icon: mdi:volume-variant-off
       t_power: 1
       t_fan_mute: 1
       t_fan_speed: 0 # auto
-      t_work_mode: 2
 properties:
   - property: f_temp_in
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -86,7 +86,7 @@ properties:
       unit: BTU/hr
       state_class: measurement
   - property: f_heat_qvalue
-    icon: mdi:weather-sunny
+    icon: mdi:fire
     sensor:
       unit: BTU/hr
       state_class: measurement

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -83,10 +83,10 @@ properties:
   - property: f_cool_qvalue
     icon: mdi:snowflake
     sensor:
-      unit: BTU/hr
+      unit: BTU/h
       state_class: measurement
   - property: f_heat_qvalue
     icon: mdi:fire
     sensor:
-      unit: BTU/hr
+      unit: BTU/h
       state_class: measurement

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -621,6 +621,15 @@
       },
       "Zone_number": {
         "name": "Number of zones"
+      },
+      "f_heat_qvalue": {
+        "name": "BTU/Hr Heating"
+      },
+      "f_cool_qvalue": {
+        "name": "BTU/Hr Cooling"
+      },
+      "f_votage": {
+        "name": "Measured Grid Voltage"
       }
     },
     "switch": {

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -623,13 +623,13 @@
         "name": "Number of zones"
       },
       "f_heat_qvalue": {
-        "name": "BTU/Hr Heating"
+        "name": "Heating"
       },
       "f_cool_qvalue": {
-        "name": "BTU/Hr Cooling"
+        "name": "Cooling"
       },
       "f_votage": {
-        "name": "Measured Grid Voltage"
+        "name": "Measured grid voltage"
       }
     },
     "switch": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -623,13 +623,13 @@
                 "name": "Number of zones"
             },
             "f_heat_qvalue": {
-              "name": "BTU/Hr Heating"
+              "name": "Heating"
             },
             "f_cool_qvalue": {
-              "name": "BTU/Hr Cooling"
+              "name": "Cooling"
             },
             "f_votage": {
-              "name": "Measured Grid Voltage"
+              "name": "Measured grid voltage"
             }
         },
         "switch": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -621,6 +621,15 @@
             },
             "Zone_number": {
                 "name": "Number of zones"
+            },
+            "f_heat_qvalue": {
+              "name": "BTU/Hr Heating"
+            },
+            "f_cool_qvalue": {
+              "name": "BTU/Hr Cooling"
+            },
+            "f_votage": {
+              "name": "Measured Grid Voltage"
             }
         },
         "switch": {


### PR DESCRIPTION
Added my model of AC. Seems similar to existing model 09-100, so copied but adjusted presets for my own use case. 




Further improvements to data_dictionary for this model and possibly others: 
- property f_votage corresponds to grid voltage, as measured by the indoor unit. 
Couldn't get this to work to add it as a property with the correct sensor device class. 

- property f_cool_qvalue corresponds to the BTU/hr of the unit, how much heat it's removing at that moment. Cool data to know how "hard" the aircon is working at a certain point in time.

- property t_fan_speed_s remains equal to t_fan_speed, so this property can probably be disabled by default?