### PR TITLE
Align strings with app

### DIFF
--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -839,7 +839,7 @@
         "name": "Beep"
       },
       "tab_setting_status": {
-        "name": "Tab setting"
+        "name": "Detergent TAB"
       },
       "tx_failure": {
         "name": "TX failure"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1918,7 +1918,7 @@
         "name": "Ice making state"
       },
       "interior_light_at_power_off_setting_status": {
-        "name": "Interior light at power off setting status"
+        "name": "Interior light at power off"
       },
       "mute": {
         "name": "Mute"
@@ -1948,7 +1948,7 @@
         "name": "Steam"
       },
       "super_rinse_setting_status": {
-        "name": "Super rinse setting status"
+        "name": "Super rinse"
       },
       "t_air": {
         "name": "Air"
@@ -1981,7 +1981,7 @@
         "name": "AI"
       },
       "tab_setting_status": {
-        "name": "Tab setting status"
+        "name": "Detergent TAB"
       }
     },
     "select": {


### PR DESCRIPTION
Use the same names for switches as the app does to avoid confusion