### PR TITLE
Add device mapping for 025-1wj120238v0b (WF5S1245BB)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -39,6 +39,7 @@
 | WF3S1114-LVW004      | Washing machine          | 025              | 1wj105246v0w           |
 |                      | Washing machine          | 025              | 1wj105418v0t           |
 | WD5I1045BWQ          | Washing machine          | 025              | 1wj105552v0w           |
+| WF5S1245BB           | Washing machine          | 025              | 1wj120238v0b           |
 | WDSE1214-EVAJMW      | Washing machine          | 025              | 1wj120261v0w           |
 | WFSE1214-MVW002      | Washing machine          | 025              | 1wj120389v0b           |
 |                      | Washing machine          | 025              | 1wj120407v0w           |

--- a/custom_components/connectlife/data_dictionaries/025-1wj120238v0b.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120238v0b.yaml
@@ -1,0 +1,57 @@
+# Washing Machine
+properties:
+  - property: Selected_program_ID
+    icon: mdi:tshirt-crew
+    select:
+      options:
+        6: drum_clean
+        7: cotton
+        9: eco_40_60
+        10: wool
+        11: quick_15
+        12: mix
+        14: spin
+        15: allergy_care
+        16: baby_care
+        18: sportswear
+        19: down
+        20: rinse_spin
+        21: silk_delicate
+        24: shirts
+        41: power_49
+        42: auto
+        44: bedding
+        45: jeans
+  - property: Spin_speed_rpm
+    icon: mdi:rotate-3d-variant
+    select:
+      options:
+        0: none
+        6: "600"
+        8: "800"
+        10: "1000"
+        12: "1200"
+        14: "1400"
+  - property: temperature
+    icon: mdi:thermometer-lines
+    select:
+      options:
+        0: cold
+        2: "20"
+        3: "30"
+        4: "40"
+        6: "60"
+        9: "90"
+  - property: Current_program_phase
+    icon: mdi:state-machine
+    sensor:
+      read_only: true
+      device_class: enum
+      options:
+        0: not_available
+        1: weigh
+        2: prewash
+        3: wash
+        4: rinse
+        7: spin-dry
+        10: finished

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -3820,7 +3820,13 @@
           "jeans": "Jeans",
           "sportswear": "Sportswear",
           "hand_wash": "Hand wash",
-          "eco": "Eco"
+          "eco": "Eco",
+          "drum_clean": "Drum clean",
+          "quick_15": "Quick 15",
+          "spin": "Spin",
+          "baby_care": "Baby care",
+          "silk_delicate": "Silk delicate",
+          "power_49": "Power 49"
         }
       },
       "softener": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -3820,7 +3820,13 @@
           "jeans": "Jeans",
           "sportswear": "Sportswear",
           "hand_wash": "Hand wash",
-          "eco": "Eco"
+          "eco": "Eco",
+          "drum_clean": "Drum clean",
+          "quick_15": "Quick 15",
+          "spin": "Spin",
+          "baby_care": "Baby care",
+          "silk_delicate": "Silk delicate",
+          "power_49": "Power 49"
         }
       },
       "softener": {


### PR DESCRIPTION
## Summary
- Add device-specific mapping for washing machine WF5S1245BB
- Overrides Selected_program_ID, Spin_speed_rpm, temperature, and Current_program_phase from default

Based on #425 by @Xevian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)