### PR TITLE
fix(015-000): correct sensor types

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -97,7 +97,13 @@ properties:
     sensor:
       read_only: true
   - property: Child_lock
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Child_lock_cmd
+        adjust: 1
   - property: Child_lock_setting_status
     hide: true
     sensor:
@@ -157,7 +163,6 @@ properties:
   - property: Display_logotype_setting_status
     hide: true
   - property: Door_status
-    hide: true
     sensor:
       device_class: enum
       options:
@@ -306,7 +311,7 @@ properties:
   - property: Remote_control_monitoring_set_commands
     hide: true
   - property: Remote_control_monitoring_set_commands_actions
-    hide: true
+    binary_sensor:
   - property: Rinse_aid_refill
     hide: true
   - property: Rinse_aid_setting_status

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -448,6 +448,9 @@
       "remote_control_mode_monitoring": {
         "name": "Remote control mode monitoring"
       },
+      "remote_control_monitoring_set_commands_actions": {
+        "name": "Remote control"
+      },
       "rx_failure": {
         "name": "RX failure"
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -448,6 +448,9 @@
             "remote_control_mode_monitoring": {
                 "name": "Remote control mode monitoring"
             },
+            "remote_control_monitoring_set_commands_actions": {
+                "name": "Remote control"
+            },
             "rx_failure": {
                 "name": "RX failure"
             },


### PR DESCRIPTION
I've tested these settings with my Asko dishwasher and they work fine. However, setting the child-lock only works if the dishwasher is turned on. I guess that is a limitation in the Connectlife platform as the app behaves the same.

* Expose 'remote control enabled' as a binary sensor.
* Expose 'child lock' as a switch
* Make 'door status' visible
* Use a more user friendly name for the 'remote control enabled' sensor