### PR TITLE
Change energy and water consumption (running program) to `total_increasing` state class

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -223,7 +223,7 @@ properties:
     icon: mdi:folder-open-outline
   - property: Energy_consumption_in_running_program
     sensor:
-      state_class: total
+      state_class: total_increasing
       device_class: energy
       unit: kWh
       multiplier: 0.1
@@ -588,7 +588,7 @@ properties:
   - property: Water_consumption_in_running_program
     sensor:
       unknown_value: 65535
-      state_class: total
+      state_class: total_increasing
       device_class: water
       unit: L
     hide: true


### PR DESCRIPTION
The properties `Water_consumption_in_running_program` and `Energy_consumption_in_running_program` are marked as state_class = total. This is incorrect because the value resets to 0 on the commencements of a new dishwasher cycle. The correct state class for this is therefore `total_increasing`.

<img width="2544" height="1538" alt="image" src="https://github.com/user-attachments/assets/aeb069c7-8560-4de1-84e6-ec056245bde8" />