### PR TITLE
Add Support for device 026-1b0470z0012j

### DIFF
--- a/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
@@ -1,0 +1,80 @@
+# Hisense 483L French Door Refrigerator HRCD483TBW
+properties:
+- property: automatic_ice_making
+  # Ice Maker switch
+  switch:
+    on: 1
+    off: 0
+- property: existing_save_mode
+  # Sample value: 1
+- property: existing_sf_mode
+  # Sample value: 1
+- property: existing_sr_mode
+  # Sample value: 1
+- property: freeze_real_temperature
+  # This meassures the temperature in the freezer (bottom left)
+  sensor:
+      device_class: temperature
+      unit: property.temperature_unit
+- property: freeze_sensor_real_temperature
+  # Sample value: -14
+- property: freeze_temperature
+  # This sets the temperature in the freezer (bottom left)
+  number:
+      device_class: temperature
+      unit: property.temperature_unit
+      min_value: property.freeze_min_temperature
+      max_value: property.freeze_max_temperature    
+- property: refrigerator_max_temperature
+  # Sample value: 9
+- property: refrigerator_min_temperature
+  # Sample value: 2
+- property: refrigerator_real_temperature
+  # This meassures the temperature in the fridge
+  sensor:
+      device_class: temperature
+      unit: property.temperature_unit # Reference the temperature_unit property
+- property: refrigerator_temperature
+  # This sets the temperature in the fridge
+  number:
+      device_class: temperature
+      unit: property.temperature_unit # Reference the temperature_unit property
+      min_value: property.refrigerator_min_temperature
+      max_value: property.refrigerator_max_temperature
+- property: save_mode
+  # Eco mode switch
+  switch:
+    on: 1
+    off: 0
+- property: sf_mode
+  # Super Freeze mode switch
+  switch:
+    on: 1
+    off: 0
+- property: sr_mode
+  # Super Cool mode switch
+  switch:
+    on: 1
+    off: 0
+- property: temperature_unit
+  # This sets the Unit
+  select:
+      options:
+        0: celsius   # Map value 0 from the API to 'celsius'
+        1: fahrenheit # Map value 1 from the API to 'fahrenheit'
+- property: variation_max_temperature
+  # Sample value: 5
+- property: variation_min_temperature
+  # Sample value: -18
+- property: variation_real_temperature
+  # This meassures the temperature in the MyChoice (bottom right)
+  sensor:
+      device_class: temperature
+      unit: property.temperature_unit
+- property: variation_temperature
+  # This sets the temperature in the MyChoice (bottom right)
+  number:
+      device_class: temperature
+      unit: property.temperature_unit
+      min_value: property: variation_min_temperature
+      max_value: property: variation_max_temperature

--- a/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
@@ -76,5 +76,5 @@ properties:
   number:
       device_class: temperature
       unit: property.temperature_unit
-      min_value: property: variation_min_temperature
-      max_value: property: variation_max_temperature
+      min_value: property.variation_min_temperature
+      max_value: property.variation_max_temperature

--- a/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
@@ -94,5 +94,5 @@ properties:
   number:
       device_class: temperature
       unit: property.temperature_unit
-      min_value: property.variation_min_temperature
-      max_value: property.variation_max_temperature
+      min_value.property.variation_min_temperature
+      max_value.property.variation_max_temperature

--- a/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0470z0012j.yaml
@@ -1,16 +1,49 @@
 # Hisense 483L French Door Refrigerator HRCD483TBW
 properties:
+- property: ice_making_state
+  # Ice Maker status
+  binary_sensor:
+    options:
+      0: off
+      1: on
 - property: automatic_ice_making
   # Ice Maker switch
   switch:
     on: 1
     off: 0
 - property: existing_save_mode
-  # Sample value: 1
+  # Eco mode status
+  binary_sensor:
+    options:
+      0: off
+      1: on
+- property: save_mode
+  # Eco mode switch
+  switch:
+    on: 1
+    off: 0
 - property: existing_sf_mode
-  # Sample value: 1
+  # Super Freeze status
+  binary_sensor:
+    options:
+      0: off
+      1: on
+- property: sf_mode
+  # Super Freeze mode switch
+  switch:
+    on: 1
+    off: 0
 - property: existing_sr_mode
-  # Sample value: 1
+  # Super Cool status
+  binary_sensor:
+    options:
+      0: off
+      1: on
+- property: sr_mode
+  # Super Cool mode switch
+  switch:
+    on: 1
+    off: 0
 - property: freeze_real_temperature
   # This meassures the temperature in the freezer (bottom left)
   sensor:
@@ -41,21 +74,6 @@ properties:
       unit: property.temperature_unit # Reference the temperature_unit property
       min_value: property.refrigerator_min_temperature
       max_value: property.refrigerator_max_temperature
-- property: save_mode
-  # Eco mode switch
-  switch:
-    on: 1
-    off: 0
-- property: sf_mode
-  # Super Freeze mode switch
-  switch:
-    on: 1
-    off: 0
-- property: sr_mode
-  # Super Cool mode switch
-  switch:
-    on: 1
-    off: 0
 - property: temperature_unit
   # This sets the Unit
   select:


### PR DESCRIPTION
I have tried to create the yaml file for this following the instructions.
Might not be right as I have no experience doing this.
The device I have is a Hisense 483L French Door Refrigerator (HRCD483TBW).
This screenshot shows the basic functions for this device in the ConnectLife app.
![Screenshot_2025-05-17-13-10-52-11_356f8f9f90ea39813f2001d57f2f7507](https://github.com/user-attachments/assets/b7691ae1-c4d8-4d84-bfab-a1abd183a095)
And without adding the file yet (I do not want to break something) I have identified these sensors in HA.
![image](https://github.com/user-attachments/assets/14b8f0f0-e0f9-4d33-b13a-21d79fbe2d05)
Any guidance with creating the yaml for this device is appreciated.