### PR TITLE
Fix calling set_value action

### DIFF
--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -114,9 +114,9 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         """Set value for this sensor."""
         _LOGGER.debug("Setting %s to %d on %s", self.status, value, self.nickname)
         if self.read_only is None:
-            _LOGGER.warning("%s may be read-only on %s", self._attr_name, self.nickname)
+            _LOGGER.warning("%s may be read-only on %s", self.entity_description.name, self.nickname)
         elif self.read_only:
-            raise ServiceValidationError(f"{self._attr_name} is read-only on {self.nickname}")
+            raise ServiceValidationError(f"{self.entity_description.name} is read-only on {self.nickname}")
         try:
             await self.async_update_device({self.status: value})
         except LifeConnectError as api_error:


### PR DESCRIPTION
When calling the set value service, I get an unknown error. Looking at the logs I see this:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 28, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 816, in handle_execute_script
    script_result = await script_obj.async_run(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
        msg.get("variables"), context=context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 1801, in async_run
    return await asyncio.shield(create_eager_task(run.async_run()))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 464, in async_run
    await self._async_step(log_exceptions=False)
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 528, in _async_step
    self._handle_exception(
    ~~~~~~~~~~~~~~~~~~~~~~^
        ex, continue_on_error, self._log_exceptions or log_exceptions
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 558, in _handle_exception
    raise exception
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 526, in _async_step
    await getattr(self, handler)()
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 764, in _async_call_service_step
    response_data = await self._async_run_long_action(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 727, in _async_run_long_action
    return await long_task
           ^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2795, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2838, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 1006, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 1078, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/config/custom_components/connectlife/sensor.py", line 134, in async_set_value
    _LOGGER.warning("%s may be read-only on %s", self._attr_name, self.nickname)
                                                 ^^^^^^^^^^^^^^^
AttributeError: 'ConnectLifeStatusSensor' object has no attribute '__attr_name'. Did you mean: '_attr_name'?
```

I don't know if this is the correct fix, but the error no longer appears. Instead, I get the expected warning log and the call succeeds.