### PR TITLE
Implement entity_category

### DIFF
--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -1,7 +1,11 @@
 """Provides a binary sensor for ConnectLife."""
+
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorEntityDescription
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
@@ -18,20 +22,23 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up ConnectLife sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
-            ConnectLifeBinaryStatusSensor(coordinator, appliance, s, dictionary.properties[s])
-            for s in appliance.status_list if is_entity(
+            ConnectLifeBinaryStatusSensor(
+                coordinator, appliance, s, dictionary.properties[s]
+            )
+            for s in appliance.status_list
+            if is_entity(
                 Platform.BINARY_SENSOR,
                 dictionary.properties[s],
-                appliance.status_list[s]
+                appliance.status_list[s],
             )
         )
 
@@ -40,11 +47,11 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
     """Sensor class for ConnectLife arbitrary status."""
 
     def __init__(
-            self,
-            coordinator: ConnectLifeCoordinator,
-            appliance: ConnectLifeAppliance,
-            status: str,
-            dd_entry: Property
+        self,
+        coordinator: ConnectLifeCoordinator,
+        appliance: ConnectLifeAppliance,
+        status: str,
+        dd_entry: Property,
     ):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.BINARY_SENSOR)
@@ -56,7 +63,8 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             translation_key=self.to_translation_key(status),
-            device_class=dd_entry.binary_sensor.device_class
+            device_class=dd_entry.binary_sensor.device_class,
+            entity_category=dd_entry.entity_category,
         )
         self.update_state()
 

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -178,102 +178,135 @@ properties:
   - property: Error_F70
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_F76
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f10
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f11
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f12
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f40
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f41
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f42
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f43
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f44
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f45
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f46
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f52
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f54
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f56
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f61
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f62
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f65
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f67
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f68
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f69
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f72
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f74
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_f75
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_1_code
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_1_cycle
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_1_status
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_2_code
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_2_cycle
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_2_status
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_3_code
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_3_cycle
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: Error_read_out_3_status
     icon: mdi:dishwasher-alert
     hide: true
+    entity_category: diagnostic
   - property: FOTA_status
     hide: true
   - property: Fan_sequence_setting_status

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -11,6 +11,7 @@ To map you device, create a file with the name `<deviceTypeCode>-<deviceFeatureC
 or if you need help with the mapping, please open a PR on GitHub with the file!
 
 The file contains two top level items:
+
 - `climate`: top level [`Climate`](#presets) configuration.
 - `properties`: list of [`Property`](#property)
 
@@ -18,7 +19,7 @@ To make a property visible by default, just add the property to the list. Note t
 mapped to [sensor](#type-sensor) entities with `hidden` set to `true` and `state_class` set to `measurement`.
 
 Each property is mapped to _one_ entity or _one_ target property. In addition, each `climate` preset is mapped to a
-set of properties and values. 
+set of properties and values.
 
 If you disable or change the type of mapping, old entities will be automatically removed from Home Assistant, while
 state attributes will change to unavailable.
@@ -28,13 +29,15 @@ If you change unit or state class for sensors, you will need to fix the history 
 
 You need to restart Home Assistant to load mapping changes.
 
-### Mapping tips and tricks:
+### Mapping tips and tricks
 
 - Generate a skeleton file using the [connectlife](https://pypi.org/project/connectlife/) package:
+
   ```bash
   pip install connectlife
   python -m connectlife.dump --username <username> --password <password> --format dd
-  ``` 
+  ```
+
 - Inspect the existing mappings files in this directory.
 - Change settings in the ConnectLife app while monitoring value changes in Home Assistant. Take a note of which
   property is changes, what the value is, and what the button or action is named in the ConnectLife app.
@@ -43,29 +46,32 @@ You need to restart Home Assistant to load mapping changes.
   expects boolean (unquoted) values.
 - Validate your mapping file with the [JSON schema](properties-schema.json).
 - Remember to add translation strings. In the base dir of this repo, run the following command to update `strings.json`:
+
   ```bash
   python -m scripts.gen_strings
   ```
+
   and then edit the added strings. Finally, merge the changes into [translations/en.json](translations/en.json).
 
 Note that translation keys must be lowercase!
 
 ## Property
 
-| Item            | Type                               | Description                                                                                                                             |
-|-----------------|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `property`      | string                             | Name of status/property.                                                                                                                |
-| `disable`       | `true`, `false`                    | If Home Assistant should not create an entity for this property. Defaults to `false`.                                                   |
-| `hide`          | `true`, `false`                    | If Home Assistant should initially hide the entity for this property. Defaults to `false`, but is set to `true` for unknown properties. |
-| `icon`          | `mdi:eye`, etc.                    | Icon to use for the entity.                                                                                                             |
-| `binary_sensor` | [BinarySensor](#type-binarysensor) | Create a binary sensor of the property.                                                                                                 |
-| `climate`       | [Climate](#type-climate)           | Map the property to a climate entity for the device.                                                                                    |
-| `humidifier`    | [Humidifier](#type-humidifier)     | Map the property to a humidifier entity for the device.                                                                                 |
-| `number`        | [Number](#type-number)             | Create a number entity of the property.                                                                                                 |
-| `select`        | [Select](#type-select)             | Create a selector of the property.                                                                                                      |
-| `sensor`        | [Sensor](#type-sensor)             | Create a sensor of the property. This is the default.                                                                                   |
-| `switch`        | [Switch](#type-switch)             | Create a switch of the property.                                                                                                        |
-| `water_heater`  | [WaterHeater](#type-waterheater)   | Map the property to a water heater entity for the device.                                                                               |
+| Item                       | Type                               | Description                                                                                                                                                                                                                                                                            |
+|----------------------------|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `property`                 | string                             | Name of status/property.                                                                                                                                                                                                                                                               |
+| `disable`                  | `true`, `false`                    | If Home Assistant should not create an entity for this property. Defaults to `false`.                                                                                                                                                                                                  |
+| `hide`                     | `true`, `false`                    | If Home Assistant should initially hide the entity for this property. Defaults to `false`, but is set to `true` for unknown properties.                                                                                                                                                |
+| `icon`                     | `mdi:eye`, etc.                    | Icon to use for the entity.                                                                                                                                                                                                                                                            |
+| `entity_category`          | `config`, `diagnostic`             | Whether the entity should be considered a diagnostics or config entity. Defaults to `None`. [More info in HA docs](https://developers.home-assistant.io/docs/core/entity/#registry-properties:~:text=automatic%20device%20registration.-,entity_category,-EntityCategory%20%7C%20None) |
+| `binary_sensor`            | [BinarySensor](#type-binarysensor) | Create a binary sensor of the property.                                                                                                                                                                                                                                                |
+| `climate`                  | [Climate](#type-climate)           | Map the property to a climate entity for the device.                                                                                                                                                                                                                                   |
+| `humidifier`               | [Humidifier](#type-humidifier)     | Map the property to a humidifier entity for the device.                                                                                                                                                                                                                                |
+| `number`                   | [Number](#type-number)             | Create a number entity of the property.                                                                                                                                                                                                                                                |
+| `select`                   | [Select](#type-select)             | Create a selector of the property.                                                                                                                                                                                                                                                     |
+| `sensor`                   | [Sensor](#type-sensor)             | Create a sensor of the property. This is the default.                                                                                                                                                                                                                                  |
+| `switch`                   | [Switch](#type-switch)             | Create a switch of the property.                                                                                                                                                                                                                                                       |
+| `water_heater`             | [WaterHeater](#type-waterheater)   | Map the property to a water heater entity for the device.                                                                                                                                                                                                                              |
 
 If an entity mapping is not given, the property is mapped to a sensor entity.
 
@@ -79,10 +85,11 @@ as `0` often implies that the sensor state is not available. For other mappings,
 
 | Item           | Type                             | Description                                                                                                                                                           |
 |----------------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `device_class` | `power`, `problem`, etc.         | For domain `binary_sensor`, name of any [BinarySensorDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/binary-sensor#available-device-classes). |   
+| `device_class` | `power`, `problem`, etc.         | For domain `binary_sensor`, name of any [BinarySensorDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/binary-sensor#available-device-classes). |
 | `options`      | dictionary of integer to boolean |                                                                                                                                                                       |
 
 Example:
+
 ```yaml
 - property: alarm
   binary_sensor:
@@ -92,7 +99,7 @@ Example:
       1: on
 ```
 
-## Type `Climate`:
+## Type `Climate`
 
 Domain `climate` can be used to map the property to a target property in a climate entity. If at least one property has
 type `climate`, a climate entity is created for the appliance.
@@ -118,6 +125,7 @@ mapping to a sensor `enum` instead.
 For `fan_mode` and `swing_mode`, remember to add [translation strings](#translation-strings) for the options.
 
 Not yet supported target properties:
+
 - `target_temperature_high`
 - `target_temperature_low`
 
@@ -128,6 +136,7 @@ that preset. You may choose to set different properties in different presets. If
 properties will not be changed when switching to that preset.
 
 E.g.:
+
 ```yaml
 climate:
   presets:
@@ -144,11 +153,11 @@ Remember to add [translation strings](#translation-strings) for preset modes.
 
 Since multiple states may match a given preset, the first matching preset of the list will be displayed in the UI.
 E.g. with the above preset definitions, if `t_eco` is 1, `t_fan_speed` is 0, _and_ `t_tms` is 1, `eco` will be displayed
-as the selected preset. 
+as the selected preset.
 
 Presets only has effect for devices with climate mappings.
 
-## Type `Humidifier`:
+## Type `Humidifier`
 
 Domain `humidifier` can be used to map the property to a target property in a humidifier entity. If at least one property has
 type `humidifier`, a humidifier entity is created for the appliance.
@@ -157,7 +166,7 @@ type `humidifier`, a humidifier entity is created for the appliance.
 |----------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `target`       | string                          | Any  of these [humidifier entity](https://developers.home-assistant.io/docs/core/entity/humidifier#properties) attributes: `action`, `is_on`, `current_humidity`, `target_humidity`, `mode`. |
 | `options`      | dictionary of integer to string | Required for `action` and `mode`.                                                                                                                                                            |
-| `device_class` | string                          | Name of any [HumidifierDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/humidifier#available-device-classes).                                                         |                                                                                                                         
+| `device_class` | string                          | Name of any [HumidifierDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/humidifier#available-device-classes).                                                         |
 
 It is sufficient to set `device_class` on one property. The value of the first encountered property is used.
 
@@ -175,7 +184,7 @@ Number entities can be set by the user.
 |-----------------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | `min_value`     | integer                                         | Minimum value.                                                                                                                |
 | `max_value`     | integer                                         | Maximum value.                                                                                                                |
-| `device_class`  | `duration`, `energy`, `water`, etc.             | Name of any [NumberDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/number/#available-device-classes). | 
+| `device_class`  | `duration`, `energy`, `water`, etc.             | Name of any [NumberDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/number/#available-device-classes). |
 | `unit`          | `min`, `°C`, `°F`, etc., _or_ `property.<name>` | Required if `device_class` is set, except not allowed when `device_class` is `aqi` or `ph`.                                   |
 
 ## Type `Select`
@@ -188,14 +197,14 @@ Remember to add [translation strings](#translation-strings) for the options.
 
 ## Type `Sensor`
 
-Sensor entities are usually read-only, but this integration provides a `set_value` service that can be applied on 
+Sensor entities are usually read-only, but this integration provides a `set_value` service that can be applied on
 the `sensor.connectlife` entities, unless the sensor is set to `read_only: true`.
 
 | Item            | Type                                            | Description                                                                                                                                                                                                               |
 |-----------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `read_only`     | `true`, `false`                                 | If this property is known to be read-only (prevents `set_value` service).                                                                                                                                                 |
 | `state_class`   | `measurement`, `total`, `total_increasing`      | Name of any [SensorStateClass enum](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes). For integer properties, defaults to `measurement`. Not allowed when `device_class` is `enum`. |
-| `device_class`  | `duration`, `energy`, `water`, etc.             | Name of any [SensorDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes).                                                                                             | 
+| `device_class`  | `duration`, `energy`, `water`, etc.             | Name of any [SensorDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes).                                                                                             |
 | `unit`          | `min`, `kWh`, `L`, etc., _or_ `property.<name>` | Required if `device_class` is set, except not allowed when `device_class` is `aqi`, `ph` or `enum`.                                                                                                                       |
 | `options`       | dictionary of integer to string                 | Required if `device_class` is set to `enum`.                                                                                                                                                                              |
 | `unknown_value` | integer                                         | The value used by the API to signal unknown value.                                                                                                                                                                        |
@@ -209,7 +218,7 @@ For device class `enum`, remember to add [translation strings](#translation-stri
 | `off` | integer | Off value. Defaults to 0. |
 | `on`  | integer | On value. Defaults to 1.  |
 
-## Type `WaterHeater`:
+## Type `WaterHeater`
 
 Domain `water_heater` can be used to map the property to a target property in a water heater entity. If at least one property has
 type `water_heater`, a water heater entity is created for the appliance.
@@ -217,7 +226,7 @@ type `water_heater`, a water heater entity is created for the appliance.
 | Item            | Type                                               | Description                                                                                                                                                                                                                                                  |
 |-----------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `target`        | string                                             | Any  of these [water heater entity](https://developers.home-assistant.io/docs/core/entity/water-heater#properties) attributes: `current_operation`, `current_temperature`, `state`, `target_temperature`, `temperature_unit`, or the special target `is_on`. |
-| `options`       | dictionary of integer to string or boolean         | Required for `current_operation`, `is_away_mode_on`, state`, and `temperature_unit`.                                                                                                                                                                         |
+| `options`       | dictionary of integer to string or boolean         | Required for `current_operation`, `is_away_mode_on`, state`, and`temperature_unit`.                                                                                                                                                                         |
 | `unknown_value` | integer                                            | The value used by the API to signal unknown value.                                                                                                                                                                                                           |
 | `min_value`     | [IntegerOrTemperature](#type-integerortemperature) | Minimum allowed value. Supported for `target_temperature` (temperature).                                                                                                                                                                                     |
 | `max_value`     | [IntegerOrTemperature](#type-integerortemperature) | Maximum allowed value. Supported for `target_temperature` (temperature).                                                                                                                                                                                     |
@@ -230,10 +239,11 @@ type `water_heater`, a water heater entity is created for the appliance.
 
 `is_on` adds operation `"off"` to the operation list. You may define this option as well on the `current_operation`
 target, but will not send in the mapped property or value when selecing the "Off" operation in Home Assistant.
-If `current_operation` is not set, `is_on` also adds operation `"on"` to the operation list. 
+If `current_operation` is not set, `is_on` also adds operation `"on"` to the operation list.
 
 For `current_operation`, remember to add [translation strings](#translation-strings) for the options.
 Note that you need to add these under `state`, and **not** under `state_attributes`, e.g.:
+
 ```json
 {
   "entity": {
@@ -249,6 +259,7 @@ Note that you need to add these under `state`, and **not** under `state_attribut
 ```
 
 Not yet supported target properties:
+
 - `target_temperature_high`
 - `target_temperature_low`
 
@@ -259,7 +270,9 @@ Either just a numeric value, or values in Celsius and/or Fahrenheit.
 ```yaml
 min_value: 10
 ```
+
 or
+
 ```yaml
 min_value:
   celsius: 0
@@ -271,6 +284,7 @@ min_value:
 Some devices have support for switching temperature unit between Celsius and Fahrenheit. For _Climate_ and _Water heater_
 entities, this is controlled by setting target `temperature_unit`. For _Number_ and _Sensor_ entities, `unit` can be set
 to `property.<name>`, where `<name>` must be a property in the same mapping file that is one of:
+
 - A _Climate_ entity with target `temperature_unit`
 - A _Select_ entity
 - A _Sensor_ entity with `device_type: enum`
@@ -280,6 +294,7 @@ mapping the numeric mapping to the translation _key_ (in the YAML mapping file, 
 
 For example, this will set the unit of `Meat_probe_measured_temperature` to Celsius if `Oven_temperature_unit` is `1`
 when the component is loaded:
+
 ```yaml
 - property: Meat_probe_measured_temperature
   sensor:
@@ -300,12 +315,13 @@ Note that units `°C`, `C`, `celsius`, and `Celsius` are normalized to `UnitOfTe
 
 # Translation strings
 
-By default, sensor entities are named by replacing `_` with ` ` in the property name. However, the property name is also
+By default, sensor entities are named by replacing `_` with `` in the property name. However, the property name is also
 the translation key for the property, so it is possible to add a different English entity name as well as provide
 translations by adding the property to [strings.json](../strings.json), and then to any [translations](../translations)
 files.
 
 For example, given the following data dictionary:
+
 ```yaml
 properties:
   - property: Door_status
@@ -318,6 +334,7 @@ properties:
 ```
 
 This goes into  [strings.json](../strings.json) and  [en.json](../translations/en.json),
+
 ```json
 {
   "entity": {
@@ -335,9 +352,10 @@ This goes into  [strings.json](../strings.json) and  [en.json](../translations/e
 }
 ```
 
-Climate and humidifier modes must be registered as `state_attributes`.  
+Climate and humidifier modes must be registered as `state_attributes`.
 
 For example, given the following data dictionary:
+
 ```yaml
 properties:
   - property: t_fan_speed
@@ -354,6 +372,7 @@ properties:
 
 Strings not in Home Assistant ([climate](https://github.com/home-assistant/core/blob/dev/homeassistant/components/climate/strings.json)
 [humidifier](https://github.com/home-assistant/core/blob/dev/homeassistant/components/humidifier/strings.json)) goes in [strings.json](../strings.json) and  [en.json](../translations/en.json):
+
 ```json
 {
   "entity": {

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -101,6 +101,14 @@
         "unavailable": {
           "type": "integer",
           "description": "If the property has this value, it is not available on the device, and no entity is created."
+        },
+        "device_category": {
+          "type": "string",
+          "description": "https://developers.home-assistant.io/docs/core/entity/#registry-properties:~:text=automatic%20device%20registration.-,entity_category,-EntityCategory%20%7C%20None",
+          "enum": [
+            "config",
+            "diagnostic"
+          ]
         }
       },
       "required": [
@@ -241,7 +249,9 @@
           "$ref": "#/definitions/Command"
         }
       },
-      "required": ["options"]
+      "required": [
+        "options"
+      ]
     },
     "Sensor": {
       "type": "object",
@@ -397,7 +407,7 @@
         "humidifier"
       ],
       "title": "Humidifier device class."
-      },
+    },
     "SensorDeviceClass": {
       "type": "string",
       "enum": [

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -5,7 +5,7 @@ import logging
 import pkgutil
 
 from connectlife.appliance import ConnectLifeAppliance
-from homeassistant.const import Platform
+from homeassistant.const import Platform, EntityCategory
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.humidifier import HumidifierDeviceClass
 from homeassistant.components.number import NumberDeviceClass
@@ -47,6 +47,7 @@ READ_ONLY = "read_only"
 STATE_CLASS = "state_class"
 SWITCH = "switch"
 UNAVAILABLE = "unavailable"
+ENTITY_CATEGORY = "entity_category"
 UNKNOWN_VALUE = "unknown_value"
 UNIT = "unit"
 
@@ -60,10 +61,14 @@ class BinarySensor:
     def __init__(self, name: str, binary_sensor: dict | None):
         if binary_sensor is None:
             binary_sensor = {}
-        self.device_class = BinarySensorDeviceClass(binary_sensor[DEVICE_CLASS]) \
-            if DEVICE_CLASS in binary_sensor else None
+        self.device_class = (
+            BinarySensorDeviceClass(binary_sensor[DEVICE_CLASS])
+            if DEVICE_CLASS in binary_sensor
+            else None
+        )
         if OPTIONS in binary_sensor:
             self.options = binary_sensor[OPTIONS]
+
 
 class Climate:
     target: str
@@ -79,9 +84,19 @@ class Climate:
         if self.target is None:
             _LOGGER.warning("Missing climate.target for for %s", name)
         self.options = climate[OPTIONS] if OPTIONS in climate else None
-        if self.options is None and self.target in [FAN_MODE, HVAC_ACTION, HVAC_MODE, SWING_MODE, TEMPERATURE_UNIT]:
+        if self.options is None and self.target in [
+            FAN_MODE,
+            HVAC_ACTION,
+            HVAC_MODE,
+            SWING_MODE,
+            TEMPERATURE_UNIT,
+        ]:
             _LOGGER.warning("Missing climate.options for %s", name)
-        self.unknown_value = climate[UNKNOWN_VALUE] if UNKNOWN_VALUE in climate and climate[UNKNOWN_VALUE] else None
+        self.unknown_value = (
+            climate[UNKNOWN_VALUE]
+            if UNKNOWN_VALUE in climate and climate[UNKNOWN_VALUE]
+            else None
+        )
         self.min_value = climate[MIN_VALUE] if MIN_VALUE in climate else None
         self.max_value = climate[MAX_VALUE] if MAX_VALUE in climate else None
 
@@ -102,7 +117,11 @@ class Humidifier:
         self.options = humidifier[OPTIONS] if OPTIONS in humidifier else None
         if self.options is None and self.target in [ACTION, MODE]:
             _LOGGER.warning("Missing humidifier.options for %s", name)
-        self.device_class = HumidifierDeviceClass(humidifier[DEVICE_CLASS]) if DEVICE_CLASS in humidifier else None
+        self.device_class = (
+            HumidifierDeviceClass(humidifier[DEVICE_CLASS])
+            if DEVICE_CLASS in humidifier
+            else None
+        )
         self.min_value = humidifier[MIN_VALUE] if MIN_VALUE in humidifier else None
         self.max_value = humidifier[MAX_VALUE] if MAX_VALUE in humidifier else None
 
@@ -123,9 +142,17 @@ class Number:
         device_class = None
         if DEVICE_CLASS in number:
             device_class = NumberDeviceClass(number[DEVICE_CLASS])
-            if device_class == NumberDeviceClass.PH or device_class == NumberDeviceClass.AQI:
+            if (
+                device_class == NumberDeviceClass.PH
+                or device_class == NumberDeviceClass.AQI
+            ):
                 if self.unit:
-                    _LOGGER.warning("%s has device class %s and unit %s", name, device_class, self.unit)
+                    _LOGGER.warning(
+                        "%s has device class %s and unit %s",
+                        name,
+                        device_class,
+                        self.unit,
+                    )
                     self.unit = None
             elif not self.unit:
                 _LOGGER.warning("%s has device class, but no unit", name)
@@ -146,8 +173,16 @@ class Select:
             self.options = {}
         else:
             self.options = select[OPTIONS]
-        self.command_name = select[COMMAND][NAME] if COMMAND in select and NAME in select[COMMAND] else None
-        self.command_adjust = select[COMMAND][ADJUST] if COMMAND in select and ADJUST in select[COMMAND] else 0
+        self.command_name = (
+            select[COMMAND][NAME]
+            if COMMAND in select and NAME in select[COMMAND]
+            else None
+        )
+        self.command_adjust = (
+            select[COMMAND][ADJUST]
+            if COMMAND in select and ADJUST in select[COMMAND]
+            else 0
+        )
 
 
 class Sensor:
@@ -163,10 +198,16 @@ class Sensor:
     def __init__(self, name: str, sensor: dict):
         if sensor is None:
             sensor = {}
-        self.unknown_value = sensor[UNKNOWN_VALUE] if UNKNOWN_VALUE in sensor and sensor[UNKNOWN_VALUE] else None
+        self.unknown_value = (
+            sensor[UNKNOWN_VALUE]
+            if UNKNOWN_VALUE in sensor and sensor[UNKNOWN_VALUE]
+            else None
+        )
         self.read_only = sensor[READ_ONLY] if READ_ONLY in sensor else None
         self.unit = sensor[UNIT] if UNIT in sensor and sensor[UNIT] else None
-        self.state_class = SensorStateClass(sensor[STATE_CLASS]) if STATE_CLASS in sensor else None
+        self.state_class = (
+            SensorStateClass(sensor[STATE_CLASS]) if STATE_CLASS in sensor else None
+        )
 
         device_class = None
         if DEVICE_CLASS in sensor:
@@ -176,16 +217,28 @@ class Sensor:
                     _LOGGER.warning("%s has device class enum, but has unit", name)
                     device_class = None
                 if self.state_class:
-                    _LOGGER.warning("%s has device class enum, but has state_class", name)
+                    _LOGGER.warning(
+                        "%s has device class enum, but has state_class", name
+                    )
                     device_class = None
                 if device_class and "options" not in sensor:
                     _LOGGER.warning("%s has device class enum, but no options", name)
                     device_class = None
                 else:
                     self.options = sensor["options"]
-            elif device_class in [SensorDeviceClass.AQI, SensorDeviceClass.DATE, SensorDeviceClass.PH, SensorDeviceClass.TIMESTAMP]:
+            elif device_class in [
+                SensorDeviceClass.AQI,
+                SensorDeviceClass.DATE,
+                SensorDeviceClass.PH,
+                SensorDeviceClass.TIMESTAMP,
+            ]:
                 if self.unit:
-                    _LOGGER.warning("%s has device class %s and unit %s", name, device_class, self.unit)
+                    _LOGGER.warning(
+                        "%s has device class %s and unit %s",
+                        name,
+                        device_class,
+                        self.unit,
+                    )
                     self.unit = None
             elif not self.unit:
                 _LOGGER.warning("%s has device class, but no unit", name)
@@ -203,12 +256,21 @@ class Switch:
     def __init__(self, name: str, switch: dict):
         if switch is None:
             switch = {}
-        self.device_class = SwitchDeviceClass(switch[DEVICE_CLASS])\
-            if DEVICE_CLASS in switch else None
+        self.device_class = (
+            SwitchDeviceClass(switch[DEVICE_CLASS]) if DEVICE_CLASS in switch else None
+        )
         self.off = switch[OFF] if OFF in switch else 0
         self.on = switch[ON] if ON in switch else 1
-        self.command_name = switch[COMMAND][NAME] if COMMAND in switch and NAME in switch[COMMAND] else None
-        self.command_adjust = switch[COMMAND][ADJUST] if COMMAND in switch and ADJUST in switch[COMMAND] else 0
+        self.command_name = (
+            switch[COMMAND][NAME]
+            if COMMAND in switch and NAME in switch[COMMAND]
+            else None
+        )
+        self.command_adjust = (
+            switch[COMMAND][ADJUST]
+            if COMMAND in switch and ADJUST in switch[COMMAND]
+            else 0
+        )
 
 
 class WaterHeater:
@@ -225,12 +287,19 @@ class WaterHeater:
         if self.target is None:
             _LOGGER.warning("Missing water_heater.target for for %s", name)
         self.options = water_heater[OPTIONS] if OPTIONS in water_heater else None
-        if self.options is None and self.target in [CURRENT_OPERATION, IS_AWAY_MODE_ON, STATE, TEMPERATURE_UNIT]:
+        if self.options is None and self.target in [
+            CURRENT_OPERATION,
+            IS_AWAY_MODE_ON,
+            STATE,
+            TEMPERATURE_UNIT,
+        ]:
             _LOGGER.warning("Missing water_heater.options for %s", name)
         if self.target == STATE and STATE_OFF not in self.options.values():
             _LOGGER.warning("Missing state off for water_heater.options for %s", name)
         if self.target == STATE and len(self.options) < 2:
-            _LOGGER.warning("Require at least 2 valid states in water_heater.options for %s", name)
+            _LOGGER.warning(
+                "Require at least 2 valid states in water_heater.options for %s", name
+            )
         self.unknown_value = (
             water_heater[UNKNOWN_VALUE]
             if UNKNOWN_VALUE in water_heater and water_heater[UNKNOWN_VALUE]
@@ -246,6 +315,7 @@ class Property:
     hide: bool
     disable: bool
     unavailable: int | None
+    entity_category: EntityCategory | None
     binary_sensor: BinarySensor
     climate: Climate
     humidifier: Humidifier
@@ -259,8 +329,15 @@ class Property:
         self.name = entry[PROPERTY]
         self.icon = entry[ICON] if ICON in entry and entry[ICON] else None
         self.hide = entry[HIDE] == bool(entry[HIDE]) if HIDE in entry else False
-        self.disable = entry[DISABLE] == bool(entry[DISABLE]) if DISABLE in entry else False
+        self.disable = (
+            entry[DISABLE] == bool(entry[DISABLE]) if DISABLE in entry else False
+        )
         self.unavailable = entry[UNAVAILABLE] if UNAVAILABLE in entry else None
+        self.entity_category = (
+            EntityCategory[entry[ENTITY_CATEGORY].upper()]
+            if ENTITY_CATEGORY in entry
+            else None
+        )
 
         if Platform.BINARY_SENSOR in entry:
             self.binary_sensor = BinarySensor(self.name, entry[Platform.BINARY_SENSOR])
@@ -283,8 +360,9 @@ class Property:
 
 
 @dataclass
-class Dictionary():
+class Dictionary:
     """Data dictionary for a ConnectLife appliance"""
+
     # Todo: Refactor Climate dataclass
     climate: dict[list[dict[str, int]]] | None
     properties: dict[str, Property]
@@ -305,11 +383,15 @@ class Dictionaries:
             data = pkgutil.get_data(__name__, f"data_dictionaries/{key}.yaml")
             parsed = yaml.safe_load(data)
             if Platform.CLIMATE in parsed:
-                climate = parsed[Platform.CLIMATE] if Platform.CLIMATE in parsed else None
+                climate = (
+                    parsed[Platform.CLIMATE] if Platform.CLIMATE in parsed else None
+                )
             for prop in parsed[PROPERTIES]:
                 properties[prop[PROPERTY]] = Property(prop)
         except FileNotFoundError:
-            _LOGGER.warning("No data dictionary found for %s (%s)", appliance.device_nickname, key)
+            _LOGGER.warning(
+                "No data dictionary found for %s (%s)", appliance.device_nickname, key
+            )
 
         dictionary = Dictionary(climate=climate, properties=properties)
         cls.dictionaries[key] = dictionary

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -1,4 +1,5 @@
 """Provides number entities for ConnectLife."""
+
 import logging
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -19,20 +20,26 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up ConnectLife number entities."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
-            ConnectLifeNumberEntity(coordinator, appliance, s, dictionary.properties[s], config_entry, dictionary)
-            for s in appliance.status_list if is_entity(
-                Platform.NUMBER,
+            ConnectLifeNumberEntity(
+                coordinator,
+                appliance,
+                s,
                 dictionary.properties[s],
-                appliance.status_list[s]
+                config_entry,
+                dictionary,
+            )
+            for s in appliance.status_list
+            if is_entity(
+                Platform.NUMBER, dictionary.properties[s], appliance.status_list[s]
             )
         )
 
@@ -43,13 +50,13 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
     _attr_native_step = 1
 
     def __init__(
-            self,
-            coordinator: ConnectLifeCoordinator,
-            appliance: ConnectLifeAppliance,
-            status: str,
-            dd_entry: Property,
-            config_entry: ConfigEntry,
-            dictionary: Dictionary,
+        self,
+        coordinator: ConnectLifeCoordinator,
+        appliance: ConnectLifeAppliance,
+        status: str,
+        dd_entry: Property,
+        config_entry: ConfigEntry,
+        dictionary: Dictionary,
     ):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.NUMBER, config_entry)
@@ -64,11 +71,10 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
             native_max_value=dd_entry.number.max_value,
             native_min_value=dd_entry.number.min_value,
             native_unit_of_measurement=to_unit(
-                dd_entry.number.unit,
-                appliance=appliance,
-                dictionary=dictionary
+                dd_entry.number.unit, appliance=appliance, dictionary=dictionary
             ),
             translation_key=self.to_translation_key(status),
+            entity_category=dd_entry.entity_category,
         )
         self.update_state()
 

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -1,4 +1,5 @@
 """Provides a switch for ConnectLife."""
+
 import logging
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
@@ -19,20 +20,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        config_entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up ConnectLife sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
-            ConnectLifeSwitch(coordinator, appliance, s, dictionary.properties[s], config_entry)
-            for s in appliance.status_list if is_entity(
-                Platform.SWITCH,
-                dictionary.properties[s],
-                appliance.status_list[s]
+            ConnectLifeSwitch(
+                coordinator, appliance, s, dictionary.properties[s], config_entry
+            )
+            for s in appliance.status_list
+            if is_entity(
+                Platform.SWITCH, dictionary.properties[s], appliance.status_list[s]
             )
         )
 
@@ -41,17 +43,19 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
     """Switch class for ConnectLife."""
 
     def __init__(
-            self,
-            coordinator: ConnectLifeCoordinator,
-            appliance: ConnectLifeAppliance,
-            status: str,
-            dd_entry: Property,
-            config_entry: ConfigEntry
+        self,
+        coordinator: ConnectLifeCoordinator,
+        appliance: ConnectLifeAppliance,
+        status: str,
+        dd_entry: Property,
+        config_entry: ConfigEntry,
     ):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.SWITCH, config_entry)
         self.status = status
-        self.command_name = dd_entry.switch.command_name if dd_entry.switch.command_name else status
+        self.command_name = (
+            dd_entry.switch.command_name if dd_entry.switch.command_name else status
+        )
         self.off = dd_entry.switch.off
         self.on = dd_entry.switch.on
         self.command_off = self.off - dd_entry.switch.command_adjust
@@ -62,7 +66,8 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             translation_key=self.to_translation_key(status),
-            device_class=dd_entry.switch.device_class
+            device_class=dd_entry.switch.device_class,
+            entity_category=dd_entry.entity_category,
         )
         self.update_state()
 
@@ -89,6 +94,5 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn on."""
         await self.async_update_device(
-            {self.command_name: self.command_on},
-            {self.status: self.on}
+            {self.command_name: self.command_on}, {self.status: self.on}
         )


### PR DESCRIPTION
This adds support for entity_category. Now you can separate entities into a `diagnostics` and `config` category.
I implemented it in my fork since it allows me to separate all the `Error_f*` sensors into a diagnostics category for less clutter. 
I thought it might be interesting for others. 
I hope you don't mind the formatting changes that went along with it. It's VScodes auto-formatting for Python. If you have some auto-formatter that I could run, I wouldn't mind using your style. 

Example usage:
```yaml
- property: Error_f54
    icon: mdi:dishwasher-alert
    hide: true
    entity_category: diagnostic
```