### PR TITLE
More commands for dishwashers

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -88,14 +88,30 @@ properties:
       device_class: duration
       unit: min
   - property: Auto_dose_quantity_setting_status
-    sensor:
-      read_only: true
+    unavailable: 0
+    select:
+      options:
+        1: "0"
+        2: "15"
+        3: "20"
+        4: "25"
+        5: "30"
+        6: "35"
+        7: "40"
+      command:
+        name: Auto_dose_quantity_setting
+        adjust: 1
   - property: Auto_dose_refill
     sensor:
       read_only: true
   - property: Auto_dose_setting_status
-    sensor:
-      read_only: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Auto_dose_setting
+        adjust: 1
   - property: Child_lock
     unavailable: 0
     switch:
@@ -306,7 +322,13 @@ properties:
   - property: Notification_volumen_setting_status
     hide: true
   - property: Odor_control_setting
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Oder_control_setting
+        adjust: 1
   - property: Pressure_calibration_setting_status
     hide: true
   - property: Remote_control_monitoring_set_commands

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
@@ -58,19 +58,31 @@ properties:
     icon: mdi:dishwasher-alert
     hide: true
   - property: Auto_dose_quantity_setting_status
-    sensor:
-      read_only: true
-    icon: mdi:information
-    hide: true
+    unavailable: 0
+    select:
+      options:
+        1: "0"
+        2: "15"
+        3: "20"
+        4: "25"
+        5: "30"
+        6: "35"
+        7: "40"
+      command:
+        name: Auto_dose_quantity_setting
+        adjust: 1
   - property: Auto_dose_refill
     sensor:
       read_only: true
     hide: true
   - property: Auto_dose_setting_status
-    sensor:
-      read_only: true
-    icon: mdi:information
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Auto_dose_setting
+        adjust: 1
   - property: Child_lock
     hide: true
   - property: Child_lock_setting_status
@@ -338,10 +350,13 @@ properties:
     icon: mdi:information
     hide: true
   - property: Odor_control_setting
-    sensor:
-      read_only: true
-    icon: mdi:information
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Oder_control_setting
+        adjust: 1
   - property: Pressure_calibration_setting_status
     sensor:
       read_only: true

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -49,14 +49,30 @@ properties:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Auto_dose_quantity_setting_status
-    sensor:
-      read_only: true
+    unavailable: 0
+    select:
+      options:
+        1: "0"
+        2: "15"
+        3: "20"
+        4: "25"
+        5: "30"
+        6: "35"
+        7: "40"
+      command:
+        name: Auto_dose_quantity_setting
+        adjust: 1
   - property: Auto_dose_refill
     sensor:
       read_only: true
   - property: Auto_dose_setting_status
-    sensor:
-      read_only: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Auto_dose_setting
+        adjust: 1
   - property: Child_lock
     hide: true
   - property: Child_lock_setting_status
@@ -252,7 +268,13 @@ properties:
   - property: Notification_volumen_setting_status
     hide: true
   - property: Odor_control_setting
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Oder_control_setting
+        adjust: 1
   - property: Pressure_calibration_setting_status
     hide: true
   - property: Remote_control_monitoring_set_commands

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -766,14 +766,8 @@
       "auto_dose_duration": {
         "name": "Auto dose duration"
       },
-      "auto_dose_quantity_setting_status": {
-        "name": "Auto dose quantity setting"
-      },
       "auto_dose_refill": {
         "name": "Auto dose refill"
-      },
-      "auto_dose_setting_status": {
-        "name": "Auto dose setting"
       },
       "bundling_humidity": {
         "name": "Bundling humidity"
@@ -981,9 +975,6 @@
       },
       "notification_volumen_setting_status": {
         "name": "Notification volume"
-      },
-      "odor_control_setting": {
-        "name": "Odor control setting"
       },
       "oven_temperature": {
         "name": "Oven temperature"
@@ -1561,6 +1552,9 @@
       "anticrease": {
         "name": "Anti crease"
       },
+      "auto_dose_setting_status": {
+        "name": "Auto dose"
+      },
       "autodose": {
         "name": "Auto dose"
       },
@@ -1584,6 +1578,9 @@
       },
       "natural_dry": {
         "name": "Natural dry"
+      },
+      "odor_control_setting": {
+        "name": "Odor control"
       },
       "t_air": {
         "name": "Air"
@@ -1617,6 +1614,9 @@
       }
     },
     "select": {
+      "auto_dose_quantity_setting_status": {
+        "name": "Auto dose quantity"
+      },
       "dry_level": {
         "name": "Drying level",
         "state": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -766,14 +766,8 @@
             "auto_dose_duration": {
                 "name": "Auto dose duration"
             },
-            "auto_dose_quantity_setting_status": {
-                "name": "Auto dose quantity setting"
-            },
             "auto_dose_refill": {
                 "name": "Auto dose refill"
-            },
-            "auto_dose_setting_status": {
-                "name": "Auto dose setting"
             },
             "bundling_humidity": {
                 "name": "Bundling humidity"
@@ -981,9 +975,6 @@
             },
             "notification_volumen_setting_status": {
                 "name": "Notification volume"
-            },
-            "odor_control_setting": {
-                "name": "Odor control setting"
             },
             "oven_temperature": {
                 "name": "Oven temperature"
@@ -1561,6 +1552,9 @@
             "anticrease": {
                 "name": "Anti crease"
             },
+            "auto_dose_setting_status": {
+                "name": "Auto dose"
+            },
             "autodose": {
                 "name": "Auto dose"
             },
@@ -1584,6 +1578,9 @@
             },
             "natural_dry": {
                 "name": "Natural dry"
+            },
+            "odor_control_setting": {
+                "name": "Odor control"
             },
             "t_air": {
                 "name": "Air"
@@ -1617,6 +1614,9 @@
             }
         },
         "select": {
+            "auto_dose_quantity_setting_status": {
+                "name": "Auto dose quantity"
+            },
             "dry_level": {
                 "name": "Drying level",
                 "state": {


### PR DESCRIPTION
Support setting auto dose quantity (if already enabled), disable auto dose quantity, and enable/disable odor control.

Note that enabling auto dose seems to require quantity to be set to more than 0 in the same API request, which is currently not supporting.

Fixes #189 