### PR TITLE
Switch from bapi to HijuConn gateway

### DIFF
--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
-from connectlife.api import ConnectLifeApi, LifeConnectAuthError
+from connectlife.api import ConnectLifeApi, LifeConnectAuthError, LifeConnectError
 
 from .const import CONF_DEVELOPMENT_MODE, CONF_TEST_SERVER_URL, DOMAIN
-from .coordinator import ConnectLifeCoordinator
+from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [
@@ -55,9 +55,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await api.login()
     except LifeConnectAuthError as ex:
         raise ConfigEntryError from ex
+    except LifeConnectError as ex:
+        raise ConfigEntryNotReady from ex
     coordinator = ConnectLifeCoordinator(hass, api)
     await coordinator.async_config_entry_first_refresh()
+    energy_coordinator = ConnectLifeEnergyCoordinator(hass, api, coordinator)
+    await energy_coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
+    hass.data[DOMAIN][f"{entry.entry_id}_energy"] = energy_coordinator
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
@@ -79,5 +84,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_energy", None)
 
     return unload_ok

--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -14,6 +14,7 @@ from .const import DOMAIN
 from .messages import format_retry_message
 
 MAX_RETRIES = 3
+ENERGY_UPDATE_INTERVAL = timedelta(minutes=10)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -135,3 +136,37 @@ class ConnectLifeCoordinator(DataUpdateCoordinator[dict[str, ConnectLifeApplianc
                     else:
                         # Self repair
                         ir.async_delete_issue(self.hass, DOMAIN, f"unavailable_device.{device_id}")
+
+
+class ConnectLifeEnergyCoordinator(DataUpdateCoordinator[dict[str, float | None]]):
+    """ConnectLife energy coordinator. Polls daily energy usage every 10 minutes."""
+
+    def __init__(self, hass, api: ConnectLifeApi, appliance_coordinator: ConnectLifeCoordinator):
+        """Initialize energy coordinator."""
+        self.api = api
+        self.appliance_coordinator = appliance_coordinator
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_energy",
+            update_interval=ENERGY_UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> dict[str, float | None]:
+        """Fetch daily energy for all appliances."""
+        result: dict[str, float | None] = {}
+        for device_id, appliance in self.appliance_coordinator.data.items():
+            try:
+                result[device_id] = await self.api.get_daily_energy_kwh(
+                    appliance.puid,
+                    appliance.device_type_code,
+                    appliance.device_feature_code,
+                )
+            except Exception:
+                _LOGGER.debug(
+                    "Failed to fetch daily energy for %s",
+                    appliance.device_nickname,
+                    exc_info=True,
+                )
+                result[device_id] = None
+        return result

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -1,12 +1,5 @@
 # Portable air conditioner
 properties:
-- property: daily_energy_kwh
-  hide: true
-  sensor:
-    read_only: true
-    state_class: total_increasing
-    device_class: energy
-    unit: kWh
 - property: f_temp_in
   icon: mdi:temp
   climate:

--- a/custom_components/connectlife/data_dictionaries/007.yaml
+++ b/custom_components/connectlife/data_dictionaries/007.yaml
@@ -1,11 +1,4 @@
 properties:
-  - property: daily_energy_kwh
-    hide: true
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
   - property: f_e_filterclean
     binary_sensor:
       device_class: problem

--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -1,12 +1,5 @@
 # Window air conditioner
 properties:
-  - property: daily_energy_kwh
-    hide: true
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
   - property: f_humidity
     climate:
       target: current_humidity

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -1,10 +1,4 @@
 properties:
-  - property: daily_energy_kwh
-    sensor:
-      device_class: energy
-      read_only: true
-      unit: kWh
-      state_class: total_increasing
   - property: f_cool_qvalue
     sensor:
       unit: BTU/h

--- a/custom_components/connectlife/data_dictionaries/012.yaml
+++ b/custom_components/connectlife/data_dictionaries/012.yaml
@@ -121,5 +121,3 @@ properties:
     # Sample value: 0002/11/30T00:00:00
   - property: TimerStatus
     # Sample value: 5
-  - property: daily_energy_kwh
-    # Sample value: 0

--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -621,10 +621,3 @@ properties:
     hide: true
   - property: Water_tank
     hide: true
-  - property: daily_energy_kwh
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
-    icon: mdi:lightning-bolt-outline

--- a/custom_components/connectlife/data_dictionaries/016.yaml
+++ b/custom_components/connectlife/data_dictionaries/016.yaml
@@ -1,11 +1,4 @@
 properties:
-  - property: daily_energy_kwh
-    hide: true
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
   - property: f_water_tank_temp
     water_heater:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/020.yaml
+++ b/custom_components/connectlife/data_dictionaries/020.yaml
@@ -625,10 +625,3 @@ properties:
   - property: Zone_number
     # Sample value: 5
     hide: true
-  - property: daily_energy_kwh
-    hide: true
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh

--- a/custom_components/connectlife/data_dictionaries/023.yaml
+++ b/custom_components/connectlife/data_dictionaries/023.yaml
@@ -412,9 +412,3 @@ properties:
     sensor:
       device_class: duration
       unit: min
-  - property: daily_energy_kwh
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh

--- a/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
@@ -27,13 +27,6 @@ properties:
       14: delay
       15: finished
   icon: 'mdi:progress-wrench'
-- property: daily_energy_kwh
-  sensor:
-    read_only: true
-    state_class: total_increasing
-    device_class: energy
-    unit: kWh
-  icon: 'mdi:lightning-bolt'
 - property: DefaultSpinSpeed
   sensor:
     read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj120261v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120261v0w.yaml
@@ -476,13 +476,6 @@ properties:
   # Sample value: 0
 - property: add_clothes_check
   # Sample value: 0
-- property: daily_energy_kwh
-  sensor:
-    read_only: true
-    state_class: total_increasing
-    device_class: energy
-    unit: kWh
-  # Sample value: 0
 - property: delay_actions_flag
   # Sample value: 0
 - property: delayclose_flag

--- a/custom_components/connectlife/data_dictionaries/025-1wj120389v0b.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120389v0b.yaml
@@ -464,13 +464,6 @@ properties:
   # Sample value: 0
 - property: add_clothes_check
   # Sample value: 0
-- property: daily_energy_kwh
-  sensor:
-    read_only: true
-    state_class: total_increasing
-    device_class: energy
-    unit: kWh
-  # Sample value: 0
 - property: delay_actions_flag
   # Sample value: 0
 - property: delayclose_flag

--- a/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
@@ -25,13 +25,6 @@ properties:
     hide: true
     binary_sensor:
       device_class: problem
-  - property: daily_energy_kwh
-    hide: true
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
   - property: date_display_format_status
     hide: true
   - property: date_format_status

--- a/custom_components/connectlife/data_dictionaries/026-1b0628z0146j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0628z0146j.yaml
@@ -64,8 +64,6 @@ properties:
     hide: true
   - property: custard_room
     hide: true
-  - property: daily_energy_kwh
-    hide: true
   - property: date_format_status
     hide: true
   - property: date_time_format_day_state

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -468,5 +468,3 @@ properties:
   # Sample value: 2
 - property: Weight_unit_setting_status
   # Sample value: 0
-- property: daily_energy_kwh
-  # Sample value: 0

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -231,14 +231,6 @@ properties:
   - property: currrent_dry_level_time
     # Sample value: 12
     hide: true
-  - property: daily_energy_kwh
-    # Sample value: 0
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
-    hide: true
   - property: default_dry_level
     # Sample value: 1
     hide: true

--- a/custom_components/connectlife/data_dictionaries/032.yaml
+++ b/custom_components/connectlife/data_dictionaries/032.yaml
@@ -303,10 +303,3 @@ properties:
   - property: Water_level_switch
     binary_sensor:
     hide: true
-  - property: daily_energy_kwh
-    hide: true
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh

--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
-  "requirements": ["connectlife==0.6.3"],
+  "requirements": ["connectlife==0.7.0"],
   "version": "0.26.4"
 }

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -10,14 +10,16 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import Platform, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import ConnectLifeCoordinator
+from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from connectlife.api import LifeConnectError
@@ -36,6 +38,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up ConnectLife sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    energy_coordinator = hass.data[DOMAIN][f"{config_entry.entry_id}_energy"]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
@@ -49,6 +52,10 @@ async def async_setup_entry(
                 appliance.status_list[s],
             )
         )
+    async_add_entities(
+        ConnectLifeEnergySensor(coordinator, energy_coordinator, appliance)
+        for appliance in coordinator.data.values()
+    )
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
@@ -151,3 +158,45 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
             await self.async_update_device({self.status: value})
         except LifeConnectError as api_error:
             raise ServiceValidationError(str(api_error)) from api_error
+
+
+class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], SensorEntity):
+    """Sensor for daily energy consumption from the ConnectLife energy endpoint."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_translation_key = "daily_energy_kwh"
+
+    def __init__(
+        self,
+        appliance_coordinator: ConnectLifeCoordinator,
+        energy_coordinator: ConnectLifeEnergyCoordinator,
+        appliance: ConnectLifeAppliance,
+    ):
+        """Initialize the energy sensor."""
+        super().__init__(energy_coordinator)
+        self._device_id = appliance.device_id
+        self._attr_unique_id = f"{appliance.device_id}-daily_energy_kwh"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, appliance.device_id)},
+        )
+        appliance_coordinator.add_entity(self._attr_unique_id, Platform.SENSOR)
+        self._update_native_value()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the energy coordinator."""
+        self._update_native_value()
+        self.async_write_ha_state()
+
+    def _update_native_value(self) -> None:
+        """Update native value from energy coordinator data."""
+        if self.coordinator.data and self._device_id in self.coordinator.data:
+            value = self.coordinator.data[self._device_id]
+            self._attr_native_value = value
+            self._attr_available = value is not None
+        else:
+            self._attr_native_value = None
+            self._attr_available = False


### PR DESCRIPTION
- Update connectlife to 0.7.0
- Add ConnectLifeEnergyCoordinator with 10-minute polling interval
- Add per-appliance ConnectLifeEnergySensor
- Handle non-auth LifeConnectError during login with ConfigEntryNotReady