### PR TITLE
Fix invalid binary_sensor options in 013.yaml

### DIFF
--- a/custom_components/connectlife/data_dictionaries/013.yaml
+++ b/custom_components/connectlife/data_dictionaries/013.yaml
@@ -946,20 +946,20 @@ properties:
   hide: true
   binary_sensor:
     options:
-      0: "not_active"
-      1: "active"
+      0: false
+      1: true
 - property: Remote_control_monitoring_set_commands
   hide: true
   binary_sensor:
     options:
-      0: "not_active"
-      1: "active"
+      0: false
+      1: true
 - property: Remote_control_monitoring_set_commands_actions
   hide: true
   binary_sensor:
     options:
-      0: "not_active"
-      1: "active"
+      0: false
+      1: true
 - property: Remove_moist_now
   disable: true
 - property: Reset_to_default
@@ -1159,8 +1159,8 @@ properties:
   hide: true
   binary_sensor:
     options:
-      0: "off"
-      1: "on"
+      0: false
+      1: true
 - property: Set_time_Hour
   hide: true
   sensor:
@@ -1197,8 +1197,8 @@ properties:
   hide: true
   binary_sensor:
     options:
-      0: "off"
-      1: "on"
+      0: false
+      1: true
 - property: Stage_lights_setting
   hide: true
 - property: Status


### PR DESCRIPTION
## Summary
- Fix 5 properties in `013.yaml` where `binary_sensor.options` had string values instead of required booleans
- `Remote_control_monitoring`, `Remote_control_monitoring_set_commands`, `Remote_control_monitoring_set_commands_actions`: `"not_active"`/`"active"` → `false`/`true`
- `Session_pairing_setting`, `Soft_pairing_setting`: `"off"`/`"on"` → `false`/`true`

## Test plan
- [x] `uv run python -m scripts.validate_mappings` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)