### PR TITLE
Update connectlife 0.6.2

### DIFF
--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
-  "requirements": ["connectlife==0.6.1"],
+  "requirements": ["connectlife==0.6.2"],
   "version": "0.26.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Custom Home Assistant component for ConnectLife devices"
 readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
-    "connectlife==0.6.1",
+    "connectlife==0.6.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -677,20 +677,20 @@ wheels = [
 
 [[package]]
 name = "connectlife"
-version = "0.6.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/07/3c069b6180abc1b702a71ae24558ffb1ebc987ed10e3aa931e3840fd6ff0/connectlife-0.6.1.tar.gz", hash = "sha256:a9c517a8ce95588f7516b9d8789d3f4d2537240cbd9b2e7ebeb3c92f6d6978c9", size = 131274, upload-time = "2026-03-25T23:10:43.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/34/c6991d355af49a5dc24cdff61c944fcbbdb675c665599b6ee1049aae4d74/connectlife-0.6.2.tar.gz", hash = "sha256:5e96ab1f16a957b7f9d5b99eb4bf83c2a9b875afd4018b1b58441f5e35f1b419", size = 131398, upload-time = "2026-03-26T16:05:57.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/78/fa98e744941e322fac92cea8712f99387f8368cb651e6e0bb963ba9d00f0/connectlife-0.6.1-py3-none-any.whl", hash = "sha256:20139861f5b00b414c366d7ac2a5403ddb309d57556211ad5eb2a419309975e6", size = 28905, upload-time = "2026-03-25T23:10:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/10/cedc9ea6df1c420e00ad4b5a0ddb420ed7bef6498129d5f565c1f849997e/connectlife-0.6.2-py3-none-any.whl", hash = "sha256:9f4a5911fa8ad23705795f3b9b1a0ffa4b4456fcf944bdc6089f0fd0d74f6500", size = 29060, upload-time = "2026-03-26T16:05:56.187Z" },
 ]
 
 [[package]]
 name = "connectlife-ha"
-version = "0.26.0"
+version = "0.26.2"
 source = { virtual = "." }
 dependencies = [
     { name = "connectlife" },
@@ -705,7 +705,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "connectlife", specifier = "==0.6.1" }]
+requires-dist = [{ name = "connectlife", specifier = "==0.6.2" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Update `connectlife` dependency from 0.6.1 to 0.6.2

Release notes: https://github.com/oyvindwe/connectlife/releases/tag/v0.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)