### PR TITLE
Use device selector instead of device filter on target

### DIFF
--- a/custom_components/connectlife/services.yaml
+++ b/custom_components/connectlife/services.yaml
@@ -9,10 +9,12 @@ set_value:
       selector:
         number:
 set_action:
-  target:
-    device:
-      integration: connectlife
   fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: connectlife
     action:
       required: true
       selector:
@@ -24,10 +26,12 @@ set_action:
             - "3"
             - "4"
 update:
-  target:
-    device:
-      integration: connectlife
   fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: connectlife
     data:
       required: true
       example: |


### PR DESCRIPTION
## Summary
- Replace deprecated `target: device:` with `device_id` field using device selector in `set_action` and `update` services
- Hassfest no longer allows device filters on target ([ref](https://developers.home-assistant.io/blog/2025/10/14/device-filter-removed-from-target-selector/))
- No changes to `services.py` — it already extracts `device_id` from call data

## Test plan
- [x] Hassfest CI passes
- [x] `set_action` and `update` services still work with device selection in HA UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)