### PR TITLE
Only inject t_beep when device supports it (#396)

### DIFF
--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -66,7 +66,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
     async def async_update_device(self, command: dict[str, int], properties: dict[str, int] | None = None):
         if properties is None:
             properties = command.copy()
-        if self._disable_beep:
+        if self._disable_beep and "t_beep" in self.coordinator.data[self.device_id].status_list:
             command["t_beep"] = 0
         await self.coordinator.async_update_device(self.device_id, command, properties)
 


### PR DESCRIPTION
The HijuConn gateway rejects commands that include properties not in the device's status list, returning `Build Command key:[t_beep] not exist.` This prevents all commands from succeeding on devices without `t_beep` when disable beep is enabled.

Fixes issue #396 