### PR TITLE
Override f_electricity property for 009-104

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -71,7 +71,7 @@ climate:
       t_super: 0
       preset: eco_sleep_4
 properties:
-  - property: f_energy
+  - property: f_electricity
     sensor:
       device_class: power
       read_only: true

--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -70,3 +70,10 @@ climate:
       t_sleep: 4
       t_super: 0
       preset: eco_sleep_4
+properties:
+  - property: f_energy
+    sensor:
+      device_class: power
+      read_only: true
+      unit: kW
+      multiplier: 0.1

--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -74,6 +74,7 @@ properties:
   - property: f_electricity
     sensor:
       device_class: power
+      state_class: measurement
       read_only: true
       unit: kW
       multiplier: 0.1


### PR DESCRIPTION
The f_electricity property seems to be the actual power in hW. See the graph:

<img width="3144" height="910" alt="image" src="https://github.com/user-attachments/assets/a4558d0e-79a8-4fd7-a146-4a7e21798c25" />
