### PR TITLE
Add mapping file for Hisense Window AC AW-08CWBRVGU01

### DIFF
--- a/custom_components/connectlife/data_dictionaries/008-301.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-301.yaml
@@ -1,0 +1,50 @@
+# Window air conditioner
+properties:
+- property: daily_energy_kwh
+  hide: true
+  sensor:
+    read_only: true
+    state_class: total_increasing
+    device_class: energy
+    unit: kWh
+- property: f_temp_in
+  icon: mdi:temp
+  climate:
+    target: current_temperature
+- property: t_fan_speed
+  climate:
+    target: fan_mode
+    options:
+      2: low
+      3: medium
+      4: high
+- property: t_power
+  climate:
+    target: is_on
+- property: t_sleep
+  icon: mdi-power-sleep
+  switch:
+    device_class: switch
+- property: t_temp
+  climate:
+    target: target_temperature
+    min_value:
+      celsius: 16
+      fahrenheit: 61
+    max_value:
+      celsius: 30
+      fahrenheit: 86
+- property: t_temp_type
+  climate:
+    target: temperature_unit
+    options:
+      0: celsius
+      1: fahrenheit
+- property: t_work_mode
+  climate:
+    target: hvac_mode
+    options:
+      0: fan_only
+      2: cool
+      3: dry
+      5: eco


### PR DESCRIPTION
The only issue I see is that the script generated an entry for daily_energy_kwh but the value is always reported as 0...
I based my work on another AC but also made sure to verify each entry to make sure it's working correctly