### PR TITLE
Add translations and new device support

### DIFF
--- a/custom_components/connectlife/data_dictionaries/025-1wj105050v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105050v0w.yaml
@@ -1,0 +1,167 @@
+#WashingMachine
+properties:
+  - property: Child_lock
+    icon: mdi:lock
+    switch:
+  - property: ApplicationPermissions
+    icon: mdi:remote
+    sensor:
+      device_class: enum
+      options:
+        2: "off"
+        3: "on"
+  - property: Current_program_phase
+    icon: mdi:state-machine
+    sensor:
+      device_class: enum
+      options:
+        0: not_available
+        1: weigh
+        2: prewash
+        3: wash
+        4: rinse
+        7: spin-dry
+        8: drying
+        10: finished
+      read_only: true
+
+  - property: Detergent_display
+    icon: mdi:alpha-d-circle-outline
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "on"
+  - property: Detergent_state
+    icon: mdi:alpha-d-circle-outline
+    binary_sensor:
+      read_only: true
+      device_class: problem
+      options:
+        0: false
+        1: true
+  - property: Softer_display
+    icon: mdi:alpha-s-circle-outline
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "on"
+  - property: Softener_state
+    icon: mdi:alpha-s-circle-outline
+    binary_sensor:
+      read_only: true
+      device_class: problem
+      options:
+        0: false
+        1: true
+  - property: Door_status
+    icon: mdi:door-closed
+    sensor:
+      device_class: enum
+      options:
+        1: "open"
+        3: "closed"
+
+  - property: machine_status
+    icon: mdi:washing-machine
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "standby"
+        2: "running"
+        3: "paused"
+
+  - property: Selected_program_ID
+    icon: mdi:tshirt-crew
+    select:
+      options:
+        1: "cotton_dry"
+        2: "synthetic_dry"
+        4: "refresh"
+        5: "anti_allergy"
+        6: "drum_cleaning"
+        7: "cotton"
+        8: "synthetic"
+        9: "eco_40_60"
+        10: "wool"
+        11: "fast15"
+        14: "spin-dry"
+        16: "baby"
+        20: "rinse_spin"
+        22: "clean_dry_60"
+        41: "power49"
+        42: "auto"
+
+  - property: Selected_program_remaining_time_in_minutes
+    icon: mdi:timer-sand
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
+
+  - property: Selected_program_total_time_in_minutes
+    icon: mdi:timer-outline
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
+
+  - property: Energy_estimate
+    icon: mdi:flash
+    sensor:
+      device_class: energy
+      unit: Wh
+      read_only: true
+      state_class: total
+
+  - property: Electricit_consumption_int
+    icon: mdi:flash
+    sensor:
+      device_class: energy
+      unit: Wh
+      read_only: true
+      state_class: total_increasing
+
+  - property: Water_consumption_int
+    icon: mdi:water
+    sensor:
+      device_class: water
+      unit: L
+      read_only: true
+      state_class: total_increasing
+
+  - property: temperature
+    icon: mdi:thermometer
+    select:
+      options:
+        0: "cold"
+        2: "20"
+        3: "30"
+        4: "40"
+        6: "60"
+        9: "90"
+
+  - property: Spin_speed_rpm
+    icon: mdi:rotate-right
+    select:
+      options:
+        14: "1400"
+        12: "1200"
+        10: "1000"
+        8: "800"
+        6: "600"
+        0: "none"
+
+  - property: mute
+    icon: mdi:volume-variant-off
+    switch:
+
+  - property: Prewash
+    icon: mdi:numeric-1-circle-outline
+    switch:
+
+  - property: Steam
+    icon: mdi:heat-wave
+    switch:

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -400,56 +400,8 @@
       "existing_sr_mode": {
         "name": "Existing SR mode"
       },
-      "f_e_arkgrille": {
-        "name": "Cabinet grille protection alarm"
-      },
       "f_e_filterclean": {
         "name": "Filter clean"
-      },
-      "f_e_incoiltemp": {
-        "name": "Indoor coil temperature sensor failure"
-      },
-      "f_e_incom": {
-        "name": "Indoor/outdoor communication failure"
-      },
-      "f_e_indisplay": {
-        "name": "Communication failure between indoor control panel and display panel"
-      },
-      "f_e_ineeprom": {
-        "name": "Indoor control board EEPROM error"
-      },
-      "f_e_inele": {
-        "name": "Communication failure between indoor control panel and indoor power panel"
-      },
-      "f_e_infanmotor": {
-        "name": "Indoor fan motor abnormal operation failure"
-      },
-      "f_e_inhumidity": {
-        "name": "Indoor humidity sensor failure"
-      },
-      "f_e_inkeys": {
-        "name": "Communication failure between indoor control panel and keypad"
-      },
-      "f_e_intemp": {
-        "name": "Indoor temperature sensor failure"
-      },
-      "f_e_invzero": {
-        "name": "Indoor voltage zero-crossing detection fault"
-      },
-      "f_e_inwifi": {
-        "name": "Communication failure between WIFI control panel and indoor control panel"
-      },
-      "f_e_outcoiltemp": {
-        "name": "Outdoor coil temperature sensor failure"
-      },
-      "f_e_outeeprom": {
-        "name": "Outdoor EEPROM error"
-      },
-      "f_e_outgastemp": {
-        "name": "Exhaust temperature sensor failure"
-      },
-      "f_e_outtemp": {
-        "name": "Outdoor ambient temperature sensor failure"
       },
       "f_e_pump": {
         "name": "Pump"
@@ -835,9 +787,6 @@
       "step3_status": {
         "name": "Step 3 status"
       },
-      "t_beep": {
-        "name": "Beep"
-      },
       "tab_setting_status": {
         "name": "Tab setting"
       },
@@ -894,9 +843,6 @@
             }
           },
           "swing_mode": {
-            "state": {}
-          },
-          "swing_horizontal_mode": {
             "state": {
               "both_sides": "Both sides",
               "forward": "Forward",
@@ -937,8 +883,10 @@
       },
       "appliance_status": {
         "state": {
-          "idle": "Idle",
-          "running": "Running"
+		  "idle": "Idle",
+		  "paused": "Paused",
+		  "running": "Running",
+		  "standby": "Standby"
         }
       },
       "applicationpermissions": {
@@ -1004,9 +952,6 @@
           "running": "Running"
         }
       },
-      "current_temperature": {
-        "name": "Current temperature"
-      },
       "daily_energy_consumption": {
         "name": "Daily energy consumption"
       },
@@ -1022,9 +967,6 @@
       "delay_start_remaining_time": {
         "name": "Delay start remaining time"
       },
-      "delay_start_remaining_time_in_minutes": {
-        "name": "Delay start remaining time in minutes"
-      },
       "delay_start_set_time": {
         "name": "Delay start set time"
       },
@@ -1033,13 +975,6 @@
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Delay start duration"
-      },
-      "delaystart_delayend_mode_status": {
-        "name": "Delay start status",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
       },
       "delaystart_delayend_remaining_timein_minutes": {
         "name": "Delay start remaining time"
@@ -1081,9 +1016,8 @@
         "state": {
           "not_available": "Not available",
           "open": "Open",
-          "closed": "Closed",
-          "closed_when_running": "Closed when running",
-          "other": "Other"
+          "other": "Other",
+          "closed": "Closed"
         }
       },
       "electricit_consumption_decimal": {
@@ -1300,9 +1234,6 @@
           "paused": "Paused",
           "stopped": "Stopped"
         }
-      },
-      "selected_program_duration_in_minutes": {
-        "name": "Selected program duration"
       },
       "selected_program_id": {
         "name": "Selected program",
@@ -1641,14 +1572,6 @@
       "spintime_index": {
         "name": "Spin time index"
       },
-      "status": {
-        "name": "Device status",
-        "state": {
-          "off": "Off",
-          "standby": "Standby",
-          "running": "Running"
-        }
-      },
       "step1_duration": {
         "name": "Step1 duration"
       },
@@ -1884,6 +1807,30 @@
       },
       "zone_number": {
         "name": "Number of zones"
+      },
+      "status": {
+        "name": "Device status",
+        "state": {
+          "off": "Off",
+          "standby": "Standby",
+          "running": "Running"
+        }
+      },
+      "door_status": {
+        "name": "Door status",
+        "state": {
+          "not_available": "Not Available",
+          "open": "Open",
+          "closed": "Closed",
+          "closed_when_running": "Closed when running"
+        }
+      },
+      "delaystart_delayend_mode_status": {
+        "name": "Delay start status",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
       }
     },
     "switch": {
@@ -2007,6 +1954,12 @@
       "extrarinsenum": {
         "name": "Extra rinse num"
       },
+      "lightbrightness": {
+        "name": "Light brightness"
+      },
+      "lightcolortemperature": {
+        "name": "Light colort emperature"
+      },
       "motorlevel": {
         "name": "Motor level"
       },
@@ -2083,12 +2036,6 @@
           "follow": "Follow",
           "not_follow": "Not Follow"
         }
-      },
-      "temperature": {
-        "name": "Temperature",
-        "state": {
-          "cold": "Cold"
-        }
       }
     },
     "water_heater": {
@@ -2107,12 +2054,6 @@
       },
       "freeze_temperature": {
         "name": "Freezeer temperature"
-      },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
       },
       "refrigerator_max_temperature": {
         "name": "Refrigerator max temperature"


### PR DESCRIPTION
This pull request includes the following changes:

- Updated `en.json`
  - Added translations for the following appliance status states:
    - `standby`
    - `paused`

- Created `025-1wj105050v0w.yaml`
  - Added support for the new device:
    - Model: `025-1wj105050v0w`
