### PR TITLE
fix: add missing multiplier in 025-1wj105219v0w for Spin_speed_rpm

### DIFF
--- a/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
@@ -80,6 +80,7 @@ properties:
   sensor: # Sample value: 10
     read_only: true
     unit: rpm
+    multiplier: 100
   icon: 'mdi:speedometer'
 - property: temperature
   sensor:   # Sample value: 2


### PR DESCRIPTION
Adding multiplier for variable Spin_speed_rpm in 025-1wj105219v0w data dictionary.