### PR TITLE
Map `daily_energy_kwh` for all devices

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006-200.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-200.yaml
@@ -1,5 +1,12 @@
 # Portable air conditioner
 properties:
+- property: daily_energy_kwh
+  hide: true
+  sensor:
+    read_only: true
+    state_class: total_increasing
+    device_class: energy
+    unit: kWh
 - property: f_temp_in
   icon: mdi:temp
   climate:

--- a/custom_components/connectlife/data_dictionaries/006-201.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-201.yaml
@@ -3,7 +3,8 @@ properties:
 - property: daily_energy_kwh
   hide: true
   sensor:
-    state_class: total
+    read_only: true
+    state_class: total_increasing
     device_class: energy
     unit: kWh
 - property: f_temp_in

--- a/custom_components/connectlife/data_dictionaries/007-400.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-400.yaml
@@ -2,7 +2,8 @@ properties:
   - property: daily_energy_kwh
     hide: true
     sensor:
-      state_class: total
+      read_only: true
+      state_class: total_increasing
       device_class: energy
       unit: kWh
   - property: f_e_filterclean

--- a/custom_components/connectlife/data_dictionaries/007-406.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-406.yaml
@@ -2,7 +2,8 @@ properties:
   - property: daily_energy_kwh
     hide: true
     sensor:
-      state_class: total
+      read_only: true
+      state_class: total_increasing
       device_class: energy
       unit: kWh
   - property: f_e_filterclean

--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -71,6 +71,13 @@ climate:
       t_fan_mute: 0
       t_super: 0
 properties:
+  - property: daily_energy_kwh
+    hide: true
+    sensor:
+      read_only: true
+      state_class: total_increasing
+      device_class: energy
+      unit: kWh
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/009-106.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-106.yaml
@@ -8,6 +8,13 @@ climate:
       t_power: 1
       t_tms: 1
 properties:
+  - property: daily_energy_kwh
+    hide: true
+    sensor:
+      read_only: true
+      state_class: total_increasing
+      device_class: energy
+      unit: kWh
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/009-109.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-109.yaml
@@ -8,6 +8,13 @@ climate:
       t_power: 1
       t_tms: 1
 properties:
+  - property: daily_energy_kwh
+    hide: true
+    sensor:
+      read_only: true
+      state_class: total_increasing
+      device_class: energy
+      unit: kWh
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/009-117.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-117.yaml
@@ -8,6 +8,13 @@ climate:
       t_power: 1
       t_tms: 1
 properties:
+  - property: daily_energy_kwh
+    hide: true
+    sensor:
+      read_only: true
+      state_class: total_increasing
+      device_class: energy
+      unit: kWh
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -9,6 +9,13 @@ climate:
       t_fan_mute: 1
       t_fan_speed: 0 # auto
 properties:
+  - property: daily_energy_kwh
+    hide: true
+    sensor:
+      read_only: true
+      state_class: total_increasing
+      device_class: energy
+      unit: kWh
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/009-129.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-129.yaml
@@ -11,7 +11,8 @@ properties:
   - property: daily_energy_kwh
     hide: true
     sensor:
-      state_class: total
+      read_only: true
+      state_class: total_increasing
       device_class: energy
       unit: kWh
   - property: f_votage

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -2,7 +2,7 @@ properties:
   - property: ADO_allowed
     hide: true
     sensor:
-      read-only: true
+      read_only: true
   - property: Alarm_auto_dose_refill
     binary_sensor:
       device_class: problem
@@ -84,27 +84,27 @@ properties:
     icon: mdi:dishwasher-alert
   - property: Auto_dose_duration
     sensor:
-      read-only: true
+      read_only: true
       device_class: duration
       unit: min
   - property: Auto_dose_quantity_setting_status
     sensor:
-      read-only: true
+      read_only: true
   - property: Auto_dose_refill
     sensor:
-      read-only: true
+      read_only: true
   - property: Auto_dose_setting_status
     sensor:
-      read-only: true
+      read_only: true
   - property: Child_lock
     hide: true
   - property: Child_lock_setting_status
     hide: true
     sensor:
-      read-only: true
+      read_only: true
   - property: Curent_program_duration
     sensor:
-      read-only: true
+      read_only: true
       device_class: duration
       unit: min
   - property: Curent_program_remaining_time
@@ -407,6 +407,7 @@ properties:
   - property: daily_energy_kwh
     hide: true
     sensor:
-      state_class: total
+      read_only: true
+      state_class: total_increasing
       device_class: energy
       unit: kWh

--- a/custom_components/connectlife/data_dictionaries/016-502.yaml
+++ b/custom_components/connectlife/data_dictionaries/016-502.yaml
@@ -1,4 +1,11 @@
 properties:
+  - property: daily_energy_kwh
+    hide: true
+    sensor:
+      read_only: true
+      state_class: total_increasing
+      device_class: energy
+      unit: kWh
   - property: f_water_tank_temp
     water_heater:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/020-63c45b513e1a4bf7.yaml
+++ b/custom_components/connectlife/data_dictionaries/020-63c45b513e1a4bf7.yaml
@@ -626,9 +626,9 @@ properties:
   # Sample value: 5
   hide: true
 - property: daily_energy_kwh
-  # Sample value: 0
   hide: true
   sensor:
-    state_class: total
+    read_only: true
+    state_class: total_increasing
     device_class: energy
     unit: kWh

--- a/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
@@ -28,7 +28,8 @@ properties:
   - property: daily_energy_kwh
     hide: true
     sensor:
-      state_class: total
+      read_only: true
+      state_class: total_increasing
       device_class: energy
       unit: kWh
   - property: date_display_format_status

--- a/custom_components/connectlife/data_dictionaries/032-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/032-000.yaml
@@ -305,6 +305,7 @@ properties:
   - property: daily_energy_kwh
     hide: true
     sensor:
-      state_class: total
+      read_only: true
+      state_class: total_increasing
       device_class: energy
       unit: kWh


### PR DESCRIPTION
- Also corrected `read-only` -> `read_only` in mapping files

Fixes issue #144