### PR TITLE
More sensor adjustments

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -358,7 +358,13 @@ properties:
   - property: High_temperature_status
     hide: true
   - property: Interior_light_at_power_off_setting_status
-    binary_sensor:
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Interior_light_at_power_off_setting
+        adjust: 1
   - property: Interior_light_status
     hide: true
   - property: Language_status

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -439,15 +439,23 @@ properties:
   - property: Super_rinse_on_demand_allowed
     hide: true
   - property: Super_rinse_setting_status
+    unavailable: 0
     switch:
       "off": 1
       "on": 2
+      command:
+        name: Super_rinse_setting
+        adjust: 1
   - property: Super_rinse_status
     hide: true
   - property: Tab_setting_status
+    unavailable: 0
     switch:
       "off": 1
       "on": 2
+      command:
+        name: Tab_setting
+        adjust: 1
   - property: Temperature_unit_status
     hide: true
   - property: Time_program_set_duration_status

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -204,7 +204,7 @@ properties:
       options:
         1: off
         2: on
-    icon: "mdi:folder-open-outline"
+    icon: mdi:folder-open-outline
   - property: Energy_consumption_in_running_program
     sensor:
       unknown_value: 65535
@@ -396,7 +396,7 @@ properties:
   - property: Rinse_aid_refill
     binary_sensor:
       device_class: problem
-    icon: mdi:dishwasher-alert
+    icon: mdi:flare
   - property: Rinse_aid_setting_status
     hide: true
   - property: Sani_Lock

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -387,7 +387,9 @@ properties:
   - property: Remote_control_monitoring_set_commands_actions
     binary_sensor:
   - property: Rinse_aid_refill
-    hide: true
+    binary_sensor:
+      device_class: problem
+    icon: mdi:dishwasher-alert
   - property: Rinse_aid_setting_status
     hide: true
   - property: Sani_Lock

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -120,8 +120,9 @@ properties:
         name: Auto_dose_quantity_setting
         adjust: 1
   - property: Auto_dose_refill
-    sensor:
-      read_only: true
+    binary_sensor:
+      device_class: problem
+    icon: mdi:dishwasher-alert
   - property: Auto_dose_setting_status
     unavailable: 0
     switch:

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -4,80 +4,98 @@ properties:
     sensor:
       read_only: true
   - property: Alarm_auto_dose_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_Autodose_level10
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_Autodose_level20
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_External_autodose_level15
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_External_autodose_level30
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_clean_the_filters
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_door_closed
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_door_opened
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_preheating_ready
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_program_done
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_program_pause
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_remote_start_canceled
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_rinse_aid_refill
+    entity_category: diagnostic
+    hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_Rinse_aid_refill_external
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_run_selfcleaning
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_salt_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_Sani_program_finished
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -185,7 +185,7 @@ properties:
       options:
         1: off
         2: on
-    icon: 'mdi:folder-open-outline'
+    icon: "mdi:folder-open-outline"
   - property: Energy_consumption_in_running_program
     sensor:
       unknown_value: 65535
@@ -340,7 +340,7 @@ properties:
   - property: High_temperature_status
     hide: true
   - property: Interior_light_at_power_off_setting_status
-    hide: true
+    binary_sensor:
   - property: Interior_light_status
     hide: true
   - property: Language_status
@@ -419,11 +419,15 @@ properties:
   - property: Super_rinse_on_demand_allowed
     hide: true
   - property: Super_rinse_setting_status
-    hide: true
+    switch:
+      "off": 1
+      "on": 2
   - property: Super_rinse_status
     hide: true
   - property: Tab_setting_status
-    hide: true
+    switch:
+      "off": 1
+      "on": 2
   - property: Temperature_unit_status
     hide: true
   - property: Time_program_set_duration_status

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
@@ -3,56 +3,67 @@ properties:
     binary_sensor: {}
     hide: false
   - property: Alarm_auto_dose_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_clean_the_filters
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_door_closed
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_door_opened
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_preheating_ready
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_program_done
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_program_pause
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_remote_start_canceled
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_rinse_aid_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_run_selfcleaning
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
     hide: true
   - property: Alarm_salt_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
@@ -91,14 +102,14 @@ properties:
     icon: mdi:information
     hide: true
   - property: Curent_program_duration
-    icon: 'mdi:update'
+    icon: mdi:update
     sensor:
       unknown_value: 65535
       read_only: true
       device_class: duration
       unit: min
   - property: Curent_program_remaining_time
-    icon: 'mdi:progress-clock'
+    icon: mdi:progress-clock
     sensor:
       unknown_value: 65535
       device_class: duration
@@ -118,7 +129,7 @@ properties:
         8: drying
         9: program_finished
         10: ventilating
-    icon: 'mdi:state-machine'
+    icon: mdi:state-machine
     hide: false
   - property: Delay_start
     binary_sensor:
@@ -150,7 +161,7 @@ properties:
         4: failure
         5: service
         6: production
-    icon: 'mdi:dishwasher'
+    icon: mdi:dishwasher
     hide: false
   - property: Display_Brightness_setting_status
     sensor:
@@ -175,126 +186,159 @@ properties:
       options:
         1: off
         2: on
-    icon: 'mdi:folder-open-outline'
+    icon: mdi:folder-open-outline
   - property: Energy_consumption_in_running_program
     sensor:
       state_class: total
       device_class: energy
       unit: hWh
-    icon: 'mdi:lightning-bolt-outline'
+    icon: mdi:lightning-bolt-outline
     hide: false
   - property: Energy_save_setting_status
     hide: true
   - property: Error_F70
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_F76
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f10
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f11
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f12
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f40
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f41
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f42
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f43
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f44
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f45
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f46
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f52
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f54
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f56
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f61
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f62
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f65
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f67
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f68
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f69
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f72
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f74
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f75
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_1_code
+    entity_category: diagnostic
     sensor:
       unknown_value: 255
-    icon: 'mdi:dishwasher-alert'
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_1_cycle
+    entity_category: diagnostic
     sensor:
       unknown_value: 65535
-    icon: 'mdi:dishwasher-alert'
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_1_status
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_2_code
+    entity_category: diagnostic
     sensor:
       unknown_value: 255
-    icon: 'mdi:dishwasher-alert'
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_2_cycle
+    entity_category: diagnostic
     sensor:
       unknown_value: 65535
-    icon: 'mdi:dishwasher-alert'
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_2_status
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_3_code
+    entity_category: diagnostic
     sensor:
       unknown_value: 255
-    icon: 'mdi:dishwasher-alert'
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_3_cycle
+    entity_category: diagnostic
     sensor:
       unknown_value: 65535
-    icon: 'mdi:dishwasher-alert'
+    icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_3_status
-    icon: 'mdi:dishwasher-alert'
+    entity_category: diagnostic
+    icon: mdi:dishwasher-alert
     hide: true
   - property: FOTA_status
   - property: Fan_sequence_setting_status
@@ -327,10 +371,13 @@ properties:
   - property: High_temperature_status
     hide: true
   - property: Interior_light_at_power_off_setting_status
-    sensor:
-      read_only: true
-    icon: mdi:information
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Interior_light_at_power_off_setting
+        adjust: 1
   - property: Interior_light_status
     sensor:
       read_only: true
@@ -369,7 +416,7 @@ properties:
   - property: Rinse_aid_refill
     binary_sensor:
       device_class: problem
-    icon: mdi:white-balance-sunny
+    icon: mdi:flare
     hide: false
   - property: Rinse_aid_setting_status
     sensor:
@@ -388,7 +435,7 @@ properties:
   - property: Selected_program_auto_door_open_function
     binary_sensor:
       device_class: door
-    icon: 'mdi:folder-open-outline'
+    icon: mdi:folder-open-outline
   - property: Selected_program_dry_function
     hide: true
   - property: Selected_program_extra_drying_function
@@ -440,20 +487,22 @@ properties:
   - property: Storage_mode_allowed
     hide: true
   - property: Super_rinse_setting_status
-    sensor:
-      read_only: true
-    icon: mdi:information
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Super_rinse_setting
+        adjust: 1
   - property: Super_rinse_status
     hide: true
   - property: Tab_setting_status
-    binary_sensor:
-      options:
-        0: off
-        1: off
-        2: on
-    icon: mdi:numeric-3-box-outline
-    hide: false
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Tab_setting
+        adjust: 1
   - property: Temperature_unit_status
     hide: true
   - property: Time_program_set_duration_status
@@ -463,7 +512,7 @@ properties:
       state_class: total
       device_class: energy
       unit: kWh
-    icon: 'mdi:lightning-bolt'
+    icon: mdi:lightning-bolt
     hide: false
   - property: Total_number_of_cycles
   - property: Total_run_time
@@ -471,35 +520,35 @@ properties:
       state_class: total
       device_class: duration
       unit: h
-    icon: 'mdi:timer-sand-full'
+    icon: mdi:timer-sand-full
     hide: false
   - property: Total_water_consumption
     sensor:
       state_class: total
       device_class: water
       unit: L
-    icon: 'mdi:water'
+    icon: mdi:water
   - property: Water_consumption_in_running_program
     sensor:
       state_class: total
       device_class: water
       unit: L
-    icon: 'mdi:water-outline'
+    icon: mdi:water-outline
   - property: Water_hardness_setting_status
     sensor:
       device_class: enum
       options:
-        1: '0.0-0.9 mmol/L'
-        2: '1.0-1.4 mmol/L'
-        3: '1.5-2.0 mmol/L'
-        4: '2.1-2.5 mmol/L'
-        5: '2.6-3.4 mmol/L'
-        6: '3.5-4.3 mmol/L'
-        7: '4.4-5.2 mmol/L'
-        8: '5.3-7.0 mmol/L'
-        9: '7.1-8.8 mmol/L'
-        10: '8.9+ mmol/L'
-    icon: 'mdi:water-opacity'
+        1: "0.0-0.9 mmol/L"
+        2: "1.0-1.4 mmol/L"
+        3: "1.5-2.0 mmol/L"
+        4: "2.1-2.5 mmol/L"
+        5: "2.6-3.4 mmol/L"
+        6: "3.5-4.3 mmol/L"
+        7: "4.4-5.2 mmol/L"
+        8: "5.3-7.0 mmol/L"
+        9: "7.1-8.8 mmol/L"
+        10: "8.9+ mmol/L"
+    icon: mdi:water-opacity
   - property: Water_inlet_setting_status
     sensor:
       read_only: true
@@ -517,5 +566,5 @@ properties:
       state_class: total
       device_class: energy
       unit: kWh
-    icon: 'mdi:lightning-bolt-outline'
+    icon: mdi:lightning-bolt-outline
     hide: false

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -1,50 +1,61 @@
 properties:
   - property: Alarm_auto_dose_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_clean_the_filters
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_door_closed
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_door_opened
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_preheating_ready
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_program_done
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_program_pause
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_remote_start_canceled
+    entity_category: diagnostic
     hide: true
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_rinse_aid_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_run_selfcleaning
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Alarm_salt_refill
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
     icon: mdi:dishwasher-alert
@@ -141,103 +152,134 @@ properties:
       options:
         1: off
         2: on
-    icon: 'mdi:folder-open-outline'
+    icon: mdi:folder-open-outline
   - property: Energy_consumption_in_running_program
     sensor:
       unknown_value: 65535
   - property: Energy_save_setting_status
     hide: true
   - property: Error_f10
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f11
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f12
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f40
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f41
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f42
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f43
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f44
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f45
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f46
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f52
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f54
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f56
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f61
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f62
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f65
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f67
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f68
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f69
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f72
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f74
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_f75
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_1_code
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_1_cycle
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_1_status
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_2_code
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_2_cycle
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_2_status
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_3_code
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_3_cycle
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: Error_read_out_3_status
+    entity_category: diagnostic
     icon: mdi:dishwasher-alert
     hide: true
   - property: FOTA_status
@@ -257,7 +299,13 @@ properties:
   - property: High_temperature_status
     hide: true
   - property: Interior_light_at_power_off_setting_status
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Interior_light_at_power_off_setting
+        adjust: 1
   - property: Interior_light_status
     hide: true
   - property: Language_status
@@ -282,7 +330,9 @@ properties:
   - property: Remote_control_monitoring_set_commands_actions
     hide: true
   - property: Rinse_aid_refill
-    hide: true
+    binary_sensor:
+      device_class: problem
+    icon: mdi:flare
   - property: Rinse_aid_setting_status
     hide: true
   - property: Selected_program_auto_door_open_function
@@ -308,11 +358,22 @@ properties:
   - property: Soft_pairing_status
     hide: true
   - property: Super_rinse_setting_status
-    hide: true
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Super_rinse_setting
+        adjust: 1
   - property: Super_rinse_status
     hide: true
   - property: Tab_setting_status
-    hide: true
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Tab_setting
+        adjust: 1
   - property: Temperature_unit_status
     hide: true
   - property: Time_program_set_duration_status

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -77,8 +77,8 @@
   "selector": {
     "actions": {
       "options": {
-        "1": "Start",
-        "2": "Stop",
+        "1": "Stop",
+        "2": "Start",
         "3": "Pause",
         "4": "Open door"
       }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -77,8 +77,8 @@
     "selector": {
         "actions": {
             "options": {
-                "1": "Start",
-                "2": "Stop",
+                "1": "Stop",
+                "2": "Start",
                 "3": "Pause",
                 "4": "Open door"
             }


### PR DESCRIPTION
* Make all alarms diagnostics sensors. They don't seem to work anyway. They always show ok.
* Fix switches for interior light at power off, super rinse aid, and tab setting. 
* Change Rinse_aid_refill and Auto_dose_refill to binary sensors of type problem. These show when you need to refill the rinse aid/dish wash, not the alarm.
* Fix order of stop/start in translations