### PR TITLE
Version 0.26.1

### DIFF
--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
   "requirements": ["connectlife==0.6.0"],
-  "version": "0.26.0"
+  "version": "0.26.1"
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.26.1

## Changes since 0.26.0
- Update connectlife 0.6.0 (#373)
- Log retries as debug (#371)
- Add pyright type checking with homeassistant-stubs (#355)
- Use device selector instead of device filter on target (#356)

🤖 Generated with [Claude Code](https://claude.com/claude-code)