### PR TITLE
Validate mapping files

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009-106.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-106.yaml
@@ -19,13 +19,13 @@ properties:
     climate:
       target: current_temperature
   - property: t_beep
-    switch: {}
+    switch:
   - property: t_eco
     icon: mdi:leaf
     switch:
       device_class: switch
   - property: t_fan_mute
-    switch: {}
+    switch:
   - property: t_fan_speed
     climate:
       target: fan_mode

--- a/custom_components/connectlife/data_dictionaries/009-109.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-109.yaml
@@ -19,13 +19,13 @@ properties:
     climate:
       target: current_temperature
   - property: t_beep
-    switch: {}
+    switch:
   - property: t_eco
     icon: mdi:leaf
     switch:
       device_class: switch
   - property: t_fan_mute
-    switch: {}
+    switch:
   - property: t_fan_speed
     climate:
       target: fan_mode

--- a/custom_components/connectlife/data_dictionaries/009-117.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-117.yaml
@@ -19,13 +19,13 @@ properties:
     climate:
       target: current_temperature
   - property: t_beep
-    switch: {}
+    switch:
   - property: t_eco
     icon: mdi:leaf
     switch:
       device_class: switch
   - property: t_fan_mute
-    switch: {}
+    switch:
   - property: t_fan_speed
     climate:
       target: fan_mode

--- a/custom_components/connectlife/data_dictionaries/009-129.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-129.yaml
@@ -48,13 +48,13 @@ properties:
     climate:
       target: current_temperature
   - property: t_beep
-    switch: {}
+    switch:
   - property: t_eco
     icon: mdi:leaf
     switch:
       device_class: switch
   - property: t_fan_mute
-    switch: {}
+    switch:
   - property: t_fan_speed
     climate:
       target: fan_mode

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
@@ -1,6 +1,6 @@
 properties:
   - property: ADO_allowed
-    binary_sensor: {}
+    binary_sensor:
     hide: false
   - property: Alarm_auto_dose_refill
     entity_category: diagnostic

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
@@ -1,6 +1,6 @@
 properties:
   - property: ADO_allowed
-    binary_sensor: {}
+    binary_sensor:
     hide: false
   - property: Alarm_auto_dose_refill
     entity_category: diagnostic

--- a/custom_components/connectlife/data_dictionaries/016-502.yaml
+++ b/custom_components/connectlife/data_dictionaries/016-502.yaml
@@ -10,14 +10,14 @@ properties:
     water_heater:
       target: current_temperature
   - property: t_air
-    switch: {}
+    switch:
   - property: t_beep
     hide: true
   - property: t_fan_speed
     # Same as t_air
     hide: true
   - property: t_sterilization
-    switch: {}
+    switch:
   - property: t_vacation
     water_heater:
       target: is_away_mode_on

--- a/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
@@ -2,7 +2,7 @@
 properties:
   - property: Child_lock
     icon: mdi:lock
-    switch: {}
+    switch:
   - property: Current_program_phase
     icon: mdi:state-machine
     sensor:
@@ -125,7 +125,7 @@ properties:
         1: "on"
   - property: Steam
     icon: mdi:heat-wave
-    switch: {}
+    switch:
   - property: temperature
     icon: mdi:thermometer-lines
     select:

--- a/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
@@ -4,12 +4,11 @@ properties:
   sensor:
     read_only: true
     device_class: enum
-    icon: 'mdi:shield-check'
+  icon: 'mdi:shield-check'
 - property: Current_program_phase
   sensor:
     read_only: true
     device_class: enum
-    icon: 'mdi:progress-wrench'
     options:
       0: not_available
       1: program_not_selected
@@ -27,6 +26,7 @@ properties:
       13: anti_crease
       14: delay
       15: finished
+  icon: 'mdi:progress-wrench'
 - property: daily_energy_kwh
   sensor:
     read_only: true

--- a/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
@@ -20,7 +20,7 @@ properties:
   - property: ali_wifi_fault_flag
     hide: true
   - property: automatic_ice_making
-    switch: {}
+    switch:
   - property: charcoal_filter_expiration_alarm
     hide: true
     binary_sensor:
@@ -168,7 +168,7 @@ properties:
       max_value: -5
   - property: frost_state
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: froze_convert_to_refri_switch_status
     hide: true
   - property: fruit_vegetables_temperature
@@ -192,7 +192,7 @@ properties:
       unit: °C
   - property: holiday_mode
     hide: true
-    switch: {}
+    switch:
   - property: humidity sensor_failure
     hide: true
     binary_sensor:
@@ -275,7 +275,7 @@ properties:
       device_class: problem
   - property: quiet_mode_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: real_humidity
     hide: true
     sensor:
@@ -313,7 +313,7 @@ properties:
     hide: true
   - property: refr_room_open
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: refr_room_over_temp_alarm
     hide: true
     binary_sensor:
@@ -487,13 +487,13 @@ properties:
       device_class: problem
   - property: sabbath_mode_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: sabbath_mode_switch_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: save_mode
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: screen_display_brightness
     hide: true
   - property: screen_display_lock
@@ -573,7 +573,7 @@ properties:
     hide: true
   - property: vacuum_on_off_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: var_room_open_2
     hide: true
   - property: var_room_over_temp_alarm

--- a/custom_components/connectlife/data_dictionaries/026-1b0628z0075j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0628z0075j.yaml
@@ -10,7 +10,7 @@ properties:
   - property: ali_wifi_fault_flag
     hide: true
   - property: automatic_ice_making
-    switch: {}
+    switch:
   - property: camera_state
     hide: true
   - property: charcoal_filter_expiration_alarm
@@ -190,7 +190,7 @@ properties:
       max_value: -14
   - property: frost_state
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: froze_convert_to_refri_switch_status
     hide: true
   - property: fruit_vegetables_temperature
@@ -212,7 +212,7 @@ properties:
     hide: true
     binary_sensor:
   - property: holiday_mode
-    switch: {}
+    switch:
   - property: humidity sensor_failure
     hide: true
     binary_sensor:
@@ -222,9 +222,9 @@ properties:
     binary_sensor:
       device_class: problem
   - property: ice_making_b_switch_status
-    switch: {}
+    switch:
   - property: ice_making_state
-    switch: {}
+    switch:
   - property: low_humidity
     hide: true
     sensor:
@@ -307,7 +307,7 @@ properties:
       device_class: problem
   - property: quiet_mode_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: real_humidity
     hide: true
     sensor:
@@ -345,7 +345,7 @@ properties:
     hide: true
   - property: refrigerator_room_open
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: refrigerator_room_over_temp_alarm
     hide: true
     binary_sensor:
@@ -435,13 +435,12 @@ properties:
       device_class: problem
   - property: sabbath_mode_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: sabbath_mode_switch_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: save_mode
-    switch: {}
-    binary_sensor: {}
+    switch:
   - property: screen_display_brightness
     hide: true
   - property: screen_display_lock
@@ -455,9 +454,9 @@ properties:
   - property: sensor_failure_status2
     hide: true
   - property: sf_mode
-    switch: {}
+    switch:
   - property: sf_sr_mutex_mode
-    switch: {}
+    switch:
   - property: shelf_light_a_state
     hide: true
   - property: shelf_light_atmosphere_brightness
@@ -479,7 +478,7 @@ properties:
   - property: special_space
     hide: true
   - property: sr_mode
-    switch: {}
+    switch:
   - property: standby_mode_state
     hide: true
   - property: standby_mode_valid
@@ -523,7 +522,7 @@ properties:
     hide: true
   - property: vacuum_on_off_status
     hide: true
-    binary_sensor: {}
+    binary_sensor:
   - property: var_room_open_2
     hide: true
   - property: var_room_over_temp_alarm

--- a/custom_components/connectlife/data_dictionaries/026-1b0628z0146j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0628z0146j.yaml
@@ -526,7 +526,7 @@ properties:
   - property: run_status_flag_5
     hide: true
   - property: running_status
-    sensor: {}
+    sensor:
   - property: running_status3
     hide: true
   - property: rx_failure

--- a/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22.yaml
+++ b/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22.yaml
@@ -5,72 +5,72 @@ properties:
     read_only: true
     device_class: duration
     unit: min
-    icon: 'mdi:update'
+  icon: 'mdi:update'
 - property: Delaystart_delayend_mode_status
   sensor:
     read_only: true
     device_class: enum
-    icon: 'mdi:timer'
     options:
-      1: off
-      3: on
+      1: "off"
+      3: "on"
+  icon: 'mdi:timer'
 - property: Selected_program_remaining_time_in_minutes
   sensor:
     read_only: true
     device_class: duration
     unit: min
-    icon: 'mdi:update'
+  icon: 'mdi:update'
 - property: Selected_program_duration_in_minutes
   sensor:
     read_only: true
     device_class: duration
     unit: min
-    icon: 'mdi:timer'
+  icon: 'mdi:timer'
 - property: Door_status
   sensor:
     read_only: true
     device_class: enum
-    icon: 'mdi:door'
     options:
       0: not_available
       1: open
       2: closed
       3: closed_when_running
+  icon: 'mdi:door'
 - property: Status
   sensor:
     read_only: true
     device_class: enum
-    icon: 'mdi:washing-machine'
     options:
-      0: off
+      0: "off"
       1: standby
       6: running
+  icon: 'mdi:washing-machine'
 - property: Current_temperature
   sensor:
     read_only: true
     device_class: temperature
     unit: °C
-    icon: 'mdi:thermometer'
+  icon: 'mdi:thermometer'
 - property: Selected_program_id_status
   sensor:
-  read_only: true
-  device_class: enum
+    read_only: true
+    device_class: enum
+    options:
+      0: eco_40_60
+      1: white_cotton
+      2: color
+      3: wool_manual
+      4: mix_synthetic
+      5: extra_hygiene
+      6: fast_20
+      7: intensive_59_32
+      9: sport
+      10: baby
+      12: shirts
+      13: drum_cleaning
+      14: spinning_draining
+      16: rinsing_softening
   icon: 'mdi:playlist-check'
-  options:
-    0: eco_40_60
-    1: white_cotton
-    2: color
-    3: wool_manual
-    4: mix_synthetic
-    5: extra_hygiene
-    6: fast_20
-    7: intensive_59_32
-    9: sport
-    10: baby
-    12: shirts
-    13: drum_cleaning
-    14: spinning_draining
-    16: rinsing_softening
 - property: ADS_Dirtiness_setting_status
   # Sample value: 2
 - property: ADS_Settings_Current_Program_Detergent_setting_status

--- a/custom_components/connectlife/data_dictionaries/030-1wk080066v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk080066v0w.yaml
@@ -1,13 +1,13 @@
 properties:
   - property: AntiCrease
     icon: mdi:iron
-    switch: {}
+    switch:
   - property: Child_lock
     icon: mdi:lock
-    switch: {}
+    switch:
   - property: Clean_Filter
     icon: mdi:brush-variant
-    binary_sensor: {}
+    binary_sensor:
   - property: Current_program_phase
     icon: mdi:tumble-dryer
     sensor:
@@ -30,7 +30,7 @@ properties:
         2: off
   - property: Drum_Light
     icon: mdi:lightbulb-on
-    switch: {}
+    switch:
   - property: Dry_Level
     icon: mdi:weather-sunny
     select:
@@ -46,7 +46,7 @@ properties:
       read_only: true
   - property: Waterbox_Full
     icon: mdi:water-alert
-    binary_sensor: {}
+    binary_sensor:
   - property: machine_status
     icon: mdi:tumble-dryer
     sensor:
@@ -58,7 +58,7 @@ properties:
       read_only: true
   - property: mute
     icon: mdi:volume-mute
-    switch: {}
+    switch:
   - property: Selected_program_ID
     icon: mdi:selection-ellipse-arrow-inside
     select:
@@ -87,4 +87,4 @@ properties:
         3: extra_dry
   - property: Natural_Dry
     icon: mdi:hair-dryer
-    switch: {}
+    switch:

--- a/custom_components/connectlife/data_dictionaries/030-1wk100028v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk100028v0w.yaml
@@ -1,13 +1,13 @@
 properties:
   - property: AntiCrease
     icon: mdi:iron
-    switch: {}
+    switch: 
   - property: Child_lock
     icon: mdi:lock
-    switch: {}
+    switch: 
   - property: Clean_Filter
     icon: mdi:brush-variant
-    binary_sensor: {}
+    binary_sensor: 
   - property: Current_program_phase
     icon: mdi:tumble-dryer
     sensor:
@@ -30,7 +30,7 @@ properties:
         2: off
   - property: Drum_Light
     icon: mdi:lightbulb-on
-    switch: {}
+    switch:
   - property: Dry_Level
     icon: mdi:weather-sunny
     select:
@@ -46,7 +46,7 @@ properties:
       read_only: true
   - property: Waterbox_Full
     icon: mdi:water-alert
-    binary_sensor: {}
+    binary_sensor:
   - property: machine_status
     icon: mdi:tumble-dryer
     sensor:
@@ -58,5 +58,5 @@ properties:
       read_only: true
   - property: mute
     icon: mdi:volume-mute
-    switch: {}
+    switch:
 

--- a/custom_components/connectlife/data_dictionaries/032-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/032-000.yaml
@@ -87,7 +87,7 @@ properties:
   - property: Bundling_sensor_setting_status
     # Example value: 0
   - property: Child_Lock_status
-    binary_sensor: {}
+    binary_sensor: 
   - property: Condensed_watermode
     hide: true
   - property: Current_programphase
@@ -104,7 +104,7 @@ properties:
       device_class: duration
       unit: min
   - property: DelayStart_DelayEnd_mode
-    binary_sensor: {}
+    binary_sensor: 
     hide: true
   - property: DelayStart_DelayEnd_remaining_timein_minutes
     sensor:
@@ -209,15 +209,15 @@ properties:
     binary_sensor:
       device_class: problem
   - property: ExtraDry_setting
-    sensor: {}
+    sensor: 
   - property: Float_switch
-    binary_sensor: {}
+    binary_sensor: 
   - property: Fota
     hide: true
   - property: HardPairingStatus
     hide: true
   - property: Humidity_sensor
-    binary_sensor: {}
+    binary_sensor: 
     hide: true
   - property: Logo_setting_status
     hide: true
@@ -226,19 +226,19 @@ properties:
   - property: NTC_sensor_2
     hide: true
   - property: Reed_switch
-    binary_sensor: {}
+    binary_sensor: 
     hide: true
   - property: Remote_control_mode_monitoring
-    binary_sensor: {}
+    binary_sensor: 
     hide: true
   - property: Remote_control_monitoring_set_commands
     hide: true
   - property: Remote_control_monitoring_set_commands_actions
     hide: true
   - property: Selected_program_AntiCrease_status
-    binary_sensor: {}
+    binary_sensor: 
   - property: Selected_program_ExtraDry_status
-    binary_sensor: {}
+    binary_sensor: 
   - property: Selected_program_ID
     icon: mdi:selection-ellipse-arrow-inside
     sensor:
@@ -261,7 +261,7 @@ properties:
         14: remote
         255: none
   - property: Selected_program_SteamFinish
-    binary_sensor: {}
+    binary_sensor: 
   - property: Selected_program_mode_status
     hide: true
     # Example value: 1
@@ -274,7 +274,7 @@ properties:
       device_class: duration
       unit: min
   - property: Session_pairing_active
-    binary_sensor: {}
+    binary_sensor:
     hide: true
   - property: Session_pairing_setting
     hide: true
@@ -300,7 +300,7 @@ properties:
     hide: true
     # Example value: 1
   - property: Water_level_switch
-    binary_sensor: {}
+    binary_sensor:
     hide: true
   - property: daily_energy_kwh
     hide: true

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -1,18 +1,18 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
-  "$ref": "#/definitions/ConnectLifeDataDictionary",
-  "definitions": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/ConnectLifeDataDictionary",
+  "$defs": {
     "ConnectLifeDataDictionary": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "climate": {
-          "$ref": "#/definitions/ClimateDevice"
+          "$ref": "#/$defs/ClimateDevice"
         },
         "properties": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Property"
+            "$ref": "#/$defs/Property"
           }
         }
       },
@@ -28,7 +28,7 @@
         "presets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Preset"
+            "$ref": "#/$defs/Preset"
           },
           "description": "List of presets"
         }
@@ -56,28 +56,28 @@
           "type": "string"
         },
         "binary_sensor": {
-          "$ref": "#/definitions/BinarySensor"
+          "$ref": "#/$defs/BinarySensor"
         },
         "climate": {
-          "$ref": "#/definitions/Climate"
+          "$ref": "#/$defs/Climate"
         },
         "humidifier": {
-          "$ref": "#/definitions/Humidifier"
+          "$ref": "#/$defs/Humidifier"
         },
         "number": {
-          "$ref": "#/definitions/Number"
+          "$ref": "#/$defs/Number"
         },
         "select": {
-          "$ref": "#/definitions/Select"
+          "$ref": "#/$defs/Select"
         },
         "sensor": {
-          "$ref": "#/definitions/Sensor"
+          "$ref": "#/$defs/Sensor"
         },
         "switch": {
-          "$ref": "#/definitions/Switch"
+          "$ref": "#/$defs/Switch"
         },
         "water_heater": {
-          "$ref": "#/definitions/WaterHeater"
+          "$ref": "#/$defs/WaterHeater"
         },
         "icon": {
           "type": "string",
@@ -118,16 +118,16 @@
       "description": "Defines a property for an appliance."
     },
     "BinarySensor": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "device_class": {
-          "$ref": "#/definitions/BinarySensorDeviceClass"
+          "$ref": "#/$defs/BinarySensorDeviceClass"
         },
         "options": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "boolean"
           },
           "description": "Map of integer to boolean. By default, 0 and 1 is mapped to off (as 0 often implies that the sensor is not available), and 1 to true."
         }
@@ -155,16 +155,16 @@
       "additionalProperties": false,
       "properties": {
         "target": {
-          "$ref": "#/definitions/ClimateTarget"
+          "$ref": "#/$defs/ClimateTarget"
         },
         "unknown_value": {
-          "$ref": "#/definitions/UnknownValue"
+          "$ref": "#/$defs/UnknownValue"
         },
         "max_value": {
-          "$ref": "#/definitions/IntegerOrTemperature"
+          "$ref": "#/$defs/IntegerOrTemperature"
         },
         "min_value": {
-          "$ref": "#/definitions/IntegerOrTemperature"
+          "$ref": "#/$defs/IntegerOrTemperature"
         },
         "options": {
           "type": "object",
@@ -180,7 +180,7 @@
       "additionalProperties": false,
       "properties": {
         "target": {
-          "$ref": "#/definitions/HumidifierTarget"
+          "$ref": "#/$defs/HumidifierTarget"
         },
         "min_value": {
           "type": "integer"
@@ -189,7 +189,7 @@
           "type": "integer"
         },
         "device_class": {
-          "$ref": "#/definitions/HumidifierDeviceClass"
+          "$ref": "#/$defs/HumidifierDeviceClass"
         },
         "options": {
           "type": "object",
@@ -205,7 +205,7 @@
       "additionalProperties": false,
       "properties": {
         "device_class": {
-          "$ref": "#/definitions/NumberDeviceClass"
+          "$ref": "#/$defs/NumberDeviceClass"
         },
         "unit": {
           "type": "string",
@@ -246,7 +246,7 @@
           "description": "Map of integer to string."
         },
         "command": {
-          "$ref": "#/definitions/Command"
+          "$ref": "#/$defs/Command"
         }
       },
       "required": [
@@ -254,11 +254,11 @@
       ]
     },
     "Sensor": {
-      "type": "object",
+      "type": ["object", "null" ],
       "additionalProperties": false,
       "properties": {
         "device_class": {
-          "$ref": "#/definitions/SensorDeviceClass"
+          "$ref": "#/$defs/SensorDeviceClass"
         },
         "read_only": {
           "type": "boolean",
@@ -275,7 +275,7 @@
           ]
         },
         "unknown_value": {
-          "$ref": "#/definitions/UnknownValue"
+          "$ref": "#/$defs/UnknownValue"
         },
         "options": {
           "type": "object",
@@ -285,7 +285,7 @@
           "description": "Map of integer to string. Required if device_class is set to enum."
         },
         "state_class": {
-          "$ref": "#/definitions/SensorStateClass"
+          "$ref": "#/$defs/SensorStateClass"
         },
         "multiplier": {
           "type": "number",
@@ -294,29 +294,29 @@
             "0.1",
             "10"
           ],
-          "default": "1"
+          "default": 1
         }
       }
     },
     "Switch": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "off": {
           "type": "integer",
           "description": "Off value",
-          "default": "0"
+          "default": 0
         },
         "on": {
           "type": "integer",
           "description": "On value",
-          "default": "1"
+          "default": 1
         },
         "device_class": {
-          "$ref": "#/definitions/SwitchDeviceClass"
+          "$ref": "#/$defs/SwitchDeviceClass"
         },
         "command": {
-          "$ref": "#/definitions/Command"
+          "$ref": "#/$defs/Command"
         }
       },
       "title": "BinarySensor"
@@ -326,23 +326,23 @@
       "additionalProperties": false,
       "properties": {
         "target": {
-          "$ref": "#/definitions/WaterHeaterTarget"
+          "$ref": "#/$defs/WaterHeaterTarget"
         },
         "unknown_value": {
-          "$ref": "#/definitions/UnknownValue"
+          "$ref": "#/$defs/UnknownValue"
         },
         "max_value": {
-          "$ref": "#/definitions/IntegerOrTemperature"
+          "$ref": "#/$defs/IntegerOrTemperature"
         },
         "min_value": {
-          "$ref": "#/definitions/IntegerOrTemperature"
+          "$ref": "#/$defs/IntegerOrTemperature"
         },
         "options": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": ["string", "boolean"]
           },
-          "description": "Map of integer to string. Required for targets current_operation, state, and temperature_unit."
+          "description": "Map of integer to string or boolean. Required for targets current_operation (string), state (string), temperature_unit (string), and is_away_mode_on (boolean)."
         }
       }
     },

--- a/scripts/validate_mappings.py
+++ b/scripts/validate_mappings.py
@@ -1,0 +1,35 @@
+import json
+import pprint
+from os import listdir
+from os.path import isfile, join
+
+from jschon import create_catalog, JSON, JSONSchema
+import yaml
+
+def my_construct_mapping(self, node, deep=False):
+    data = self.construct_mapping_org(node, deep)
+    return {(str(key) if isinstance(key, int) else key): data[key] for key in data}
+
+def main(basedir):
+    yaml.SafeLoader.construct_mapping_org = yaml.SafeLoader.construct_mapping
+    yaml.SafeLoader.construct_mapping = my_construct_mapping
+
+    device_dir = f"{basedir}/data_dictionaries"
+    create_catalog("2020-12")
+    schema_file = f"{device_dir}/properties-schema.json"
+    schema = JSONSchema.loadf(schema_file)
+    schema.validate()
+
+    filenames = list(filter(lambda f: f[-5:] == ".yaml", [f for f in listdir(device_dir) if isfile(join(device_dir, f))]))
+    filenames.sort()
+    for filename in filenames:
+        print(f"Validating {filename}")
+        with open(f"{device_dir}/{filename}", "r") as f:
+            mappings_yaml = yaml.safe_load(f)
+        mappings_json = JSON(mappings_yaml)
+        result = schema.evaluate(mappings_json)
+        if not result.valid:
+            pprint.pp(result.output("basic")["errors"])
+
+if __name__ == "__main__":
+    main("custom_components/connectlife")


### PR DESCRIPTION
- Updated mapping file schema to JSON Schema 2020-12
- Corrected default values for integers in schema
- Aligned schema with implementation:
  - Allow empty sections for `binary_sensor`, `sensor`, and `switch`
  - `binary_sensor` option value type is boolean
  - `water_heater` option value type is boolean for target `is_away_mode_on`
- Added `scripts.validate_mappings` to check that all mapping files are valid
- Corrected invalid mapping files