### PR TITLE
Fix DelayEndTime unit from min to h in 025.yaml

### DIFF
--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -158,7 +158,7 @@ properties:
     icon: mdi:clock-outline
     sensor:
       device_class: duration
-      unit: min
+      unit: h
       read_only: true
   - property: order_time_minimum_hour
     icon: mdi:clock-start


### PR DESCRIPTION
During my use I detected that I put a 10 hour delay and it appears there as minute. I fix it and tested and it works with my washing  machine.

Please let me know if you have any doubt or if I made anything wrong.