### PR TITLE
Update actions/checkout to v6 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -9,5 +9,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v6"
       - uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6 in the hassfest workflow
- v4 runs on Node.js 20, which is deprecated and will be forced to Node.js 24 starting June 2nd, 2026

## Test plan
- [x] Verify hassfest CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)