### PR TITLE
Add device mapping for 030-1wk100266v0f (DH5S102BB) and update default

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -57,5 +57,6 @@
 | DH3S802BW3           | Tumble dryer             | 030              | 1wk080066v0w           |
 | DH5S102BW            | Tumble dryer             | 030              | 1wk100028v0w           |
 | DHSE10               | Tumble dryer             | 030              | 1wk100130v0f           |
+| DH5S102BB            | Tumble dryer             | 030              | 1wk100266v0f           |
 | DHSE80-BEW001        | Tumble dryer             | 030              | 1wk080027e0w           |
 | DPNA83W              | Tumble dryer             | 032              | 000                    |

--- a/custom_components/connectlife/data_dictionaries/030-1wk100266v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk100266v0f.yaml
@@ -1,0 +1,21 @@
+# Tumble Dryer
+properties:
+  - property: Selected_program_ID
+    icon: mdi:selection-ellipse-arrow-inside
+    select:
+      options:
+        1: auto
+        2: allergy_care
+        3: ion_refresh
+        4: sportswear
+        5: towels
+        6: duvet
+        7: time_dry
+        8: cotton
+        9: baby_care
+        10: synthetics
+        11: wool
+        13: quick_30
+        14: rack_dry
+        17: shirts
+        18: bedding

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -159,6 +159,12 @@ properties:
     # Sample value: 0
   - property: QuickerMode
     # Sample value: 0
+  - property: Remaining_time_of_selected_program
+    icon: mdi:update
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
   - property: ScreenSaverTime
     # Sample value: 0
   - property: Selected_program_ID
@@ -187,12 +193,24 @@ properties:
       unit: min
       read_only: true
     icon: mdi:timer
+  - property: Selected_program_total_running_time
+    icon: mdi:timer
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
   - property: Selected_program_total_running_time_in_minutes
     sensor:
       read_only: true
       device_class: duration
       unit: min
     icon: mdi:timer
+  - property: Selected_program_total_time
+    icon: mdi:timer
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
   - property: Selected_program_total_time_in_minutes
     sensor:
       read_only: true
@@ -289,6 +307,9 @@ properties:
   - property: parse_lib_ver
     # Sample value: 20241030
     hide: true
+  - property: selected_program
+    hide: true
+    entity_category: diagnostic
   - property: stoprunning_flag
     # Sample value: 0
     hide: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2168,8 +2168,14 @@
           "60_c": "60 \u00b0C"
         }
       },
+      "selected_program_total_running_time": {
+        "name": "Selected program total running time"
+      },
       "selected_program_total_running_time_in_minutes": {
         "name": "Selected program total running time"
+      },
+      "selected_program_total_time": {
+        "name": "Selected program total time"
       },
       "selected_program_total_time_in_minutes": {
         "name": "Selected program total time"
@@ -3820,7 +3826,14 @@
           "jeans": "Jeans",
           "sportswear": "Sportswear",
           "hand_wash": "Hand wash",
-          "eco": "Eco"
+          "eco": "Eco",
+          "ion_refresh": "Ion refresh",
+          "duvet": "Duvet",
+          "time_dry": "Time dry",
+          "baby_care": "Baby care",
+          "synthetics": "Synthetics",
+          "quick_30": "Quick 30",
+          "rack_dry": "Rack dry"
         }
       },
       "softener": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2168,8 +2168,14 @@
           "60_c": "60 \u00b0C"
         }
       },
+      "selected_program_total_running_time": {
+        "name": "Selected program total running time"
+      },
       "selected_program_total_running_time_in_minutes": {
         "name": "Selected program total running time"
+      },
+      "selected_program_total_time": {
+        "name": "Selected program total time"
       },
       "selected_program_total_time_in_minutes": {
         "name": "Selected program total time"
@@ -3820,7 +3826,14 @@
           "jeans": "Jeans",
           "sportswear": "Sportswear",
           "hand_wash": "Hand wash",
-          "eco": "Eco"
+          "eco": "Eco",
+          "ion_refresh": "Ion refresh",
+          "duvet": "Duvet",
+          "time_dry": "Time dry",
+          "baby_care": "Baby care",
+          "synthetics": "Synthetics",
+          "quick_30": "Quick 30",
+          "rack_dry": "Rack dry"
         }
       },
       "softener": {


### PR DESCRIPTION
## Summary
- Add device-specific mapping for tumble dryer DH5S102BB
- Add shared properties to default 030.yaml: Remaining_time_of_selected_program, Selected_program_total_running_time, Selected_program_total_time, selected_program

Based on #425 by @Xevian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)