### PR TITLE
Sort translation files and expand keys in en.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,11 @@ uv sync
 # Validate data dictionary YAML files against JSON schema
 uv run python -m scripts.validate_mappings
 
-# Regenerate strings.json from data dictionaries
+# Regenerate strings.json and en.json from data dictionaries, sort all translations
 uv run python -m scripts.gen_strings
+
+# Sort all translation files (without regenerating strings)
+uv run python -m scripts.sort_translations
 
 # Run the test server for local development
 uv run python -m connectlife.test_server -d <dumps_dir>
@@ -80,5 +83,5 @@ The API library is published to PyPI as `connectlife` and developed in a separat
 1. Generate skeleton: `python -m connectlife.dump --username <user> --password <pass> --format dd`
 2. Create/edit YAML in `data_dictionaries/` (see `data_dictionaries/README.md` for full schema docs)
 3. Validate: `uv run python -m scripts.validate_mappings`
-4. Generate strings: `uv run python -m scripts.gen_strings`
+4. Generate strings and translations: `uv run python -m scripts.gen_strings`
 5. Translation keys must be lowercase; YAML booleans (`true`, `false`, `on`, `off`, `yes`, `no`) must be quoted in option values

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,13 +21,33 @@ Install dev dependencies (in `connectlife-ha` repo):
 uv sync
 ```
 
-## Generate `strings.json` 
+## Generate `strings.json` and `en.json`
 
-This will add strings for new properties.
+This will add strings for new properties, update `translations/en.json`, and sort all translation files.
 
 ```bash
 uv run python -m scripts.gen_strings
 ```
+
+## Providing translations
+
+Translation files are located in `custom_components/connectlife/translations/`.
+
+`strings.json` is the source of truth for English strings. It uses Home Assistant
+`[%key:...]` references for common strings (e.g. config flow labels). The file
+`translations/en.json` is generated automatically as a copy of `strings.json` —
+do not edit it manually.
+
+To add or update a translation:
+
+1. Copy `translations/en.json` to a new language file (e.g. `translations/fr.json`)
+   or edit an existing one.
+2. Translate the values. Do not translate keys, only values.
+3. Replace any `[%key:...]` references with the translated text.
+4. Sort the translation file:
+   ```bash
+   uv run python -m scripts.sort_translations
+   ```
 
 ## Validate mapping files
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,16 +35,15 @@ Translation files are located in `custom_components/connectlife/translations/`.
 
 `strings.json` is the source of truth for English strings. It uses Home Assistant
 `[%key:...]` references for common strings (e.g. config flow labels). The file
-`translations/en.json` is generated automatically as a copy of `strings.json` —
-do not edit it manually.
+`translations/en.json` is generated automatically from `strings.json` with
+`[%key:...]` references expanded — do not edit it manually.
 
 To add or update a translation:
 
 1. Copy `translations/en.json` to a new language file (e.g. `translations/fr.json`)
    or edit an existing one.
 2. Translate the values. Do not translate keys, only values.
-3. Replace any `[%key:...]` references with the translated text.
-4. Sort the translation file:
+3. Sort the translation file:
    ```bash
    uv run python -m scripts.sort_translations
    ```

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1,135 +1,18 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
-        }
-      }
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    }
-  },
-  "issues": {
-    "unavailable_device": {
-      "title": "{device_name} no longer available",
-      "fix_flow": {
-        "abort": {
-          "issue_ignored": "Ignored \"{device_name} no longer available\". The device and all its entities will still be listed in the regiestry."
-        },
-        "step": {
-          "init": {
-            "title": "{device_name} no longer available",
-            "description": "The device \"{device_name}\" is now longer available in your ConnectLife account. If you no longer have this device, you can delete it from Home Assistant.",
-            "menu_options": {
-              "ignore": "Ignore",
-              "remove": "Remove"
-            }
-          },
-          "remove": {
-            "title": "Remove {device_name}",
-            "description": "The device \"{device_name}\" and all its entities will be removed from Home Assistant."
-          }
-        }
-      }
-    },
-    "unsupported_beep": {
-      "title": "Disable beep not supported by {device_name}",
-      "fix_flow": {
-        "abort": {
-          "issue_ignored": "Ignored \"Disable beep not supported by {device_name}\"."
-        },
-        "step": {
-          "init": {
-            "title": "Disable beep not supported by {device_name}",
-            "description": "The device \"{device_name}\" does not support the disable beep option.",
-            "menu_options": {
-              "confirm": "Update configuration",
-              "ignore": "Ignore"
-            }
-          }
-        }
-      }
-    }
-  },
-  "options": {
     "step": {
-      "init": {
-        "menu_options": {
-          "select_device": "Configure a device",
-          "development": "Configure development mode"
-        }
-      },
-      "select_device": {
+      "user": {
         "data": {
-          "device": "Select device"
-        },
-        "description": "Configure a device."
-      },
-      "configure_device": {
-        "data": {
-          "disable_beep": "Disable beep"
-        },
-        "description": "Configure a device."
-      },
-      "development": {
-        "data": {
-          "development_mode": "Development mode",
-          "test_server_url": "Test server URL"
-        },
-        "description": "Enable development mode to connect to test server instead of the ConnectLife API."
-      }
-    },
-    "error": {
-      "test_server_invalid": "Invalid test server URL",
-      "test_server_required": "Development mode requires test server URL"
-    }
-  },
-  "selector": {
-    "actions": {
-      "options": {
-        "1": "Stop",
-        "2": "Start",
-        "3": "Pause",
-        "4": "Open door"
-      }
-    }
-  },
-  "services": {
-    "set_value": {
-      "name": "Set value",
-      "description": "Sets a value for the status. Use with care. Does not apply multiplier when setting.",
-      "fields": {
-        "value": {
-          "name": "Value",
-          "description": "Value to set."
-        }
-      }
-    },
-    "set_action": {
-      "name": "Set action",
-      "description": "Sets action for device. Use with care.",
-      "fields": {
-        "action": {
-          "name": "Action",
-          "description": "Action to set."
-        }
-      }
-    },
-    "update": {
-      "name": "Update device",
-      "description": "Updates all properties defined in the data field.",
-      "fields": {
-        "data": {
-          "name": "Data",
-          "description": "Properties that should be updated"
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
         }
       }
     }
@@ -1330,30 +1213,27 @@
         "state_attributes": {
           "fan_mode": {
             "state": {
-              "middle_low": "Middle low",
-              "middle_high": "Middle high"
+              "middle_high": "Middle high",
+              "middle_low": "Middle low"
             }
           },
           "preset_mode": {
             "state": {
               "ai": "AI",
-              "off": "Off",
-              "mute": "Mute",
+              "bedtime": "Bedtime",
               "eco_mute": "Eco mute",
-              "super": "Super",
-              "sleep_1": "Sleep 1",
-              "sleep_2": "Sleep 2",
-              "sleep_3": "Sleep 3",
-              "sleep_4": "Sleep 4",
               "eco_sleep_1": "Eco sleep 1",
               "eco_sleep_2": "Eco sleep 2",
               "eco_sleep_3": "Eco sleep 3",
               "eco_sleep_4": "Eco sleep 4",
-              "bedtime": "Bedtime"
+              "mute": "Mute",
+              "off": "Off",
+              "sleep_1": "Sleep 1",
+              "sleep_2": "Sleep 2",
+              "sleep_3": "Sleep 3",
+              "sleep_4": "Sleep 4",
+              "super": "Super"
             }
-          },
-          "swing_mode": {
-            "state": {}
           },
           "swing_horizontal_mode": {
             "state": {
@@ -1363,6 +1243,9 @@
               "right": "Right",
               "swing": "Swing"
             }
+          },
+          "swing_mode": {
+            "state": {}
           }
         }
       }
@@ -1373,12 +1256,506 @@
           "mode": {
             "state": {
               "auto": "Auto",
+              "clothes_dry": "Clothes dry",
               "continuous": "Continuous",
-              "manual": "Manual",
-              "clothes_dry": "Clothes dry"
+              "manual": "Manual"
             }
           }
         }
+      }
+    },
+    "number": {
+      "delayendtime_hour": {
+        "name": "Delayendtime hour"
+      },
+      "freeze_max_temperature": {
+        "name": "Freezeer max temperature"
+      },
+      "freeze_min_temperature": {
+        "name": "Freezeer min temperature"
+      },
+      "freeze_temperature": {
+        "name": "Freezeer temperature"
+      },
+      "gratin_from_below_functionset_time_in_seconds": {
+        "name": "Gratin from below function set time"
+      },
+      "gratin_function_set_time_in_seconds": {
+        "name": "Gratin function set time"
+      },
+      "lightbrightness": {
+        "name": "Light brightness"
+      },
+      "lightcolortemperature": {
+        "name": "Light color temperature"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Refrigerator max temperature"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Refrigerator min temperature"
+      },
+      "refrigerator_temperature": {
+        "name": "Refrigerator temperature"
+      },
+      "variation_max_temperature": {
+        "name": "Variation max temperature"
+      },
+      "variation_min_temperature": {
+        "name": "Variation min temperature"
+      },
+      "variation_temperature": {
+        "name": "Variation temperature"
+      }
+    },
+    "select": {
+      "actions": {
+        "name": "Actions",
+        "state": {
+          "add_duration": "Add duration",
+          "add_gratin": "Add gratin",
+          "none": "None",
+          "pause": "Pause",
+          "start": "Start",
+          "steam_shot": "Steam shot",
+          "stop": "Stop",
+          "stop_finish": "Stop finish"
+        }
+      },
+      "auto_dose_quantity_setting_status": {
+        "name": "Auto dose quantity"
+      },
+      "baking_steps_intensity_levels": {
+        "name": "Baking steps intensity levels",
+        "state": {
+          "none": "None"
+        }
+      },
+      "baking_steps_intensity_levels_type": {
+        "name": "Baking steps intensity levels type",
+        "state": {
+          "low_mid_high": "Low mid high",
+          "none": "None",
+          "not_used": "Not used",
+          "rare_medium_well_done": "Rare medium well done"
+        }
+      },
+      "brightness": {
+        "name": "Brightness"
+      },
+      "cooking_intensity": {
+        "name": "Cooking intensity"
+      },
+      "delayendtime": {
+        "name": "Delay end time",
+        "state": {
+          "10_hours": "10 hours",
+          "11_hours": "11 hours",
+          "12_hours": "12 hours",
+          "13_hours": "13 hours",
+          "14_hours": "14 hours",
+          "15_hours": "15 hours",
+          "16_hours": "16 hours",
+          "17_hours": "17 hours",
+          "18_hours": "18 hours",
+          "19_hours": "19 hours",
+          "1_hour": "1 hour",
+          "20_hours": "20 hours",
+          "21_hours": "21 hours",
+          "22_hours": "22 hours",
+          "23_hours": "23 hours",
+          "24_hours": "24 hours",
+          "2_hours": "2 hours",
+          "3_hours": "3 hours",
+          "4_hours": "4 hours",
+          "5_hours": "5 hours",
+          "6_hours": "6 hours",
+          "7_hours": "7 hours",
+          "8_hours": "8 hours",
+          "9_hours": "9 hours",
+          "none": "None"
+        }
+      },
+      "detergent": {
+        "name": "Detergent",
+        "state": {
+          "auto": "Auto",
+          "less": "Less",
+          "more": "More",
+          "standard": "Standard"
+        }
+      },
+      "dry_level": {
+        "name": "Drying level",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
+      "dry_time": {
+        "name": "Dry time",
+        "state": {
+          "10_min": "10 min",
+          "120_min": "120 min",
+          "15_min": "15 min",
+          "180_min": "180 min",
+          "240_min": "240 min",
+          "30_min": "30 min",
+          "5_min": "5 min",
+          "60_min": "60 min",
+          "90_min": "90 min",
+          "cupboard": "Cupboard",
+          "extra_dry": "Extra dry",
+          "iron": "Iron",
+          "none": "None",
+          "pre-ironing": "Pre-ironing",
+          "wardrobe": "Wardrobe"
+        }
+      },
+      "drymodel": {
+        "name": "Dry model",
+        "state": {
+          "dry_only": "Dry only",
+          "wash": "Wash",
+          "wash_and_dry": "Wash and dry"
+        }
+      },
+      "extrarinsenum": {
+        "name": "Extra rinse",
+        "state": {
+          "none": "None"
+        }
+      },
+      "language_status": {
+        "name": "Language",
+        "state": {
+          "english": "English",
+          "simplified_chinese": "Simplified chinese"
+        }
+      },
+      "motorlevel": {
+        "name": "Motor level"
+      },
+      "oven_temperature_unit": {
+        "name": "Oven temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "sand_timer_1_status_cmd": {
+        "name": "Sand timer 1 control",
+        "state": {
+          "cancel": "Cancel",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
+      "sand_timer_2_status_cmd": {
+        "name": "Sand timer 2 control",
+        "state": {
+          "cancel": "Cancel",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
+      "sand_timer_3_status_cmd": {
+        "name": "Sand timer 3 control",
+        "state": {
+          "cancel": "Cancel",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
+      "selected_program_id": {
+        "name": "Selected program",
+        "state": {
+          "allergy_care": "Allergy care",
+          "anti_allergy": "Anti allergy",
+          "auto": "Auto",
+          "baby": "Baby",
+          "baby_care": "Baby care",
+          "bed_linen": "Bed linen",
+          "bedding": "Bedding",
+          "clean_dry_60": "Clean dry 60",
+          "cotton": "Cotton",
+          "cotton_dry": "Cotton dry",
+          "delicates": "Delicates",
+          "down": "Down",
+          "drum_clean": "Drum clean",
+          "drum_cleaning": "Drum cleaning",
+          "duvet": "Duvet",
+          "eco": "Eco",
+          "eco_40_60": "Eco 40 60",
+          "fast15": "Fast15",
+          "fast30": "Quick 30",
+          "full_load_49": "Full load 49",
+          "hand_wash": "Hand wash",
+          "ion_refresh": "Ion refresh",
+          "jeans": "Jeans",
+          "mix": "Mix",
+          "pets": "Pets",
+          "power49": "Power49",
+          "power_30": "Power 30",
+          "power_49": "Power 49",
+          "quick_15": "Quick 15",
+          "quick_30": "Quick 30",
+          "rack_dry": "Rack dry",
+          "refresh": "Refresh",
+          "rinse_spin": "Rinse spin",
+          "shirts": "Shirts",
+          "silk_delicate": "Silk delicate",
+          "spin": "Spin",
+          "spin-dry": "Spin-dry",
+          "sports": "Sports",
+          "sportswear": "Sportswear",
+          "synthetic": "Synthetics",
+          "synthetic_dry": "Synthetic dry",
+          "synthetics": "Synthetics",
+          "time": "Time",
+          "time_dry": "Time dry",
+          "towels": "Towels",
+          "wash_and_dry_49": "Wash and dry 49",
+          "wool": "Wool"
+        }
+      },
+      "softener": {
+        "name": "Softener",
+        "state": {
+          "auto": "Auto",
+          "less": "Less",
+          "more": "More",
+          "standard": "Standard"
+        }
+      },
+      "spin_speed_rpm": {
+        "name": "Spin speed",
+        "state": {
+          "none": "None"
+        }
+      },
+      "stain_removal": {
+        "name": "Stain removal",
+        "state": {
+          "blood": "Blood",
+          "coffee": "Coffee",
+          "grass": "Grass",
+          "juice": "Juice",
+          "milk": "Milk",
+          "oil": "Oil",
+          "soil": "Soil",
+          "sweat": "Sweat",
+          "wine": "Wine"
+        }
+      },
+      "steam_123": {
+        "name": "Steam 123",
+        "state": {
+          "steam123_0": "Steam123 0",
+          "steam123_1": "Steam123 1",
+          "steam123_2": "Steam123 2",
+          "steam123_3": "Steam123 3"
+        }
+      },
+      "step_1_bake_mode": {
+        "name": "Step 1 bake mode",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake - Cleaning",
+          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
+          "extrabake_warming": "ExtraBake - Warming",
+          "meatprobebake": "MeatProbeBake",
+          "probake": "ProBake",
+          "recipe": "Recipe",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
+        }
+      },
+      "step_1_set_microwave_wattage": {
+        "name": "Step 1 set microwave wattage",
+        "state": {
+          "none": "None"
+        }
+      },
+      "step_1_time_unit": {
+        "name": "Step 1 time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_2_bake_mode": {
+        "name": "Step 2 bake mode",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Recipe",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
+        }
+      },
+      "step_2_set_microwave_wattage": {
+        "name": "Step 2 set microwave wattage",
+        "state": {
+          "none": "None"
+        }
+      },
+      "step_2_time_unit": {
+        "name": "Step 2 time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_3_bake_mode": {
+        "name": "Step 3 bake mode",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Recipe",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
+        }
+      },
+      "step_3_set_microwave_wattage": {
+        "name": "Step 3 set microwave wattage",
+        "state": {
+          "none": "None"
+        }
+      },
+      "step_3_status": {
+        "name": "Step 3 status",
+        "state": {
+          "active": "Active",
+          "available": "Available",
+          "not_active": "Not active"
+        }
+      },
+      "step_3_time_unit": {
+        "name": "Step 3 time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_after_bake_mode": {
+        "name": "Step after bake mode",
+        "state": {
+          "gratine": "Gratine"
+        }
+      },
+      "step_after_bake_time_unit": {
+        "name": "Step after bake time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_pre_bake_mode": {
+        "name": "Step pre bake mode",
+        "state": {
+          "delay_start_waiting": "Delay start waiting",
+          "not_active": "Not active",
+          "preheat": "Preheat"
+        }
+      },
+      "step_pre_bake_time_unit": {
+        "name": "Step pre bake time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "t_fan_speed": {
+        "name": "Fan speed",
+        "state": {
+          "auto": "Auto",
+          "high": "High",
+          "low": "Low"
+        }
+      },
+      "t_sleep": {
+        "name": "Sleep Mode",
+        "state": {
+          "for_kid": "For kid",
+          "for_old": "For old",
+          "for_young": "For young",
+          "general": "General",
+          "off": "Off"
+        }
+      },
+      "t_swing_angle": {
+        "name": "Swing angle",
+        "state": {
+          "angle_1": "Angle 1",
+          "angle_2": "Angle 2",
+          "angle_3": "Angle 3",
+          "angle_4": "Angle 4",
+          "angle_5": "Angle 5",
+          "angle_6": "Angle 6",
+          "auto": "Auto",
+          "swing": "Swing"
+        }
+      },
+      "t_swing_follow": {
+        "name": "AI ventilation",
+        "state": {
+          "follow": "Follow",
+          "not_follow": "Not Follow",
+          "off": "Off"
+        }
+      },
+      "temperature": {
+        "name": "Temperature",
+        "state": {
+          "cold": "Cold"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "time_format": {
+        "name": "Time format",
+        "state": {
+          "12h": "12h",
+          "24h": "24h"
+        }
+      },
+      "volume": {
+        "name": "Volume"
+      },
+      "warming_drawer_power_level": {
+        "name": "Warming drawer power level",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
+      "water_hardness": {
+        "name": "Water hardness"
       }
     },
     "sensor": {
@@ -1406,8 +1783,8 @@
       "applicationpermissions": {
         "name": "Application permissions",
         "state": {
-          "not_granted": "Not granted",
-          "granted": "Granted"
+          "granted": "Granted",
+          "not_granted": "Not granted"
         }
       },
       "auto_dose_duration": {
@@ -1419,8 +1796,8 @@
       "autodose_flag": {
         "name": "Auto dose flag",
         "state": {
-          "unavailable": "Unavailable",
-          "available": "Available"
+          "available": "Available",
+          "unavailable": "Unavailable"
         }
       },
       "bundling_humidity": {
@@ -1448,38 +1825,38 @@
       "current_baking_step": {
         "name": "Current baking step",
         "state": {
-          "preheat": "Preheat",
-          "step_1": "Step 1",
-          "step_2": "Step 2",
-          "step_3": "Step 3",
+          "after_bake": "After bake",
           "after_bake_finished": "After bake finished",
           "pre_bake": "Pre bake",
-          "after_bake": "After bake",
-          "special": "Special"
+          "preheat": "Preheat",
+          "special": "Special",
+          "step_1": "Step 1",
+          "step_2": "Step 2",
+          "step_3": "Step 3"
         }
       },
       "current_program_phase": {
         "state": {
-          "not_available": "Not available",
-          "program_not_selected": "Program not selected",
-          "program_selected": "Program selected",
+          "anti_crease": "Anti crease",
+          "delay": "Delay",
           "delay_start_waiting": "Delay start waiting",
+          "drying": "Drying",
+          "finished": "Finished",
+          "idle": "Idle",
+          "main_wash": "Main wash",
+          "not_available": "Not available",
           "preheat": "Preheat",
           "preheat_finished": "Preheat finished",
           "prewash": "Pre-wash",
-          "main_wash": "Main wash",
-          "drying": "Drying",
           "program_finished": "Finished",
-          "ventilating": "Ventilating",
-          "idle": "Idle",
-          "running": "Running",
-          "anti_crease": "Anti crease",
-          "delay": "Delay",
-          "finished": "Finished",
-          "weigh": "Weigh",
-          "wash": "Wash",
+          "program_not_selected": "Program not selected",
+          "program_selected": "Program selected",
           "rinse": "Rinse",
-          "spin-dry": "Spin-dry"
+          "running": "Running",
+          "spin-dry": "Spin-dry",
+          "ventilating": "Ventilating",
+          "wash": "Wash",
+          "weigh": "Weigh"
         }
       },
       "current_programphase": {
@@ -1534,8 +1911,8 @@
         "name": "Detergent",
         "state": {
           "less": "Less",
-          "standard": "Standard",
-          "more": "More"
+          "more": "More",
+          "standard": "Standard"
         }
       },
       "detergent_display": {
@@ -1544,6 +1921,7 @@
       "detergentstandarddosage": {
         "name": "Detergent standard dosage",
         "state": {
+          "100ml": "100 ml",
           "10ml": "10 ml",
           "15ml": "15 ml",
           "20ml": "20 ml",
@@ -1561,13 +1939,15 @@
           "80ml": "80 ml",
           "85ml": "85 ml",
           "90ml": "90 ml",
-          "95ml": "95 ml",
-          "100ml": "100 ml"
+          "95ml": "95 ml"
         }
       },
       "device_status": {
         "state": {
+          "after_bake_finished": "After bake finished",
+          "delay_time_waiting": "Delay time waiting",
           "demo_mode": "Demo mode",
+          "error": "Error",
           "failure": "Failure",
           "idle": "Idle",
           "iq": "IQ",
@@ -1575,14 +1955,11 @@
           "not_available": "Not available",
           "pause": "Paused",
           "pause_mode": "Paused",
+          "paused": "Paused",
           "production": "Production",
           "running": "Running",
           "service": "Service",
-          "stand_by": "Stand by",
-          "paused": "Paused",
-          "delay_time_waiting": "Delay time waiting",
-          "error": "Error",
-          "after_bake_finished": "After bake finished"
+          "stand_by": "Stand by"
         }
       },
       "display_brightness_setting_status": {
@@ -1597,19 +1974,19 @@
       "display_switch_to_standby_after_minutes": {
         "name": "Display switch to standby after minutes",
         "state": {
-          "5_min": "5 min",
           "15_min": "15 min",
-          "30_min": "30 min"
+          "30_min": "30 min",
+          "5_min": "5 min"
         }
       },
       "door_status": {
         "name": "Door status",
         "state": {
+          "closed": "Closed",
+          "locked": "Locked",
           "not_available": "Not available",
           "open": "Open",
-          "closed": "Closed",
-          "other": "Other",
-          "locked": "Locked"
+          "other": "Other"
         }
       },
       "dryopen_defaultspinspeed": {
@@ -1639,7 +2016,6 @@
       "error_code": {
         "name": "Error code",
         "state": {
-          "none": "None",
           "error_f01": "Error f01",
           "error_f03": "Error f03",
           "error_f04": "Error f04",
@@ -1653,7 +2029,8 @@
           "error_f17": "Error f17",
           "error_f18": "Error f18",
           "error_f23": "Error f23",
-          "error_f24": "Error f24"
+          "error_f24": "Error f24",
+          "none": "None"
         }
       },
       "error_read_out_1_code": {
@@ -1698,10 +2075,10 @@
       "feedback_volumen_setting_status": {
         "name": "Feedback volume",
         "state": {
-          "mute": "Mute",
+          "high": "High",
           "low": "Low",
           "mid": "Mid",
-          "high": "High"
+          "mute": "Mute"
         }
       },
       "filter_state": {
@@ -1713,11 +2090,11 @@
       "fota": {
         "name": "Fota",
         "state": {
-          "not_available": "Not available",
-          "waiting_for_confirmation": "Waiting for confirmation",
-          "in_progress": "In progress",
+          "confirm_fota": "Confirm fota",
           "finished": "Finished",
-          "confirm_fota": "Confirm fota"
+          "in_progress": "In progress",
+          "not_available": "Not available",
+          "waiting_for_confirmation": "Waiting for confirmation"
         }
       },
       "freeze_door_open_time": {
@@ -1753,10 +2130,10 @@
       "hardpairingstatus": {
         "name": "Hard pairing status",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "unpair_all_users": "Unpair all users",
-          "reserved": "Reserved"
+          "not_active": "Not active",
+          "reserved": "Reserved",
+          "unpair_all_users": "Unpair all users"
         }
       },
       "heat_pump_setting_status": {
@@ -1771,9 +2148,9 @@
       "hob_warming_zone_power_level": {
         "name": "Hob warming zone power level",
         "state": {
+          "high": "High",
           "low": "Low",
-          "medium": "Medium",
-          "high": "High"
+          "medium": "Medium"
         }
       },
       "hob_zone_1_status": {
@@ -1828,9 +2205,9 @@
         "name": "Machine status",
         "state": {
           "off": "Off",
-          "standby": "Standby",
+          "paused": "Paused",
           "running": "Running",
-          "paused": "Paused"
+          "standby": "Standby"
         }
       },
       "mainwashtime": {
@@ -1854,9 +2231,9 @@
       "meat_probe_status": {
         "name": "Meat probe status",
         "state": {
-          "not_active": "Not active",
+          "active_hob": "Active hob",
           "active_oven": "Active oven",
-          "active_hob": "Active hob"
+          "not_active": "Not active"
         }
       },
       "medium_humidity": {
@@ -1962,8 +2339,8 @@
       "sand_timer1_status": {
         "name": "Timer 1 status",
         "state": {
-          "started": "Started",
           "paused": "Paused",
+          "started": "Started",
           "stopped": "Stopped"
         }
       },
@@ -1973,8 +2350,8 @@
       "sand_timer2_status": {
         "name": "Timer 2 status",
         "state": {
-          "started": "Started",
           "paused": "Paused",
+          "started": "Started",
           "stopped": "Stopped"
         }
       },
@@ -1984,8 +2361,8 @@
       "sand_timer3_status": {
         "name": "Timer 3 status",
         "state": {
-          "started": "Started",
           "paused": "Paused",
+          "started": "Started",
           "stopped": "Stopped"
         }
       },
@@ -2010,11 +2387,11 @@
       "sand_timer_1_status": {
         "name": "Sand timer 1 status",
         "state": {
+          "ended": "Ended",
           "not_active": "Not active",
-          "running": "Running",
           "paused": "Paused",
-          "stopped": "Stopped",
-          "ended": "Ended"
+          "running": "Running",
+          "stopped": "Stopped"
         }
       },
       "sand_timer_2_duration_hours": {
@@ -2038,11 +2415,11 @@
       "sand_timer_2_status": {
         "name": "Sand timer 2 status",
         "state": {
+          "ended": "Ended",
           "not_active": "Not active",
-          "running": "Running",
           "paused": "Paused",
-          "stopped": "Stopped",
-          "ended": "Ended"
+          "running": "Running",
+          "stopped": "Stopped"
         }
       },
       "sand_timer_3_duration_hours": {
@@ -2066,11 +2443,11 @@
       "sand_timer_3_status": {
         "name": "Sand timer 3 status",
         "state": {
+          "ended": "Ended",
           "not_active": "Not active",
-          "running": "Running",
           "paused": "Paused",
-          "stopped": "Stopped",
-          "ended": "Ended"
+          "running": "Running",
+          "stopped": "Stopped"
         }
       },
       "scanned_ean_code": {
@@ -2082,76 +2459,76 @@
       "selected_program_id": {
         "name": "Selected program",
         "state": {
+          "anti_allergy": "Anti allergy",
+          "auto": "Auto",
+          "baby": "Baby",
+          "bed_linen": "Bed linen",
+          "cotton": "Cotton",
           "cotton_storage": "Cotton storage",
-          "standard": "Standard",
+          "down": "Down",
+          "extra_hygiene": "Extra hygiene",
+          "fast30": "Fast30",
+          "fast89": "Fast89",
           "iron": "Iron",
           "mix": "Mix",
-          "synthetic": "Synthetic",
-          "wool": "Wool",
-          "bed_linen": "Bed linen",
-          "time": "Time",
-          "baby": "Baby",
+          "none": "None",
+          "refresh": "Refresh",
+          "remote": "Remote",
           "sensitive": "Sensitive",
           "shirts": "Shirts",
           "sports": "Sports",
-          "fast89": "Fast89",
-          "extra_hygiene": "Extra hygiene",
-          "remote": "Remote",
-          "none": "None",
-          "auto": "Auto",
-          "anti_allergy": "Anti allergy",
-          "refresh": "Refresh",
+          "standard": "Standard",
+          "synthetic": "Synthetic",
+          "time": "Time",
           "towels": "Towels",
-          "cotton": "Cotton",
-          "fast30": "Fast30",
-          "down": "Down"
+          "wool": "Wool"
         }
       },
       "selected_program_id_status": {
         "name": "Selected program",
         "state": {
           "auto": "Auto",
-          "eco": "Eco",
-          "one_hour": "1 hour",
-          "intensive": "Intensive",
-          "glass": "Glass",
-          "hygiene": "Hygiene",
-          "night": "Night",
+          "baby": "Baby",
           "clean": "Clean",
-          "eco_40_60": "Eco 40-60",
-          "white_cotton": "White Cotton",
           "color": "Color",
-          "wool_manual": "Wool & Manual",
-          "mix_synthetic": "Mix/Synthetic",
+          "down_feathers": "Down feathers",
+          "draining": "Draining",
+          "drum_cleaning": "Drum Cleaning",
+          "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra Hygiene",
           "fast_20": "Fast 20'",
+          "glass": "Glass",
+          "hygiene": "Hygiene",
+          "intensive": "Intensive",
           "intensive_59_32": "Intensive 59'/32'",
-          "sport": "Sport",
-          "baby": "Baby",
-          "shirts": "Shirts",
-          "drum_cleaning": "Drum Cleaning",
-          "spinning_draining": "Spinning & Draining",
-          "rinsing_softening": "Rinsing & Softening",
+          "mix_synthetic": "Mix/Synthetic",
+          "night": "Night",
           "no_program_selected": "No program selected",
+          "one_hour": "1 hour",
           "pet_hair_removal": "Pet hair removal",
-          "draining": "Draining",
-          "down_feathers": "Down feathers"
+          "rinsing_softening": "Rinsing & Softening",
+          "shirts": "Shirts",
+          "spinning_draining": "Spinning & Draining",
+          "sport": "Sport",
+          "white_cotton": "White Cotton",
+          "wool_manual": "Wool & Manual"
         }
       },
       "selected_program_mode": {
         "name": "Selected program mode",
         "state": {
-          "normal": "Normal",
-          "fast": "Fast"
+          "fast": "Fast",
+          "normal": "Normal"
         }
       },
       "selected_program_mode_status": {
         "name": "Program mode",
         "state": {
-          "not_available": "Not available",
-          "normal": "Normal",
+          "extra_fast": "Extra fast",
           "fast": "Fast",
-          "extra_fast": "Extra fast"
+          "normal": "Normal",
+          "not_available": "Not available"
         }
       },
       "selected_program_remaining_time_in_minutes": {
@@ -2160,12 +2537,12 @@
       "selected_program_set_temperature_status": {
         "name": "Temperature",
         "state": {
-          "not_available": "Not available",
-          "cold": "Cold",
           "20_c": "20 \u00b0C",
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C"
+          "60_c": "60 \u00b0C",
+          "cold": "Cold",
+          "not_available": "Not available"
         }
       },
       "selected_program_total_running_time": {
@@ -2183,14 +2560,14 @@
       "selected_program_washing_spin_speed_rpm_status": {
         "name": "Spin speed",
         "state": {
-          "not_available": "Not available",
-          "no_spin": "No spin",
           "0_rpm": "0",
-          "800_rpm": "800",
-          "400_rpm": "400",
           "1000_rpm": "1000",
           "1200_rpm": "1200",
-          "1400_rpm": "1400"
+          "1400_rpm": "1400",
+          "400_rpm": "400",
+          "800_rpm": "800",
+          "no_spin": "No spin",
+          "not_available": "Not available"
         }
       },
       "selected_programduration_inminutes": {
@@ -2202,28 +2579,28 @@
       "session_pairing_active": {
         "name": "Session pairing active",
         "state": {
+          "close_session": "Close session",
           "no_active_session": "No active session",
           "request_denied": "Request denied",
-          "session_is_active": "Session is active",
-          "close_session": "Close session"
+          "session_is_active": "Session is active"
         }
       },
       "set_progress_type": {
         "name": "Set progress type",
         "state": {
-          "oven_set": "Oven set",
+          "cleaning": "Cleaning",
+          "culi_set": "Culi set",
+          "defrost": "Defrost",
+          "fast_set": "Fast set",
           "mw_set": "Mw set",
           "mwc_set": "Mwc set",
-          "st_set": "St set",
-          "stc_set": "Stc set",
-          "fast_set": "Fast set",
-          "stage_set": "Stage set",
-          "culi_set": "Culi set",
-          "warming": "Warming",
-          "defrost": "Defrost",
-          "cleaning": "Cleaning",
+          "none": "None",
+          "oven_set": "Oven set",
           "pyrolysis": "Pyrolysis",
-          "none": "None"
+          "st_set": "St set",
+          "stage_set": "Stage set",
+          "stc_set": "Stc set",
+          "warming": "Warming"
         }
       },
       "set_time_hour": {
@@ -2258,13 +2635,13 @@
       "sl1_functions": {
         "name": "Zone 1 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl1_ntc_sensor": {
@@ -2279,11 +2656,11 @@
       "sl1_zone_shape": {
         "name": "Zone 1 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl2_active_timer": {
@@ -2297,13 +2674,13 @@
       "sl2_functions": {
         "name": "Zone 2 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl2_ntc_sensor": {
@@ -2318,11 +2695,11 @@
       "sl2_zone_shape": {
         "name": "Zone 2 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl3_active_timer": {
@@ -2336,13 +2713,13 @@
       "sl3_functions": {
         "name": "Zone 3 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl3_ntc_sensor": {
@@ -2357,11 +2734,11 @@
       "sl3_zone_shape": {
         "name": "Zone 3 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl4_active_timer": {
@@ -2375,13 +2752,13 @@
       "sl4_functions": {
         "name": "Zone 4 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl4_ntc_sensor": {
@@ -2396,11 +2773,11 @@
       "sl4_zone_shape": {
         "name": "Zone 4 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl5_active_timer": {
@@ -2414,13 +2791,13 @@
       "sl5_functions": {
         "name": "Zone 5 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl5_ntc_sensor": {
@@ -2435,11 +2812,11 @@
       "sl5_zone_shape": {
         "name": "Zone 5 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl6_active_timer": {
@@ -2453,13 +2830,13 @@
       "sl6_functions": {
         "name": "Zone 6 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl6_ntc_sensor": {
@@ -2474,19 +2851,19 @@
       "sl6_zone_shape": {
         "name": "Zone 6 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "softener": {
         "name": "Softener",
         "state": {
           "less": "Less",
-          "standard": "Standard",
-          "more": "More"
+          "more": "More",
+          "standard": "Standard"
         }
       },
       "softer_display": {
@@ -2495,6 +2872,7 @@
       "softnerstandarddosage": {
         "name": "Softener standard dosage",
         "state": {
+          "100ml": "100 ml",
           "10ml": "10 ml",
           "15ml": "15 ml",
           "20ml": "20 ml",
@@ -2512,8 +2890,7 @@
           "80ml": "80 ml",
           "85ml": "85 ml",
           "90ml": "90 ml",
-          "95ml": "95 ml",
-          "100ml": "100 ml"
+          "95ml": "95 ml"
         }
       },
       "sound_setting": {
@@ -2531,15 +2908,15 @@
       "status": {
         "name": "Device status",
         "state": {
-          "off": "Off",
-          "standby": "Standby",
-          "running": "Running",
-          "not_avaliable": "Not avaliable",
+          "delay_time_waiting": "Delay time waiting",
+          "error": "Error",
           "idle": "Idle",
+          "not_avaliable": "Not avaliable",
+          "off": "Off",
           "pause": "Pause",
           "production": "Production",
-          "delay_time_waiting": "Delay time waiting",
-          "error": "Error"
+          "running": "Running",
+          "standby": "Standby"
         }
       },
       "steam_assist_time_used": {
@@ -2551,45 +2928,45 @@
       "step1_heater_system": {
         "name": "Step 1 heater system",
         "state": {
-          "hot_air": "Hot air",
-          "eco_hot_air": "Eco hot air",
-          "top_bottom": "Top bottom",
-          "hot_air_bottom": "Hot air bottom",
-          "bottom_fan": "Bottom fan",
+          "aqua_clean": "Aqua clean",
           "bottom": "Bottom",
-          "top": "Top",
-          "small_grill": "Small grill",
-          "large_grill": "Large grill",
-          "large_grill_fan": "Large grill fan",
-          "pro_roasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_fan": "Bottom fan",
+          "clean_air": "Clean air",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "descale": "Descale",
+          "eco_hot_air": "Eco hot air",
+          "fast_preheat": "Fast preheat",
+          "grill_fan_micro": "Grill fan micro",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air": "Hot air",
+          "hot_air_bottom": "Hot air bottom",
+          "hot_air_micro": "Hot air micro",
           "hot_air_steam_1": "Hot air steam 1",
           "hot_air_steam_2": "Hot air steam 2",
           "hot_air_steam_3": "Hot air steam 3",
-          "fast_preheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
+          "hotairmicro": "Hot air + microwave",
           "keep_warm": "Keep warm",
-          "plates": "Plates",
-          "aqua_clean": "Aqua clean",
-          "steam_clean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "microwave_defrost": "Microwave defrost",
-          "sous_vide": "Sous vide",
+          "large_grill": "Large grill",
+          "large_grill_fan": "Large grill fan",
           "low_temp_steam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "clean_air": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
+          "micro": "Microwave",
           "microwave_clean": "Microwave clean",
-          "hot_air_micro": "Hot air micro",
-          "grill_fan_micro": "Grill fan micro"
+          "microwave_defrost": "Microwave defrost",
+          "plates": "Plates",
+          "pro_roasting": "Pro roasting",
+          "programs": "Programs",
+          "pyro": "Pyro",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "small_grill": "Small grill",
+          "sous_vide": "Sous vide",
+          "steam": "Steam",
+          "steam_clean": "Steam clean",
+          "top": "Top",
+          "top_bottom": "Top bottom",
+          "warming": "Warming"
         }
       },
       "step1_remaining_time": {
@@ -2601,10 +2978,10 @@
       "step1_steam_assist_intensity": {
         "name": "Step 1 steam assist intensity",
         "state": {
-          "not_active": "Not active",
+          "high": "High",
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "not_active": "Not active"
         }
       },
       "step1_steam_assistset_time_in_minutes": {
@@ -2616,43 +2993,43 @@
       "step2_heater_system": {
         "name": "Step 2 heater system",
         "state": {
-          "hot_air": "Hot air",
-          "eco_hot_air": "Eco hot air",
-          "top_bottom": "Top bottom",
-          "hot_air_bottom": "Hot air bottom",
-          "bottom_fan": "Bottom fan",
+          "aqua_clean": "Aqua clean",
           "bottom": "Bottom",
-          "top": "Top",
-          "small_grill": "Small grill",
-          "large_grill": "Large grill",
-          "large_grill_fan": "Large grill fan",
-          "pro_roasting": "Pro roasting",
-          "hot_air_micro": "Hot air micro",
+          "bottom_fan": "Bottom fan",
+          "clean_air": "Clean air",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "descale": "Descale",
+          "eco_hot_air": "Eco hot air",
+          "fast_preheat": "Fast preheat",
           "grill_fan_micro": "Grill fan micro",
-          "micro": "Microwave",
+          "hot_air": "Hot air",
+          "hot_air_bottom": "Hot air bottom",
+          "hot_air_micro": "Hot air micro",
           "hot_air_steam_1": "Hot air steam 1",
           "hot_air_steam_2": "Hot air steam 2",
           "hot_air_steam_3": "Hot air steam 3",
-          "fast_preheat": "Fast preheat",
-          "pyrolysis": "Pyrolysis",
-          "defrost": "Defrost",
           "keep_warm": "Keep warm",
-          "plates": "Plates",
-          "aqua_clean": "Aqua clean",
-          "steam_clean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "microwave_defrost": "Microwave defrost",
-          "sous_vide": "Sous vide",
+          "large_grill": "Large grill",
+          "large_grill_fan": "Large grill fan",
           "low_temp_steam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "clean_air": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
+          "micro": "Microwave",
+          "microwave_clean": "Microwave clean",
+          "microwave_defrost": "Microwave defrost",
+          "plates": "Plates",
+          "pro_roasting": "Pro roasting",
           "programs": "Programs",
-          "warming": "Warming",
-          "microwave_clean": "Microwave clean"
+          "pyrolysis": "Pyrolysis",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "small_grill": "Small grill",
+          "sous_vide": "Sous vide",
+          "steam": "Steam",
+          "steam_clean": "Steam clean",
+          "top": "Top",
+          "top_bottom": "Top bottom",
+          "warming": "Warming"
         }
       },
       "step2_remaining_time": {
@@ -2664,10 +3041,10 @@
       "step2_steam_assist_intensity": {
         "name": "Step 2 steam assist intensity",
         "state": {
-          "not_active": "Not active",
+          "high": "High",
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "not_active": "Not active"
         }
       },
       "step2_steam_assistset_time_in_minutes": {
@@ -2679,43 +3056,43 @@
       "step3_heater_system": {
         "name": "Step3 heater system",
         "state": {
-          "hot_air": "Hot air",
-          "eco_hot_air": "Eco hot air",
-          "top_bottom": "Top bottom",
-          "hot_air_bottom": "Hot air bottom",
-          "bottom_fan": "Bottom fan",
+          "aqua_clean": "Aqua clean",
           "bottom": "Bottom",
-          "top": "Top",
-          "small_grill": "Small grill",
-          "large_grill": "Large grill",
-          "large_grill_fan": "Large grill fan",
-          "pro_roasting": "Pro roasting",
-          "hot_air_micro": "Hot air micro",
+          "bottom_fan": "Bottom fan",
+          "clean_air": "Clean air",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "descale": "Descale",
+          "eco_hot_air": "Eco hot air",
+          "fast_preheat": "Fast preheat",
           "grill_fan_micro": "Grill fan micro",
-          "micro": "Microwave",
+          "hot_air": "Hot air",
+          "hot_air_bottom": "Hot air bottom",
+          "hot_air_micro": "Hot air micro",
           "hot_air_steam_1": "Hot air steam 1",
           "hot_air_steam_2": "Hot air steam 2",
           "hot_air_steam_3": "Hot air steam 3",
-          "fast_preheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keep_warm": "Keep warm",
-          "plates": "Plates",
-          "aqua_clean": "Aqua clean",
-          "steam_clean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "microwave_defrost": "Microwave defrost",
-          "sous_vide": "Sous vide",
+          "large_grill": "Large grill",
+          "large_grill_fan": "Large grill fan",
           "low_temp_steam": "Low temperature steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "clean_air": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
+          "micro": "Microwave",
+          "microwave_clean": "Microwave clean",
+          "microwave_defrost": "Microwave defrost",
+          "plates": "Plates",
+          "pro_roasting": "Pro roasting",
           "programs": "Programs",
-          "warming": "Warming",
-          "microwave_clean": "Microwave clean"
+          "pyro": "Pyro",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "small_grill": "Small grill",
+          "sous_vide": "Sous vide",
+          "steam": "Steam",
+          "steam_clean": "Steam clean",
+          "top": "Top",
+          "top_bottom": "Top bottom",
+          "warming": "Warming"
         }
       },
       "step3_remaining_time": {
@@ -2727,10 +3104,10 @@
       "step3_steam_assist_intensity": {
         "name": "Step 3 steam assist intensity",
         "state": {
-          "not_active": "Not active",
+          "high": "High",
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "not_active": "Not active"
         }
       },
       "step3_steam_assistset_time_in_minutes": {
@@ -2739,18 +3116,18 @@
       "step_1_bake_mode": {
         "name": "Step 1 bake mode",
         "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake - Cleaning",
+          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
+          "extrabake_warming": "ExtraBake - Warming",
+          "meatprobebake": "MeatProbeBake",
+          "probake": "ProBake",
           "recipe": "Recipe",
           "steambake": "SteamBake",
           "steamcombibake": "SteamCombiBake",
-          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
-          "extrabake_warming": "ExtraBake - Warming",
-          "extrabake_cleaning": "ExtraBake - Cleaning",
-          "meatprobebake": "MeatProbeBake"
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
         }
       },
       "step_1_duration": {
@@ -2765,79 +3142,79 @@
       "step_1_set_heater_system": {
         "name": "Step 1 set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_1_set_microwave_wattage": {
@@ -2852,30 +3229,30 @@
       "step_1_steam_available": {
         "name": "Step 1 steam available",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_1_time_unit": {
         "name": "Step 1 time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_2_bake_mode": {
         "name": "Step 2 bake mode",
         "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
           "recipe": "Recipe",
           "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
         }
       },
       "step_2_duration": {
@@ -2890,79 +3267,79 @@
       "step_2_set_heater_system": {
         "name": "Step 2 set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_2_set_microwave_wattage": {
@@ -2977,30 +3354,30 @@
       "step_2_steam_available": {
         "name": "Step 2 steam available",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_2_time_unit": {
         "name": "Step 2 time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_3_bake_mode": {
         "name": "Step 3 bake mode",
         "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
           "recipe": "Recipe",
           "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
         }
       },
       "step_3_duration": {
@@ -3015,79 +3392,79 @@
       "step_3_set_heater_system": {
         "name": "Step 3 set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_3_set_microwave_wattage": {
@@ -3102,25 +3479,25 @@
       "step_3_status": {
         "name": "Step 3 status",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_3_steam_available": {
         "name": "Step 3 steam available",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_3_time_unit": {
         "name": "Step 3 time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_after_bake_duration": {
@@ -3141,79 +3518,79 @@
       "step_after_bake_set_heater_system": {
         "name": "Step after bake set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_after_bake_set_temperature": {
@@ -3222,9 +3599,9 @@
       "step_after_bake_time_unit": {
         "name": "Step after bake time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_pre_bake_duration": {
@@ -3233,9 +3610,9 @@
       "step_pre_bake_mode": {
         "name": "Step pre bake mode",
         "state": {
+          "delay_start_waiting": "Delay start waiting",
           "not_active": "Not active",
-          "preheat": "Preheat",
-          "delay_start_waiting": "Delay start waiting"
+          "preheat": "Preheat"
         }
       },
       "step_pre_bake_passed_time": {
@@ -3247,79 +3624,79 @@
       "step_pre_bake_set_heater_system": {
         "name": "Step pre bake set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_pre_bake_set_temperature": {
@@ -3328,9 +3705,9 @@
       "step_pre_bake_time_unit": {
         "name": "Step pre bake time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "super_rinse_setting_status": {
@@ -3422,9 +3799,9 @@
       "warming_drawer_power_level": {
         "name": "Warming drawer power level",
         "state": {
+          "high": "High",
           "low": "Low",
-          "medium": "Medium",
-          "high": "High"
+          "medium": "Medium"
         }
       },
       "washing_machine_type_kg": {
@@ -3626,506 +4003,129 @@
         "name": "Welcome"
       }
     },
-    "select": {
-      "actions": {
-        "name": "Actions",
-        "state": {
-          "start": "Start",
-          "pause": "Pause",
-          "stop_finish": "Stop finish",
-          "add_duration": "Add duration",
-          "add_gratin": "Add gratin",
-          "steam_shot": "Steam shot",
-          "none": "None",
-          "stop": "Stop"
-        }
-      },
-      "auto_dose_quantity_setting_status": {
-        "name": "Auto dose quantity"
-      },
-      "baking_steps_intensity_levels": {
-        "name": "Baking steps intensity levels",
-        "state": {
-          "none": "None"
-        }
-      },
-      "baking_steps_intensity_levels_type": {
-        "name": "Baking steps intensity levels type",
-        "state": {
-          "none": "None",
-          "not_used": "Not used",
-          "low_mid_high": "Low mid high",
-          "rare_medium_well_done": "Rare medium well done"
-        }
-      },
-      "brightness": {
-        "name": "Brightness"
-      },
-      "cooking_intensity": {
-        "name": "Cooking intensity"
-      },
-      "delayendtime": {
-        "name": "Delay end time",
-        "state": {
-          "none": "None",
-          "1_hour": "1 hour",
-          "2_hours": "2 hours",
-          "3_hours": "3 hours",
-          "4_hours": "4 hours",
-          "5_hours": "5 hours",
-          "6_hours": "6 hours",
-          "7_hours": "7 hours",
-          "8_hours": "8 hours",
-          "9_hours": "9 hours",
-          "10_hours": "10 hours",
-          "11_hours": "11 hours",
-          "12_hours": "12 hours",
-          "13_hours": "13 hours",
-          "14_hours": "14 hours",
-          "15_hours": "15 hours",
-          "16_hours": "16 hours",
-          "17_hours": "17 hours",
-          "18_hours": "18 hours",
-          "19_hours": "19 hours",
-          "20_hours": "20 hours",
-          "21_hours": "21 hours",
-          "22_hours": "22 hours",
-          "23_hours": "23 hours",
-          "24_hours": "24 hours"
-        }
-      },
-      "detergent": {
-        "name": "Detergent",
-        "state": {
-          "auto": "Auto",
-          "less": "Less",
-          "standard": "Standard",
-          "more": "More"
-        }
-      },
-      "dry_level": {
-        "name": "Drying level",
-        "state": {
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "dry_time": {
-        "name": "Dry time",
-        "state": {
-          "wardrobe": "Wardrobe",
-          "pre-ironing": "Pre-ironing",
-          "extra_dry": "Extra dry",
-          "30_min": "30 min",
-          "60_min": "60 min",
-          "90_min": "90 min",
-          "120_min": "120 min",
-          "180_min": "180 min",
-          "240_min": "240 min",
-          "iron": "Iron",
-          "cupboard": "Cupboard",
-          "none": "None",
-          "5_min": "5 min",
-          "10_min": "10 min",
-          "15_min": "15 min"
-        }
-      },
-      "drymodel": {
-        "name": "Dry model",
-        "state": {
-          "wash": "Wash",
-          "wash_and_dry": "Wash and dry",
-          "dry_only": "Dry only"
-        }
-      },
-      "extrarinsenum": {
-        "name": "Extra rinse",
-        "state": {
-          "none": "None"
-        }
-      },
-      "language_status": {
-        "name": "Language",
-        "state": {
-          "english": "English",
-          "simplified_chinese": "Simplified chinese"
-        }
-      },
-      "motorlevel": {
-        "name": "Motor level"
-      },
-      "oven_temperature_unit": {
-        "name": "Oven temperature unit",
-        "state": {
-          "celsius": "Celsius",
-          "fahrenheit": "Fahrenheit"
-        }
-      },
-      "sand_timer_1_status_cmd": {
-        "name": "Sand timer 1 control",
-        "state": {
-          "start": "Start",
-          "stop": "Stop",
-          "pause": "Pause",
-          "cancel": "Cancel"
-        }
-      },
-      "sand_timer_2_status_cmd": {
-        "name": "Sand timer 2 control",
-        "state": {
-          "start": "Start",
-          "stop": "Stop",
-          "pause": "Pause",
-          "cancel": "Cancel"
-        }
-      },
-      "sand_timer_3_status_cmd": {
-        "name": "Sand timer 3 control",
-        "state": {
-          "start": "Start",
-          "stop": "Stop",
-          "pause": "Pause",
-          "cancel": "Cancel"
-        }
-      },
-      "selected_program_id": {
-        "name": "Selected program",
-        "state": {
-          "auto": "Auto",
-          "anti_allergy": "Anti allergy",
-          "refresh": "Refresh",
-          "sports": "Sports",
-          "towels": "Towels",
-          "time": "Time",
-          "cotton": "Cotton",
-          "baby": "Baby",
-          "synthetic": "Synthetics",
-          "wool": "Wool",
-          "delicates": "Delicates",
-          "fast30": "Quick 30",
-          "shirts": "Shirts",
-          "bed_linen": "Bed linen",
-          "down": "Down",
-          "cotton_dry": "Cotton dry",
-          "synthetic_dry": "Synthetic dry",
-          "drum_cleaning": "Drum cleaning",
-          "eco_40_60": "Eco 40 60",
-          "fast15": "Fast15",
-          "spin-dry": "Spin-dry",
-          "rinse_spin": "Rinse spin",
-          "clean_dry_60": "Clean dry 60",
-          "power49": "Power49",
-          "allergy_care": "Allergy care",
-          "wash_and_dry_49": "Wash and dry 49",
-          "bedding": "Bedding",
-          "power_30": "Power 30",
-          "pets": "Pets",
-          "full_load_49": "Full load 49",
-          "mix": "Mix",
-          "jeans": "Jeans",
-          "sportswear": "Sportswear",
-          "hand_wash": "Hand wash",
-          "eco": "Eco",
-          "ion_refresh": "Ion refresh",
-          "duvet": "Duvet",
-          "time_dry": "Time dry",
-          "baby_care": "Baby care",
-          "synthetics": "Synthetics",
-          "quick_30": "Quick 30",
-          "rack_dry": "Rack dry",
-          "drum_clean": "Drum clean",
-          "quick_15": "Quick 15",
-          "spin": "Spin",
-          "silk_delicate": "Silk delicate",
-          "power_49": "Power 49"
-        }
-      },
-      "softener": {
-        "name": "Softener",
-        "state": {
-          "auto": "Auto",
-          "less": "Less",
-          "standard": "Standard",
-          "more": "More"
-        }
-      },
-      "spin_speed_rpm": {
-        "name": "Spin speed",
-        "state": {
-          "none": "None"
-        }
-      },
-      "stain_removal": {
-        "name": "Stain removal",
-        "state": {
-          "wine": "Wine",
-          "grass": "Grass",
-          "soil": "Soil",
-          "coffee": "Coffee",
-          "milk": "Milk",
-          "juice": "Juice",
-          "sweat": "Sweat",
-          "blood": "Blood",
-          "oil": "Oil"
-        }
-      },
-      "steam_123": {
-        "name": "Steam 123",
-        "state": {
-          "steam123_0": "Steam123 0",
-          "steam123_1": "Steam123 1",
-          "steam123_2": "Steam123 2",
-          "steam123_3": "Steam123 3"
-        }
-      },
-      "step_1_bake_mode": {
-        "name": "Step 1 bake mode",
-        "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Recipe",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake",
-          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
-          "extrabake_warming": "ExtraBake - Warming",
-          "extrabake_cleaning": "ExtraBake - Cleaning",
-          "meatprobebake": "MeatProbeBake"
-        }
-      },
-      "step_1_set_microwave_wattage": {
-        "name": "Step 1 set microwave wattage",
-        "state": {
-          "none": "None"
-        }
-      },
-      "step_1_time_unit": {
-        "name": "Step 1 time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_2_bake_mode": {
-        "name": "Step 2 bake mode",
-        "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Recipe",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
-        }
-      },
-      "step_2_set_microwave_wattage": {
-        "name": "Step 2 set microwave wattage",
-        "state": {
-          "none": "None"
-        }
-      },
-      "step_2_time_unit": {
-        "name": "Step 2 time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_3_bake_mode": {
-        "name": "Step 3 bake mode",
-        "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Recipe",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
-        }
-      },
-      "step_3_set_microwave_wattage": {
-        "name": "Step 3 set microwave wattage",
-        "state": {
-          "none": "None"
-        }
-      },
-      "step_3_status": {
-        "name": "Step 3 status",
-        "state": {
-          "not_active": "Not active",
-          "active": "Active",
-          "available": "Available"
-        }
-      },
-      "step_3_time_unit": {
-        "name": "Step 3 time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_after_bake_mode": {
-        "name": "Step after bake mode",
-        "state": {
-          "gratine": "Gratine"
-        }
-      },
-      "step_after_bake_time_unit": {
-        "name": "Step after bake time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_pre_bake_mode": {
-        "name": "Step pre bake mode",
-        "state": {
-          "not_active": "Not active",
-          "preheat": "Preheat",
-          "delay_start_waiting": "Delay start waiting"
-        }
-      },
-      "step_pre_bake_time_unit": {
-        "name": "Step pre bake time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "t_fan_speed": {
-        "name": "Fan speed",
-        "state": {
-          "auto": "Auto",
-          "low": "Low",
-          "high": "High"
-        }
-      },
-      "t_sleep": {
-        "name": "Sleep Mode",
-        "state": {
-          "off": "Off",
-          "general": "General",
-          "for_old": "For old",
-          "for_young": "For young",
-          "for_kid": "For kid"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Swing angle",
-        "state": {
-          "swing": "Swing",
-          "auto": "Auto",
-          "angle_1": "Angle 1",
-          "angle_2": "Angle 2",
-          "angle_3": "Angle 3",
-          "angle_4": "Angle 4",
-          "angle_5": "Angle 5",
-          "angle_6": "Angle 6"
-        }
-      },
-      "t_swing_follow": {
-        "name": "AI ventilation",
-        "state": {
-          "off": "Off",
-          "follow": "Follow",
-          "not_follow": "Not Follow"
-        }
-      },
-      "temperature": {
-        "name": "Temperature",
-        "state": {
-          "cold": "Cold"
-        }
-      },
-      "temperature_unit": {
-        "name": "Temperature unit",
-        "state": {
-          "celsius": "Celsius",
-          "fahrenheit": "Fahrenheit"
-        }
-      },
-      "time_format": {
-        "name": "Time format",
-        "state": {
-          "12h": "12h",
-          "24h": "24h"
-        }
-      },
-      "volume": {
-        "name": "Volume"
-      },
-      "warming_drawer_power_level": {
-        "name": "Warming drawer power level",
-        "state": {
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "water_hardness": {
-        "name": "Water hardness"
-      }
-    },
     "water_heater": {
       "connectlife": {
         "state": {
           "auto": "Auto"
         }
       }
+    }
+  },
+  "issues": {
+    "unavailable_device": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "Ignored \"{device_name} no longer available\". The device and all its entities will still be listed in the regiestry."
+        },
+        "step": {
+          "init": {
+            "description": "The device \"{device_name}\" is now longer available in your ConnectLife account. If you no longer have this device, you can delete it from Home Assistant.",
+            "menu_options": {
+              "ignore": "Ignore",
+              "remove": "Remove"
+            },
+            "title": "{device_name} no longer available"
+          },
+          "remove": {
+            "description": "The device \"{device_name}\" and all its entities will be removed from Home Assistant.",
+            "title": "Remove {device_name}"
+          }
+        }
+      },
+      "title": "{device_name} no longer available"
     },
-    "number": {
-      "delayendtime_hour": {
-        "name": "Delayendtime hour"
+    "unsupported_beep": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "Ignored \"Disable beep not supported by {device_name}\"."
+        },
+        "step": {
+          "init": {
+            "description": "The device \"{device_name}\" does not support the disable beep option.",
+            "menu_options": {
+              "confirm": "Update configuration",
+              "ignore": "Ignore"
+            },
+            "title": "Disable beep not supported by {device_name}"
+          }
+        }
       },
-      "freeze_max_temperature": {
-        "name": "Freezeer max temperature"
+      "title": "Disable beep not supported by {device_name}"
+    }
+  },
+  "options": {
+    "error": {
+      "test_server_invalid": "Invalid test server URL",
+      "test_server_required": "Development mode requires test server URL"
+    },
+    "step": {
+      "configure_device": {
+        "data": {
+          "disable_beep": "Disable beep"
+        },
+        "description": "Configure a device."
       },
-      "freeze_min_temperature": {
-        "name": "Freezeer min temperature"
+      "development": {
+        "data": {
+          "development_mode": "Development mode",
+          "test_server_url": "Test server URL"
+        },
+        "description": "Enable development mode to connect to test server instead of the ConnectLife API."
       },
-      "freeze_temperature": {
-        "name": "Freezeer temperature"
+      "init": {
+        "menu_options": {
+          "development": "Configure development mode",
+          "select_device": "Configure a device"
+        }
       },
-      "gratin_from_below_functionset_time_in_seconds": {
-        "name": "Gratin from below function set time"
-      },
-      "gratin_function_set_time_in_seconds": {
-        "name": "Gratin function set time"
-      },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
-      "refrigerator_max_temperature": {
-        "name": "Refrigerator max temperature"
-      },
-      "refrigerator_min_temperature": {
-        "name": "Refrigerator min temperature"
-      },
-      "refrigerator_temperature": {
-        "name": "Refrigerator temperature"
-      },
-      "variation_max_temperature": {
-        "name": "Variation max temperature"
-      },
-      "variation_min_temperature": {
-        "name": "Variation min temperature"
-      },
-      "variation_temperature": {
-        "name": "Variation temperature"
+      "select_device": {
+        "data": {
+          "device": "Select device"
+        },
+        "description": "Configure a device."
       }
+    }
+  },
+  "selector": {
+    "actions": {
+      "options": {
+        "1": "Stop",
+        "2": "Start",
+        "3": "Pause",
+        "4": "Open door"
+      }
+    }
+  },
+  "services": {
+    "set_action": {
+      "description": "Sets action for device. Use with care.",
+      "fields": {
+        "action": {
+          "description": "Action to set.",
+          "name": "Action"
+        }
+      },
+      "name": "Set action"
+    },
+    "set_value": {
+      "description": "Sets a value for the status. Use with care. Does not apply multiplier when setting.",
+      "fields": {
+        "value": {
+          "description": "Value to set.",
+          "name": "Value"
+        }
+      },
+      "name": "Set value"
+    },
+    "update": {
+      "description": "Updates all properties defined in the data field.",
+      "fields": {
+        "data": {
+          "description": "Properties that should be updated",
+          "name": "Data"
+        }
+      },
+      "name": "Update device"
     }
   }
 }

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -17,107 +17,11 @@
       }
     }
   },
-  "issues": {
-    "unavailable_device": {
-      "title": "{device_name} nicht mehr verf\u00fcgbar",
-      "fix_flow": {
-        "abort": {
-          "issue_ignored": "\"{device_name} nicht mehr verf\u00fcgbar\" wurde ignoriert. Das Ger\u00e4t und alle zugeh\u00f6rigen Eintr\u00e4ge bleiben im Verzeichnis."
-        },
-        "step": {
-          "init": {
-            "title": "{device_name} nicht mehr verf\u00fcgbar",
-            "description": "Das Ger\u00e4t \"{device_name}\" ist nicht mehr in deinem ConnectLife-Konto verf\u00fcgbar. Wenn du das Ger\u00e4t nicht mehr besitzt, kannst du es aus Home Assistant entfernen.",
-            "menu_options": {
-              "ignore": "Ignorieren",
-              "remove": "Entfernen"
-            }
-          },
-          "remove": {
-            "title": "{device_name} entfernen",
-            "description": "Das Ger\u00e4t \"{device_name}\" und alle zugeh\u00f6rigen Entit\u00e4ten werden aus Home Assistant entfernt."
-          }
-        }
-      }
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "menu_options": {
-          "select_device": "Ger\u00e4t konfigurieren",
-          "development": "Entwicklungsmodus konfigurieren"
-        }
-      },
-      "select_device": {
-        "data": {
-          "device": "Ger\u00e4t ausw\u00e4hlen"
-        },
-        "description": "Ein Ger\u00e4t konfigurieren."
-      },
-      "configure_device": {
-        "data": {
-          "disable_beep": "Signalton deaktivieren"
-        },
-        "description": "Ein Ger\u00e4t konfigurieren."
-      },
-      "development": {
-        "data": {
-          "development_mode": "Entwicklungsmodus",
-          "test_server_url": "Test-Server-URL"
-        },
-        "description": "Aktiviere den Entwicklungsmodus, um eine Verbindung zum Testserver anstelle der ConnectLife-API herzustellen."
-      }
-    },
-    "error": {
-      "test_server_invalid": "Ung\u00fcltige Test-Server-URL",
-      "test_server_required": "Entwicklungsmodus erfordert eine Test-Server-URL"
-    }
-  },
-  "selector": {
-    "actions": {
-      "options": {
-        "1": "Stopp",
-        "2": "Start",
-        "3": "Pause",
-        "4": "T\u00fcr \u00f6ffnen"
-      }
-    }
-  },
-  "services": {
-    "set_value": {
-      "name": "Wert setzen",
-      "description": "Setzt einen Wert f\u00fcr den Status. Vorsicht bei der Verwendung. Es wird kein Multiplikator angewendet.",
-      "fields": {
-        "value": {
-          "name": "Wert",
-          "description": "Zu setzender Wert."
-        }
-      }
-    },
-    "set_action": {
-      "name": "Aktion setzen",
-      "description": "Setzt eine Aktion f\u00fcr das Ger\u00e4t. Vorsicht bei der Verwendung.",
-      "fields": {
-        "action": {
-          "name": "Aktion",
-          "description": "Zu setzende Aktion."
-        }
-      }
-    },
-    "update": {
-      "name": "Ger\u00e4t aktualisieren",
-      "description": "Aktualisiert alle Eigenschaften, die im Datenfeld definiert sind.",
-      "fields": {
-        "data": {
-          "name": "Daten",
-          "description": "Eigenschaften, die aktualisiert werden sollen"
-        }
-      }
-    }
-  },
   "entity": {
     "binary_sensor": {
+      "add_moist_now": {
+        "name": "Feuchtigkeit jetzt hinzuf\u00fcgen"
+      },
       "ado_allowed": {
         "name": "ADO erlaubt"
       },
@@ -160,6 +64,9 @@
       "alarm_alarm_time_reached": {
         "name": "Alarmzeit erreicht"
       },
+      "alarm_aquaclean_finished": {
+        "name": "AquaClean abgeschlossen"
+      },
       "alarm_auto_dose_refill": {
         "name": "Automatische Dosierung auff\u00fcllen"
       },
@@ -178,17 +85,41 @@
       "alarm_baking_finished": {
         "name": "Backvorgang abgeschlossen"
       },
+      "alarm_baking_stoped": {
+        "name": "Alarm Backen gestoppt"
+      },
+      "alarm_child_lock_deactivated_on_the_oven": {
+        "name": "Alarm Kindersicherung am Ofen deaktiviert"
+      },
       "alarm_clean_the_filters": {
         "name": "Filter reinigen"
+      },
+      "alarm_cleaning_suggestion_after_baking_finished": {
+        "name": "Alarm Reinigungsempfehlung nach dem Backen"
+      },
+      "alarm_defrost_finished": {
+        "name": "Alarm Auftauen abgeschlossen"
       },
       "alarm_descale_now": {
         "name": "Jetzt entkalken"
       },
+      "alarm_descaling_needed": {
+        "name": "Alarm Entkalkung erforderlich"
+      },
       "alarm_door_closed": {
         "name": "T\u00fcr geschlossen"
       },
+      "alarm_door_locked": {
+        "name": "Alarm T\u00fcr verriegelt"
+      },
       "alarm_door_opened": {
         "name": "T\u00fcr ge\u00f6ffnet"
+      },
+      "alarm_ean_scan_info": {
+        "name": "Alarm EAN-Scan Info"
+      },
+      "alarm_empty_and_clean_water_tank": {
+        "name": "Alarm Wassertank leeren und reinigen"
       },
       "alarm_external_autodose_level15": {
         "name": "Externe automatische Dosierung Stufe 15"
@@ -196,8 +127,20 @@
       "alarm_external_autodose_level30": {
         "name": "Externe automatische Dosierung Stufe 30"
       },
+      "alarm_fast_preheat_active": {
+        "name": "Alarm Schnellvorheizen aktiv"
+      },
+      "alarm_fast_preheating_finished": {
+        "name": "Alarm Schnellvorheizen abgeschlossen"
+      },
       "alarm_hob_hood_started": {
         "name": "Kochfeldhaube gestartet"
+      },
+      "alarm_keepwarm_ended": {
+        "name": "Warmhalten beendet"
+      },
+      "alarm_mw_active": {
+        "name": "Mikrowelle aktiv"
       },
       "alarm_ntc_coil_overheating": {
         "name": "NTC-Spule \u00fcberhitzt"
@@ -208,17 +151,35 @@
       "alarm_ntc_tc": {
         "name": "NTC TC"
       },
+      "alarm_oven_temperature_too_high": {
+        "name": "Alarm Ofentemperatur zu hoch"
+      },
+      "alarm_oven_usage_reached_set_limit_auto_cleaning_suggested": {
+        "name": "Alarm Ofennutzung Grenzwert erreicht, Reinigung empfohlen"
+      },
+      "alarm_platewarm_ended": {
+        "name": "Tellerw\u00e4rmen beendet"
+      },
       "alarm_preheat_reached": {
         "name": "Vorheiztemperatur erreicht"
       },
       "alarm_preheating_ready": {
         "name": "Vorheizen abgeschlossen"
       },
+      "alarm_probe_inserted": {
+        "name": "Alarm Sonde eingesteckt"
+      },
+      "alarm_probe_temp_reached": {
+        "name": "Alarm Sondentemperatur erreicht"
+      },
       "alarm_program_done": {
         "name": "Programm abgeschlossen"
       },
       "alarm_program_pause": {
         "name": "Programm pausiert"
+      },
+      "alarm_pyrolytic_finished": {
+        "name": "Alarm Pyrolyse abgeschlossen"
       },
       "alarm_remote_start_canceled": {
         "name": "Fernstart abgebrochen"
@@ -232,14 +193,38 @@
       "alarm_run_selfcleaning": {
         "name": "Selbstreinigung starten"
       },
+      "alarm_running_time_over_10_or_24_hour_limit_error": {
+        "name": "Alarm Laufzeit \u00fcber 10 oder 24 Stunden Limit"
+      },
+      "alarm_sabbath_reminder": {
+        "name": "Alarm Sabbat-Erinnerung"
+      },
       "alarm_salt_refill": {
         "name": "Salz nachf\u00fcllen"
+      },
+      "alarm_sand_timer_1_elapsed": {
+        "name": "Alarm Timer 1 abgelaufen"
+      },
+      "alarm_sand_timer_2_elapsed": {
+        "name": "Alarm Timer 2 abgelaufen"
+      },
+      "alarm_sand_timer_3_elapsed": {
+        "name": "Alarm Timer 3 abgelaufen"
       },
       "alarm_sani_program_finished": {
         "name": "Sanit\u00e4rprogramm abgeschlossen"
       },
+      "alarm_set_temperature_reached": {
+        "name": "Alarm eingestellte Temperatur erreicht"
+      },
       "alarm_steam_empty": {
         "name": "Dampf leer"
+      },
+      "alarm_steam_fill_alarm": {
+        "name": "Alarm Dampf Bef\u00fcllungsalarm"
+      },
+      "alarm_steam_function_active": {
+        "name": "Alarm Dampffunktion aktiv"
       },
       "alarm_temperature_reached": {
         "name": "Temperatur erreicht"
@@ -249,6 +234,9 @@
       },
       "alarm_turn_food": {
         "name": "Essen wenden"
+      },
+      "alarm_user_interaction_on_appliance_detected": {
+        "name": "Alarm Benutzerinteraktion am Ger\u00e4t erkannt"
       },
       "alarm_voltage": {
         "name": "Spannung"
@@ -265,11 +253,101 @@
       "alarm_water_tank_empty": {
         "name": "Wassertank leer"
       },
+      "alarm_water_tank_is_empty": {
+        "name": "Alarm Wassertank ist leer"
+      },
+      "alarm_water_tank_is_missing": {
+        "name": "Alarm Wassertank fehlt"
+      },
       "alarm_water_tank_missing": {
         "name": "Wassertank fehlt"
       },
       "alarm_zone_turned_off": {
         "name": "Zone ausgeschaltet"
+      },
+      "alarmalmost_finished": {
+        "name": "Alarm fast fertig"
+      },
+      "alarmchild_lockoff": {
+        "name": "Alarm Kindersicherung aus"
+      },
+      "alarmchild_lockon": {
+        "name": "Alarm Kindersicherung ein"
+      },
+      "alarmcleantank": {
+        "name": "Alarm Tank reinigen"
+      },
+      "alarmdehydrate_ended": {
+        "name": "Alarm D\u00f6rren beendet"
+      },
+      "alarmdescalestep1": {
+        "name": "Alarm Entkalkung Schritt 1"
+      },
+      "alarmdescalestep2": {
+        "name": "Alarm Entkalkung Schritt 2"
+      },
+      "alarmdescalestep3": {
+        "name": "Alarm Entkalkung Schritt 3"
+      },
+      "alarmdescaling_interrupted": {
+        "name": "Alarm Entkalkung unterbrochen"
+      },
+      "alarmemptytankpause": {
+        "name": "Alarm Tank leer Pause"
+      },
+      "alarmfilltank": {
+        "name": "Alarm Tank bef\u00fcllen"
+      },
+      "alarmincreased_power_consumption": {
+        "name": "Alarm erh\u00f6hter Stromverbrauch"
+      },
+      "alarmkey_lock_on": {
+        "name": "Alarm Tastensperre ein"
+      },
+      "alarmmicrowave_system_finished": {
+        "name": "Alarm Mikrowelle fertig"
+      },
+      "alarmoven_system_finished": {
+        "name": "Alarm Ofen fertig"
+      },
+      "alarmpoptankopened": {
+        "name": "Alarm Tank ge\u00f6ffnet"
+      },
+      "alarmpower_failure_running": {
+        "name": "Alarm Stromausfall w\u00e4hrend Betrieb"
+      },
+      "alarmprobe_lost_connection": {
+        "name": "Alarm Sonde Verbindung verloren"
+      },
+      "alarmremotestartpowerfailure": {
+        "name": "Alarm Fernstart Stromausfall"
+      },
+      "alarmremove_probe": {
+        "name": "Alarm Sonde entfernen"
+      },
+      "alarmsabbathabouttostart": {
+        "name": "Alarm Sabbat beginnt bald"
+      },
+      "alarmsabbathended": {
+        "name": "Alarm Sabbat beendet"
+      },
+      "alarmsabbathpostpone": {
+        "name": "Alarm Sabbat verschoben"
+      },
+      "alarmsteam_interrupted": {
+        "name": "Alarm Dampf unterbrochen"
+      },
+      "alarmsteam_system_finished": {
+        "name": "Alarm Dampfsystem fertig"
+      },
+      "alarmsteamclean_finished": {
+        "name": "Alarm Dampfreinigung abgeschlossen"
+      },
+      "alarmtanklevel1": {
+        "name": "Alarm Tankf\u00fcllstand 1"
+      },
+      "ali_wifi_fault_flag": {
+        "name": "WLAN-St\u00f6rung"
       },
       "auto_dose_refill": {
         "name": "Automatische Dosierung nachf\u00fcllen"
@@ -310,6 +388,15 @@
       "clean_filter": {
         "name": "Filter reinigen"
       },
+      "condensation_fan_failure_status": {
+        "name": "Kondensationsl\u00fcfter Ausfallstatus"
+      },
+      "control_failure_status": {
+        "name": "Steuerungsausfallstatus"
+      },
+      "crisp_function_status": {
+        "name": "Knusperfunktion Status"
+      },
       "delay_start": {
         "name": "Verz\u00f6gerter Start"
       },
@@ -322,8 +409,17 @@
       "demo_mode": {
         "name": "Demo-Modus"
       },
+      "detergent_display": {
+        "name": "Waschmittelanzeige"
+      },
+      "detergent_state": {
+        "name": "Waschmittelzustand"
+      },
       "door": {
         "name": "T\u00fcr"
+      },
+      "door_lock": {
+        "name": "T\u00fcrverriegelung"
       },
       "door_status": {
         "name": "T\u00fcrstatus"
@@ -361,14 +457,86 @@
       "error_16": {
         "name": "Fehler 16"
       },
+      "error_17": {
+        "name": "Fehler 17"
+      },
+      "error_18": {
+        "name": "Fehler 18"
+      },
+      "error_19": {
+        "name": "Fehler 19"
+      },
       "error_2": {
         "name": "Fehler 2"
+      },
+      "error_20": {
+        "name": "Fehler 20"
+      },
+      "error_21": {
+        "name": "Fehler 21"
+      },
+      "error_22": {
+        "name": "Fehler 22"
+      },
+      "error_23": {
+        "name": "Fehler 23"
+      },
+      "error_24": {
+        "name": "Fehler 24"
+      },
+      "error_25": {
+        "name": "Fehler 25"
+      },
+      "error_26": {
+        "name": "Fehler 26"
+      },
+      "error_27": {
+        "name": "Fehler 27"
+      },
+      "error_28": {
+        "name": "Fehler 28"
+      },
+      "error_29": {
+        "name": "Fehler 29"
       },
       "error_3": {
         "name": "Fehler 3"
       },
+      "error_30": {
+        "name": "Fehler 30"
+      },
+      "error_31": {
+        "name": "Fehler 31"
+      },
+      "error_32": {
+        "name": "Fehler 32"
+      },
+      "error_33": {
+        "name": "Fehler 33"
+      },
+      "error_34": {
+        "name": "Fehler 34"
+      },
+      "error_35": {
+        "name": "Fehler 35"
+      },
+      "error_36": {
+        "name": "Fehler 36"
+      },
+      "error_37": {
+        "name": "Fehler 37"
+      },
+      "error_38": {
+        "name": "Fehler 38"
+      },
+      "error_39": {
+        "name": "Fehler 39"
+      },
       "error_4": {
         "name": "Fehler 4"
+      },
+      "error_40": {
+        "name": "Fehler 40"
       },
       "error_5": {
         "name": "Fehler 5"
@@ -402,6 +570,9 @@
       },
       "existing_sr_mode": {
         "name": "Aktueller SR-Modus"
+      },
+      "extra_rinse": {
+        "name": "Extra Sp\u00fclen"
       },
       "extra_rinse_status": {
         "name": "Programmoption Extra-Sp\u00fclung"
@@ -505,6 +676,9 @@
       "freeze_poweron_ad": {
         "name": "Energiesparmodus f\u00fcr Gefrieren aktiviert"
       },
+      "frize_temp_2_degree_above_starting_point": {
+        "name": "Gefriertemperatur 2\u00b0 \u00fcber Startwert"
+      },
       "frost_state": {
         "name": "Froststatus"
       },
@@ -513,6 +687,21 @@
       },
       "gold_water_supply_mode": {
         "name": "Gold-Wasserversorgungsmodus"
+      },
+      "gratin_available": {
+        "name": "Gratin verf\u00fcgbar"
+      },
+      "gratin_from_below_function_allowed": {
+        "name": "Gratin von unten erlaubt"
+      },
+      "gratin_from_below_function_status": {
+        "name": "Gratin von unten Status"
+      },
+      "gratin_status": {
+        "name": "Gratin Status"
+      },
+      "grill_plate_status": {
+        "name": "Grillplattenstatus"
       },
       "hard_pairing_status": {
         "name": "Status der festen Kopplung"
@@ -523,14 +712,26 @@
       "high_temperature": {
         "name": "Hohe Temperatur"
       },
+      "hob_status": {
+        "name": "Kochfeldstatus"
+      },
+      "hob_warming_zone_status": {
+        "name": "Kochfeld Warmhaltezone Status"
+      },
       "humidity_sensor": {
         "name": "Luftfeuchtigkeitssensor"
       },
       "humidity_sensor_failure": {
         "name": "Fehler des Luftfeuchtigkeitssensors"
       },
+      "ice_make_room_alarm": {
+        "name": "Eisbereiter-Raumalarm"
+      },
       "ice_making_machine_failure": {
         "name": "Fehler der Eisherstellungsmaschine"
+      },
+      "ice_making_normal_status": {
+        "name": "Eisherstellung Normalzustand"
       },
       "ice_making_state": {
         "name": "Status der Eisherstellung"
@@ -547,8 +748,14 @@
       "inlet_pipe_temp_sens_head_failure": {
         "name": "Fehler des Einlassrohr-Temperatursensors"
       },
+      "interior_light_control_available": {
+        "name": "Innenbeleuchtungssteuerung verf\u00fcgbar"
+      },
       "light": {
         "name": "Licht"
+      },
+      "lock_fresh_mode": {
+        "name": "Frischhaltesperre"
       },
       "low_wine_area_c_evaporator_fault": {
         "name": "Fehler des Verdampfers in Bereich C der Weinlagerung"
@@ -594,6 +801,9 @@
       },
       "reed_switch": {
         "name": "Reed-Schalter"
+      },
+      "refi_temp_2_degree_above_starting_point": {
+        "name": "K\u00fchlschranktemperatur 2\u00b0 \u00fcber Startwert"
       },
       "refr_defrosting_failure": {
         "name": "Fehlfunktion der K\u00fchlschrank-Abtauung"
@@ -646,6 +856,12 @@
       "remote_control_mode_monitoring": {
         "name": "Fernsteuerungsmodus-\u00dcberwachung"
       },
+      "remote_control_monitoring": {
+        "name": "Fernsteuerungs\u00fcberwachung"
+      },
+      "remote_control_monitoring_set_commands": {
+        "name": "Fernsteuerung Befehle"
+      },
       "remote_control_monitoring_set_commands_actions": {
         "name": "Fernsteuerung"
       },
@@ -696,6 +912,9 @@
       },
       "session_pairing_active": {
         "name": "Sitzungskopplung aktiv"
+      },
+      "session_pairing_setting": {
+        "name": "Sitzungskopplung Einstellung"
       },
       "sf_mode": {
         "name": "SF-Modus"
@@ -844,372 +1063,6 @@
       "sl6_status": {
         "name": "Zone 6 Status"
       },
-      "sr_mode": {
-        "name": "SR-Modus"
-      },
-      "step1_status": {
-        "name": "Schritt 1 Status"
-      },
-      "step2_status": {
-        "name": "Schritt 2 Status"
-      },
-      "step3_status": {
-        "name": "Schritt 3 Status"
-      },
-      "stopaddgo_status": {
-        "name": "Stop-Add-Go aktiv"
-      },
-      "stopaddgoallowed": {
-        "name": "Stop-Add-Go erlaubt"
-      },
-      "t_beep": {
-        "name": "Signalton"
-      },
-      "tab_setting_status": {
-        "name": "Tab-Einstellung"
-      },
-      "tx_failure": {
-        "name": "TX-Fehler"
-      },
-      "vacuum_on_off_status": {
-        "name": "Staubsauger Ein/Aus Status"
-      },
-      "vari_evap_temp_sens_head_failure": {
-        "name": "Fehler des Verdampfertemperatursensors (Vari)"
-      },
-      "vari_temp_sens_head_failure": {
-        "name": "Fehler des Temperatursensors (Vari)"
-      },
-      "vibration_alarm": {
-        "name": "Vibrationsalarm"
-      },
-      "vibration_sensor_fault": {
-        "name": "Fehler des Vibrationssensors"
-      },
-      "water_level_switch": {
-        "name": "Wasserstandsschalter"
-      },
-      "waterbox_full": {
-        "name": "Wasserbeh\u00e4lter voll"
-      },
-      "add_moist_now": {
-        "name": "Feuchtigkeit jetzt hinzuf\u00fcgen"
-      },
-      "alarm_aquaclean_finished": {
-        "name": "AquaClean abgeschlossen"
-      },
-      "alarm_baking_stoped": {
-        "name": "Alarm Backen gestoppt"
-      },
-      "alarm_child_lock_deactivated_on_the_oven": {
-        "name": "Alarm Kindersicherung am Ofen deaktiviert"
-      },
-      "alarm_cleaning_suggestion_after_baking_finished": {
-        "name": "Alarm Reinigungsempfehlung nach dem Backen"
-      },
-      "alarm_defrost_finished": {
-        "name": "Alarm Auftauen abgeschlossen"
-      },
-      "alarm_descaling_needed": {
-        "name": "Alarm Entkalkung erforderlich"
-      },
-      "alarm_door_locked": {
-        "name": "Alarm T\u00fcr verriegelt"
-      },
-      "alarm_ean_scan_info": {
-        "name": "Alarm EAN-Scan Info"
-      },
-      "alarm_empty_and_clean_water_tank": {
-        "name": "Alarm Wassertank leeren und reinigen"
-      },
-      "alarm_fast_preheat_active": {
-        "name": "Alarm Schnellvorheizen aktiv"
-      },
-      "alarm_fast_preheating_finished": {
-        "name": "Alarm Schnellvorheizen abgeschlossen"
-      },
-      "alarm_keepwarm_ended": {
-        "name": "Warmhalten beendet"
-      },
-      "alarm_mw_active": {
-        "name": "Mikrowelle aktiv"
-      },
-      "alarm_oven_temperature_too_high": {
-        "name": "Alarm Ofentemperatur zu hoch"
-      },
-      "alarm_oven_usage_reached_set_limit_auto_cleaning_suggested": {
-        "name": "Alarm Ofennutzung Grenzwert erreicht, Reinigung empfohlen"
-      },
-      "alarm_platewarm_ended": {
-        "name": "Tellerw\u00e4rmen beendet"
-      },
-      "alarm_probe_inserted": {
-        "name": "Alarm Sonde eingesteckt"
-      },
-      "alarm_probe_temp_reached": {
-        "name": "Alarm Sondentemperatur erreicht"
-      },
-      "alarm_pyrolytic_finished": {
-        "name": "Alarm Pyrolyse abgeschlossen"
-      },
-      "alarm_running_time_over_10_or_24_hour_limit_error": {
-        "name": "Alarm Laufzeit \u00fcber 10 oder 24 Stunden Limit"
-      },
-      "alarm_sabbath_reminder": {
-        "name": "Alarm Sabbat-Erinnerung"
-      },
-      "alarm_sand_timer_1_elapsed": {
-        "name": "Alarm Timer 1 abgelaufen"
-      },
-      "alarm_sand_timer_2_elapsed": {
-        "name": "Alarm Timer 2 abgelaufen"
-      },
-      "alarm_sand_timer_3_elapsed": {
-        "name": "Alarm Timer 3 abgelaufen"
-      },
-      "alarm_set_temperature_reached": {
-        "name": "Alarm eingestellte Temperatur erreicht"
-      },
-      "alarm_steam_fill_alarm": {
-        "name": "Alarm Dampf Bef\u00fcllungsalarm"
-      },
-      "alarm_steam_function_active": {
-        "name": "Alarm Dampffunktion aktiv"
-      },
-      "alarm_user_interaction_on_appliance_detected": {
-        "name": "Alarm Benutzerinteraktion am Ger\u00e4t erkannt"
-      },
-      "alarm_water_tank_is_empty": {
-        "name": "Alarm Wassertank ist leer"
-      },
-      "alarm_water_tank_is_missing": {
-        "name": "Alarm Wassertank fehlt"
-      },
-      "alarmalmost_finished": {
-        "name": "Alarm fast fertig"
-      },
-      "alarmchild_lockoff": {
-        "name": "Alarm Kindersicherung aus"
-      },
-      "alarmchild_lockon": {
-        "name": "Alarm Kindersicherung ein"
-      },
-      "alarmcleantank": {
-        "name": "Alarm Tank reinigen"
-      },
-      "alarmdehydrate_ended": {
-        "name": "Alarm D\u00f6rren beendet"
-      },
-      "alarmdescalestep1": {
-        "name": "Alarm Entkalkung Schritt 1"
-      },
-      "alarmdescalestep2": {
-        "name": "Alarm Entkalkung Schritt 2"
-      },
-      "alarmdescalestep3": {
-        "name": "Alarm Entkalkung Schritt 3"
-      },
-      "alarmdescaling_interrupted": {
-        "name": "Alarm Entkalkung unterbrochen"
-      },
-      "alarmemptytankpause": {
-        "name": "Alarm Tank leer Pause"
-      },
-      "alarmfilltank": {
-        "name": "Alarm Tank bef\u00fcllen"
-      },
-      "alarmincreased_power_consumption": {
-        "name": "Alarm erh\u00f6hter Stromverbrauch"
-      },
-      "alarmkey_lock_on": {
-        "name": "Alarm Tastensperre ein"
-      },
-      "alarmmicrowave_system_finished": {
-        "name": "Alarm Mikrowelle fertig"
-      },
-      "alarmoven_system_finished": {
-        "name": "Alarm Ofen fertig"
-      },
-      "alarmpoptankopened": {
-        "name": "Alarm Tank ge\u00f6ffnet"
-      },
-      "alarmpower_failure_running": {
-        "name": "Alarm Stromausfall w\u00e4hrend Betrieb"
-      },
-      "alarmprobe_lost_connection": {
-        "name": "Alarm Sonde Verbindung verloren"
-      },
-      "alarmremotestartpowerfailure": {
-        "name": "Alarm Fernstart Stromausfall"
-      },
-      "alarmremove_probe": {
-        "name": "Alarm Sonde entfernen"
-      },
-      "alarmsabbathabouttostart": {
-        "name": "Alarm Sabbat beginnt bald"
-      },
-      "alarmsabbathended": {
-        "name": "Alarm Sabbat beendet"
-      },
-      "alarmsabbathpostpone": {
-        "name": "Alarm Sabbat verschoben"
-      },
-      "alarmsteam_interrupted": {
-        "name": "Alarm Dampf unterbrochen"
-      },
-      "alarmsteam_system_finished": {
-        "name": "Alarm Dampfsystem fertig"
-      },
-      "alarmsteamclean_finished": {
-        "name": "Alarm Dampfreinigung abgeschlossen"
-      },
-      "alarmtanklevel1": {
-        "name": "Alarm Tankf\u00fcllstand 1"
-      },
-      "ali_wifi_fault_flag": {
-        "name": "WLAN-St\u00f6rung"
-      },
-      "condensation_fan_failure_status": {
-        "name": "Kondensationsl\u00fcfter Ausfallstatus"
-      },
-      "control_failure_status": {
-        "name": "Steuerungsausfallstatus"
-      },
-      "crisp_function_status": {
-        "name": "Knusperfunktion Status"
-      },
-      "detergent_display": {
-        "name": "Waschmittelanzeige"
-      },
-      "detergent_state": {
-        "name": "Waschmittelzustand"
-      },
-      "door_lock": {
-        "name": "T\u00fcrverriegelung"
-      },
-      "error_17": {
-        "name": "Fehler 17"
-      },
-      "error_18": {
-        "name": "Fehler 18"
-      },
-      "error_19": {
-        "name": "Fehler 19"
-      },
-      "error_20": {
-        "name": "Fehler 20"
-      },
-      "error_21": {
-        "name": "Fehler 21"
-      },
-      "error_22": {
-        "name": "Fehler 22"
-      },
-      "error_23": {
-        "name": "Fehler 23"
-      },
-      "error_24": {
-        "name": "Fehler 24"
-      },
-      "error_25": {
-        "name": "Fehler 25"
-      },
-      "error_26": {
-        "name": "Fehler 26"
-      },
-      "error_27": {
-        "name": "Fehler 27"
-      },
-      "error_28": {
-        "name": "Fehler 28"
-      },
-      "error_29": {
-        "name": "Fehler 29"
-      },
-      "error_30": {
-        "name": "Fehler 30"
-      },
-      "error_31": {
-        "name": "Fehler 31"
-      },
-      "error_32": {
-        "name": "Fehler 32"
-      },
-      "error_33": {
-        "name": "Fehler 33"
-      },
-      "error_34": {
-        "name": "Fehler 34"
-      },
-      "error_35": {
-        "name": "Fehler 35"
-      },
-      "error_36": {
-        "name": "Fehler 36"
-      },
-      "error_37": {
-        "name": "Fehler 37"
-      },
-      "error_38": {
-        "name": "Fehler 38"
-      },
-      "error_39": {
-        "name": "Fehler 39"
-      },
-      "error_40": {
-        "name": "Fehler 40"
-      },
-      "extra_rinse": {
-        "name": "Extra Sp\u00fclen"
-      },
-      "frize_temp_2_degree_above_starting_point": {
-        "name": "Gefriertemperatur 2\u00b0 \u00fcber Startwert"
-      },
-      "gratin_available": {
-        "name": "Gratin verf\u00fcgbar"
-      },
-      "gratin_from_below_function_allowed": {
-        "name": "Gratin von unten erlaubt"
-      },
-      "gratin_from_below_function_status": {
-        "name": "Gratin von unten Status"
-      },
-      "gratin_status": {
-        "name": "Gratin Status"
-      },
-      "grill_plate_status": {
-        "name": "Grillplattenstatus"
-      },
-      "hob_status": {
-        "name": "Kochfeldstatus"
-      },
-      "hob_warming_zone_status": {
-        "name": "Kochfeld Warmhaltezone Status"
-      },
-      "ice_make_room_alarm": {
-        "name": "Eisbereiter-Raumalarm"
-      },
-      "ice_making_normal_status": {
-        "name": "Eisherstellung Normalzustand"
-      },
-      "interior_light_control_available": {
-        "name": "Innenbeleuchtungssteuerung verf\u00fcgbar"
-      },
-      "lock_fresh_mode": {
-        "name": "Frischhaltesperre"
-      },
-      "refi_temp_2_degree_above_starting_point": {
-        "name": "K\u00fchlschranktemperatur 2\u00b0 \u00fcber Startwert"
-      },
-      "remote_control_monitoring": {
-        "name": "Fernsteuerungs\u00fcberwachung"
-      },
-      "remote_control_monitoring_set_commands": {
-        "name": "Fernsteuerung Befehle"
-      },
-      "session_pairing_setting": {
-        "name": "Sitzungskopplung Einstellung"
-      },
       "soft_pairing_setting": {
         "name": "Soft-Kopplung Einstellung"
       },
@@ -1218,6 +1071,9 @@
       },
       "softer_display": {
         "name": "Weichsp\u00fcleranzeige"
+      },
+      "sr_mode": {
+        "name": "SR-Modus"
       },
       "steam123_0_available": {
         "name": "Steam123 0 verf\u00fcgbar"
@@ -1234,11 +1090,20 @@
       "steam_shot": {
         "name": "Dampfsto\u00df"
       },
+      "step1_status": {
+        "name": "Schritt 1 Status"
+      },
       "step1_steam_assist": {
         "name": "Schritt 1 Dampfunterst\u00fctzung"
       },
+      "step2_status": {
+        "name": "Schritt 2 Status"
+      },
       "step2_steam_assist": {
         "name": "Schritt 2 Dampfunterst\u00fctzung"
+      },
+      "step3_status": {
+        "name": "Schritt 3 Status"
       },
       "step3_steam_assist": {
         "name": "Schritt 3 Dampfunterst\u00fctzung"
@@ -1261,6 +1126,21 @@
       "step_pre_bake_status": {
         "name": "Vorbackphase Status"
       },
+      "stopaddgo_status": {
+        "name": "Stop-Add-Go aktiv"
+      },
+      "stopaddgoallowed": {
+        "name": "Stop-Add-Go erlaubt"
+      },
+      "t_beep": {
+        "name": "Signalton"
+      },
+      "tab_setting_status": {
+        "name": "Tab-Einstellung"
+      },
+      "tx_failure": {
+        "name": "TX-Fehler"
+      },
       "up_wine_area_a_evaporator_fault": {
         "name": "Oberer Weinbereich A Verdampferfehler"
       },
@@ -1273,8 +1153,14 @@
       "up_wine_area_a_temp_fault": {
         "name": "Oberer Weinbereich A Temperaturfehler"
       },
+      "vacuum_on_off_status": {
+        "name": "Staubsauger Ein/Aus Status"
+      },
       "var_room_over_temp_alarm": {
         "name": "Variabler Raum \u00dcbertemperaturalarm"
+      },
+      "vari_evap_temp_sens_head_failure": {
+        "name": "Fehler des Verdampfertemperatursensors (Vari)"
       },
       "vari_room_open": {
         "name": "Variabler Raum ge\u00f6ffnet"
@@ -1282,14 +1168,29 @@
       "vari_temp_2_degree_above_starting_point": {
         "name": "Variable Temperatur 2\u00b0 \u00fcber Startwert"
       },
+      "vari_temp_sens_head_failure": {
+        "name": "Fehler des Temperatursensors (Vari)"
+      },
       "variable_fan_failure_status": {
         "name": "Variabler L\u00fcfterausfall"
       },
       "variable_heater_failure_status": {
         "name": "Variable Heizungsausfall"
       },
+      "vibration_alarm": {
+        "name": "Vibrationsalarm"
+      },
+      "vibration_sensor_fault": {
+        "name": "Fehler des Vibrationssensors"
+      },
       "warming_drawer_status": {
         "name": "Warmhalteschublade Status"
+      },
+      "water_level_switch": {
+        "name": "Wasserstandsschalter"
+      },
+      "waterbox_full": {
+        "name": "Wasserbeh\u00e4lter voll"
       },
       "wine_sensor_failure_flag": {
         "name": "Weinsensorfehler"
@@ -1300,30 +1201,27 @@
         "state_attributes": {
           "fan_mode": {
             "state": {
-              "middle_low": "Mittel niedrig",
-              "middle_high": "Mittel hoch"
+              "middle_high": "Mittel hoch",
+              "middle_low": "Mittel niedrig"
             }
           },
           "preset_mode": {
             "state": {
               "ai": "KI",
-              "off": "Aus",
-              "mute": "Stumm",
+              "bedtime": "Schlafenszeit",
               "eco_mute": "Eco-Stumm",
-              "super": "Super",
-              "sleep_1": "Schlafmodus 1",
-              "sleep_2": "Schlafmodus 2",
-              "sleep_3": "Schlafmodus 3",
-              "sleep_4": "Schlafmodus 4",
               "eco_sleep_1": "Eco-Schlafmodus 1",
               "eco_sleep_2": "Eco-Schlafmodus 2",
               "eco_sleep_3": "Eco-Schlafmodus 3",
               "eco_sleep_4": "Eco-Schlafmodus 4",
-              "bedtime": "Schlafenszeit"
+              "mute": "Stumm",
+              "off": "Aus",
+              "sleep_1": "Schlafmodus 1",
+              "sleep_2": "Schlafmodus 2",
+              "sleep_3": "Schlafmodus 3",
+              "sleep_4": "Schlafmodus 4",
+              "super": "Super"
             }
-          },
-          "swing_mode": {
-            "state": {}
           },
           "swing_horizontal_mode": {
             "state": {
@@ -1333,6 +1231,9 @@
               "right": "Rechts",
               "swing": "Schwenken"
             }
+          },
+          "swing_mode": {
+            "state": {}
           }
         }
       }
@@ -1343,12 +1244,487 @@
           "mode": {
             "state": {
               "auto": "Automatisch",
+              "clothes_dry": "Kleidung trocknen",
               "continuous": "Kontinuierlich",
-              "manual": "Manuell",
-              "clothes_dry": "Kleidung trocknen"
+              "manual": "Manuell"
             }
           }
         }
+      }
+    },
+    "number": {
+      "freeze_max_temperature": {
+        "name": "Maximale Gefriertemperatur"
+      },
+      "freeze_min_temperature": {
+        "name": "Minimale Gefriertemperatur"
+      },
+      "freeze_temperature": {
+        "name": "Gefriertemperatur"
+      },
+      "gratin_from_below_functionset_time_in_seconds": {
+        "name": "Gratin von unten Zeiteinstellung"
+      },
+      "gratin_function_set_time_in_seconds": {
+        "name": "Gratin Zeiteinstellung"
+      },
+      "lightbrightness": {
+        "name": "Lichthelligkeit"
+      },
+      "lightcolortemperature": {
+        "name": "Lichtfarbtemperatur"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Maximale K\u00fchlschranktemperatur"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Minimale K\u00fchlschranktemperatur"
+      },
+      "refrigerator_temperature": {
+        "name": "K\u00fchlschranktemperatur"
+      },
+      "variation_max_temperature": {
+        "name": "Maximale Temperaturvariation"
+      },
+      "variation_min_temperature": {
+        "name": "Minimale Temperaturvariation"
+      },
+      "variation_temperature": {
+        "name": "Temperaturvariation"
+      }
+    },
+    "select": {
+      "actions": {
+        "name": "Aktionen",
+        "state": {
+          "add_duration": "Dauer hinzuf\u00fcgen",
+          "add_gratin": "Gratin hinzuf\u00fcgen",
+          "none": "Keine",
+          "pause": "Pause",
+          "start": "Start",
+          "steam_shot": "Dampfsto\u00df",
+          "stop": "Stopp",
+          "stop_finish": "Stopp / Fertig"
+        }
+      },
+      "auto_dose_quantity_setting_status": {
+        "name": "Automatische Dosierungsmenge"
+      },
+      "baking_steps_intensity_levels": {
+        "name": "Backschritte Intensit\u00e4tsstufen",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "baking_steps_intensity_levels_type": {
+        "name": "Backschritte Intensit\u00e4tsstufen Typ",
+        "state": {
+          "low_mid_high": "Niedrig Mittel Hoch",
+          "none": "Keine",
+          "not_used": "Nicht verwendet",
+          "rare_medium_well_done": "Rare Medium Well done"
+        }
+      },
+      "brightness": {
+        "name": "Helligkeit"
+      },
+      "cooking_intensity": {
+        "name": "Kochintensit\u00e4t"
+      },
+      "delayendtime": {
+        "name": "Startverz\u00f6gerung Endzeit",
+        "state": {
+          "10_hours": "10 Stunden",
+          "11_hours": "11 Stunden",
+          "12_hours": "12 Stunden",
+          "13_hours": "13 Stunden",
+          "14_hours": "14 Stunden",
+          "15_hours": "15 Stunden",
+          "16_hours": "16 Stunden",
+          "17_hours": "17 Stunden",
+          "18_hours": "18 Stunden",
+          "19_hours": "19 Stunden",
+          "1_hour": "1 Stunde",
+          "20_hours": "20 Stunden",
+          "21_hours": "21 Stunden",
+          "22_hours": "22 Stunden",
+          "23_hours": "23 Stunden",
+          "24_hours": "24 Stunden",
+          "2_hours": "2 Stunden",
+          "3_hours": "3 Stunden",
+          "4_hours": "4 Stunden",
+          "5_hours": "5 Stunden",
+          "6_hours": "6 Stunden",
+          "7_hours": "7 Stunden",
+          "8_hours": "8 Stunden",
+          "9_hours": "9 Stunden",
+          "none": "Keine"
+        }
+      },
+      "detergent": {
+        "name": "Waschmittel",
+        "state": {
+          "auto": "Automatisch",
+          "less": "Weniger",
+          "more": "Mehr",
+          "standard": "Standard"
+        }
+      },
+      "dry_level": {
+        "name": "Trocknungsstufe",
+        "state": {
+          "high": "Hoch",
+          "low": "Niedrig",
+          "medium": "Mittel"
+        }
+      },
+      "dry_time": {
+        "name": "Trocknungszeit",
+        "state": {
+          "120_min": "120 min",
+          "180_min": "180 min",
+          "240_min": "240 min",
+          "30_min": "30 min",
+          "60_min": "60 min",
+          "90_min": "90 min",
+          "cupboard": "Schranktrocken",
+          "extra_dry": "Extra Trocken",
+          "iron": "B\u00fcgelfeucht",
+          "none": "Keine",
+          "pre-ironing": "Vor B\u00fcgeln",
+          "wardrobe": "Schranktrocken"
+        }
+      },
+      "drymodel": {
+        "name": "Trocknungsmodus",
+        "state": {
+          "dry_only": "Nur Trocknen",
+          "wash": "Waschen",
+          "wash_and_dry": "Waschen und Trocknen"
+        }
+      },
+      "extrarinsenum": {
+        "name": "Zus\u00e4tzliche Sp\u00fclg\u00e4nge",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "language_status": {
+        "name": "Sprache",
+        "state": {
+          "english": "Englisch",
+          "simplified_chinese": "Vereinfachtes Chinesisch"
+        }
+      },
+      "motorlevel": {
+        "name": "Motorleistung"
+      },
+      "oven_temperature_unit": {
+        "name": "Ofen Temperatureinheit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "sand_timer_1_status_cmd": {
+        "name": "Timer 1 Steuerung",
+        "state": {
+          "cancel": "Abbrechen",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stopp"
+        }
+      },
+      "sand_timer_2_status_cmd": {
+        "name": "Timer 2 Steuerung",
+        "state": {
+          "cancel": "Abbrechen",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stopp"
+        }
+      },
+      "sand_timer_3_status_cmd": {
+        "name": "Timer 3 Steuerung",
+        "state": {
+          "cancel": "Abbrechen",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stopp"
+        }
+      },
+      "selected_program_id": {
+        "name": "Programm",
+        "state": {
+          "allergy_care": "Allergiepflege",
+          "anti_allergy": "Anti-Allergie",
+          "auto": "Automatisch",
+          "baby": "Babyprogramm",
+          "bed_linen": "Bettw\u00e4sche",
+          "bedding": "Bettw\u00e4sche",
+          "clean_dry_60": "Sauber & Trocken 60'",
+          "cotton": "Baumwolle",
+          "cotton_dry": "Baumwolle trocken",
+          "delicates": "Feinw\u00e4sche",
+          "down": "Daunen",
+          "drum_cleaning": "Trommelreinigung",
+          "eco_40_60": "Eco 40-60",
+          "fast15": "Schnell 15'",
+          "fast30": "Schnell 30'",
+          "full_load_49": "Volle Ladung 49",
+          "hand_wash": "Handw\u00e4sche",
+          "jeans": "Jeans",
+          "mix": "Mischgewebe",
+          "pets": "Haustiere",
+          "power49": "Power 49'",
+          "power_30": "Power 30",
+          "refresh": "Auffrischen",
+          "rinse_spin": "Sp\u00fclen & Schleudern",
+          "shirts": "Hemdprogramm",
+          "spin-dry": "Schleudern & Trocknen",
+          "sports": "Sport",
+          "sportswear": "Sportkleidung",
+          "synthetic": "Synthetik",
+          "synthetic_dry": "Synthetik trocken",
+          "time": "Zeitprogramm",
+          "towels": "Handt\u00fccher",
+          "wash_and_dry_49": "Waschen und Trocknen 49",
+          "wool": "Wolle"
+        }
+      },
+      "softener": {
+        "name": "Weichsp\u00fcler",
+        "state": {
+          "auto": "Automatisch",
+          "less": "Weniger",
+          "more": "Mehr",
+          "standard": "Standard"
+        }
+      },
+      "spin_speed_rpm": {
+        "name": "Schleudergeschwindigkeit",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "stain_removal": {
+        "name": "Fleckenentfernung",
+        "state": {
+          "blood": "Blut",
+          "coffee": "Kaffee",
+          "grass": "Gras",
+          "juice": "Saft",
+          "milk": "Milch",
+          "oil": "\u00d6l",
+          "soil": "Erde",
+          "sweat": "Schwei\u00df",
+          "wine": "Wein"
+        }
+      },
+      "steam_123": {
+        "name": "Steam 123",
+        "state": {
+          "steam123_0": "Steam123 0",
+          "steam123_1": "Steam123 1",
+          "steam123_2": "Steam123 2",
+          "steam123_3": "Steam123 3"
+        }
+      },
+      "step_1_bake_mode": {
+        "name": "Schritt 1 Backmodus",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake \u2013 Reinigung",
+          "extrabake_fastpreheat": "ExtraBake \u2013 Schnellvorheizen",
+          "extrabake_warming": "ExtraBake \u2013 Aufw\u00e4rmen",
+          "meatprobebake": "MeatProbeBake",
+          "probake": "ProBake",
+          "recipe": "Rezept",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefiniert"
+        }
+      },
+      "step_1_set_microwave_wattage": {
+        "name": "Schritt 1 Mikrowellenleistung",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "step_1_time_unit": {
+        "name": "Schritt 1 Zeiteinheit",
+        "state": {
+          "hours": "Stunden",
+          "minutes": "Minuten",
+          "seconds": "Sekunden"
+        }
+      },
+      "step_2_bake_mode": {
+        "name": "Schritt 2 Backmodus",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Rezept",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefiniert"
+        }
+      },
+      "step_2_set_microwave_wattage": {
+        "name": "Schritt 2 Mikrowellenleistung",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "step_2_time_unit": {
+        "name": "Schritt 2 Zeiteinheit",
+        "state": {
+          "hours": "Stunden",
+          "minutes": "Minuten",
+          "seconds": "Sekunden"
+        }
+      },
+      "step_3_bake_mode": {
+        "name": "Schritt 3 Backmodus",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Rezept",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefiniert"
+        }
+      },
+      "step_3_set_microwave_wattage": {
+        "name": "Schritt 3 Mikrowellenleistung",
+        "state": {
+          "none": "Keine"
+        }
+      },
+      "step_3_status": {
+        "name": "Schritt 3 Status",
+        "state": {
+          "active": "Aktiv",
+          "available": "Verf\u00fcgbar",
+          "not_active": "Nicht aktiv"
+        }
+      },
+      "step_3_time_unit": {
+        "name": "Schritt 3 Zeiteinheit",
+        "state": {
+          "hours": "Stunden",
+          "minutes": "Minuten",
+          "seconds": "Sekunden"
+        }
+      },
+      "step_after_bake_mode": {
+        "name": "Nachbackphase Modus",
+        "state": {
+          "gratine": "Gratinieren"
+        }
+      },
+      "step_after_bake_time_unit": {
+        "name": "Nachbackphase Zeiteinheit",
+        "state": {
+          "hours": "Stunden",
+          "minutes": "Minuten",
+          "seconds": "Sekunden"
+        }
+      },
+      "step_pre_bake_mode": {
+        "name": "Vorbackphase Modus",
+        "state": {
+          "delay_start_waiting": "Warte auf Startverz\u00f6gerung",
+          "not_active": "Nicht aktiv",
+          "preheat": "Vorheizen"
+        }
+      },
+      "step_pre_bake_time_unit": {
+        "name": "Vorbackphase Zeiteinheit",
+        "state": {
+          "hours": "Stunden",
+          "minutes": "Minuten",
+          "seconds": "Sekunden"
+        }
+      },
+      "t_fan_speed": {
+        "name": "L\u00fcftergeschwindigkeit",
+        "state": {
+          "auto": "Automatisch",
+          "high": "Hoch",
+          "low": "Niedrig"
+        }
+      },
+      "t_sleep": {
+        "name": "Schlafmodus",
+        "state": {
+          "for_kid": "F\u00fcr Kinder",
+          "for_old": "F\u00fcr \u00e4ltere Menschen",
+          "for_young": "F\u00fcr junge Menschen",
+          "general": "Allgemein",
+          "off": "Aus"
+        }
+      },
+      "t_swing_angle": {
+        "name": "Schwenkwinkel",
+        "state": {
+          "angle_1": "Winkel 1",
+          "angle_2": "Winkel 2",
+          "angle_3": "Winkel 3",
+          "angle_4": "Winkel 4",
+          "angle_5": "Winkel 5",
+          "angle_6": "Winkel 6",
+          "auto": "Automatisch",
+          "swing": "Schwenken"
+        }
+      },
+      "t_swing_follow": {
+        "name": "KI-Bel\u00fcftung",
+        "state": {
+          "follow": "Folgen",
+          "not_follow": "Nicht folgen",
+          "off": "Aus"
+        }
+      },
+      "temperature": {
+        "name": "Temperatur",
+        "state": {
+          "cold": "Kalt"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperatureinheit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "time_format": {
+        "name": "Zeitformat",
+        "state": {
+          "12h": "12h",
+          "24h": "24h"
+        }
+      },
+      "volume": {
+        "name": "Lautst\u00e4rke"
+      },
+      "warming_drawer_power_level": {
+        "name": "Warmhalteschublade Leistungsstufe",
+        "state": {
+          "high": "Hoch",
+          "low": "Niedrig",
+          "medium": "Mittel"
+        }
+      },
+      "water_hardness": {
+        "name": "Wasserh\u00e4rte"
       }
     },
     "sensor": {
@@ -1360,6 +1736,9 @@
       },
       "alarm_door_opened": {
         "name": "T\u00fcr ge\u00f6ffnet"
+      },
+      "almost_finished_notification_settingtimer_in_minutes": {
+        "name": "Bald-fertig-Benachrichtigung Timer"
       },
       "anticrease_setting": {
         "name": "Anti-Knitter-Dauer"
@@ -1373,8 +1752,8 @@
       "applicationpermissions": {
         "name": "Anwendungsberechtigungen",
         "state": {
-          "not_granted": "Nicht gew\u00e4hrt",
-          "granted": "Gew\u00e4hrt"
+          "granted": "Gew\u00e4hrt",
+          "not_granted": "Nicht gew\u00e4hrt"
         }
       },
       "auto_dose_duration": {
@@ -1382,6 +1761,13 @@
       },
       "auto_dose_refill": {
         "name": "Automatische Dosierung nachf\u00fcllen"
+      },
+      "autodose_flag": {
+        "name": "Autodosierung Kennzeichen",
+        "state": {
+          "available": "Verf\u00fcgbar",
+          "unavailable": "Nicht verf\u00fcgbar"
+        }
       },
       "bundling_humidity": {
         "name": "B\u00fcndelfeuchtigkeit"
@@ -1392,6 +1778,13 @@
       "child_lock_setting_status": {
         "name": "Kindersicherungseinstellung"
       },
+      "crisp_function_available": {
+        "name": "Knusperfunktion verf\u00fcgbar",
+        "state": {
+          "function_available": "Funktion verf\u00fcgbar",
+          "function_not_available": "Funktion nicht verf\u00fcgbar"
+        }
+      },
       "curent_program_duration": {
         "name": "Programmdauer aktuell"
       },
@@ -1401,38 +1794,38 @@
       "current_baking_step": {
         "name": "Aktueller Backschritt",
         "state": {
-          "preheat": "Vorheizen",
-          "step_1": "Schritt 1",
-          "step_2": "Schritt 2",
-          "step_3": "Schritt 3",
+          "after_bake": "Nachbacken",
           "after_bake_finished": "Nach dem Backen abgeschlossen",
           "pre_bake": "Vorbacken",
-          "after_bake": "Nachbacken",
-          "special": "Spezial"
+          "preheat": "Vorheizen",
+          "special": "Spezial",
+          "step_1": "Schritt 1",
+          "step_2": "Schritt 2",
+          "step_3": "Schritt 3"
         }
       },
       "current_program_phase": {
         "state": {
-          "not_available": "Nicht verf\u00fcgbar",
-          "program_not_selected": "Kein Programm ausgew\u00e4hlt",
-          "program_selected": "Programm ausgew\u00e4hlt",
+          "anti_crease": "Anti-Knitter",
+          "delay": "Verz\u00f6gerung",
           "delay_start_waiting": "Verz\u00f6gerter Start wartet",
+          "drying": "Trocknen",
+          "finished": "Abgeschlossen",
+          "idle": "Leerlauf",
+          "main_wash": "Hauptw\u00e4sche",
+          "not_available": "Nicht verf\u00fcgbar",
           "preheat": "Vorheizen",
           "preheat_finished": "Vorheizen abgeschlossen",
           "prewash": "Vorw\u00e4sche",
-          "main_wash": "Hauptw\u00e4sche",
-          "drying": "Trocknen",
           "program_finished": "Abgeschlossen",
-          "ventilating": "L\u00fcften",
-          "idle": "Leerlauf",
-          "running": "L\u00e4uft",
-          "anti_crease": "Anti-Knitter",
-          "delay": "Verz\u00f6gerung",
-          "finished": "Abgeschlossen",
-          "weigh": "Wiegen",
-          "wash": "Waschen",
+          "program_not_selected": "Kein Programm ausgew\u00e4hlt",
+          "program_selected": "Programm ausgew\u00e4hlt",
           "rinse": "Sp\u00fclen",
-          "spin-dry": "Schleudern"
+          "running": "L\u00e4uft",
+          "spin-dry": "Schleudern",
+          "ventilating": "L\u00fcften",
+          "wash": "Waschen",
+          "weigh": "Wiegen"
         }
       },
       "current_programphase": {
@@ -1483,12 +1876,47 @@
       "delaystart_delayend_remaining_timein_minutes": {
         "name": "Startverz\u00f6gerung Gesamtlaufzeit Verbleibend"
       },
+      "detergent": {
+        "name": "Waschmittel",
+        "state": {
+          "less": "Weniger",
+          "more": "Mehr",
+          "standard": "Standard"
+        }
+      },
       "detergent_display": {
         "name": "Waschmittelanzeige"
       },
+      "detergentstandarddosage": {
+        "name": "Waschmittel Standarddosierung",
+        "state": {
+          "100ml": "100 ml",
+          "10ml": "10 ml",
+          "15ml": "15 ml",
+          "20ml": "20 ml",
+          "25ml": "25 ml",
+          "30ml": "30 ml",
+          "35ml": "35 ml",
+          "40ml": "40 ml",
+          "45ml": "45 ml",
+          "50ml": "50 ml",
+          "55ml": "55 ml",
+          "60ml": "60 ml",
+          "65ml": "65 ml",
+          "70ml": "70 ml",
+          "75ml": "75 ml",
+          "80ml": "80 ml",
+          "85ml": "85 ml",
+          "90ml": "90 ml",
+          "95ml": "95 ml"
+        }
+      },
       "device_status": {
         "state": {
+          "after_bake_finished": "Nach dem Backen abgeschlossen",
+          "delay_time_waiting": "Verz\u00f6gerungszeit wartet",
           "demo_mode": "Demo-Modus",
+          "error": "Fehler",
           "failure": "Fehler",
           "idle": "Leerlauf",
           "iq": "IQ",
@@ -1496,14 +1924,11 @@
           "not_available": "Nicht verf\u00fcgbar",
           "pause": "Pausiert",
           "pause_mode": "Pausenmodus",
+          "paused": "Pausiert",
           "production": "Produktion",
           "running": "L\u00e4uft",
           "service": "Service",
-          "stand_by": "Standby",
-          "paused": "Pausiert",
-          "delay_time_waiting": "Verz\u00f6gerungszeit wartet",
-          "error": "Fehler",
-          "after_bake_finished": "Nach dem Backen abgeschlossen"
+          "stand_by": "Standby"
         }
       },
       "display_brightness_setting_status": {
@@ -1515,15 +1940,26 @@
       "display_logotype_setting_status": {
         "name": "Bildschirm-Logotyp"
       },
+      "display_switch_to_standby_after_minutes": {
+        "name": "Display Standby nach Minuten",
+        "state": {
+          "15_min": "15 min",
+          "30_min": "30 min",
+          "5_min": "5 min"
+        }
+      },
       "door_status": {
         "name": "T\u00fcr",
         "state": {
+          "closed": "Geschlossen",
+          "locked": "Verriegelt",
           "not_available": "Nicht verf\u00fcgbar",
           "open": "Ge\u00f6ffnet",
-          "closed": "Geschlossen",
-          "other": "Andere",
-          "locked": "Verriegelt"
+          "other": "Andere"
         }
+      },
+      "dryopen_defaultspinspeed": {
+        "name": "Standard Schleudergeschwindigkeit"
       },
       "electricit_consumption_decimal": {
         "name": "Stromverbrauch (Dezimal)"
@@ -1542,6 +1978,26 @@
       },
       "environment_real_temperature": {
         "name": "Reale Umgebungstemperatur"
+      },
+      "error_code": {
+        "name": "Fehlercode",
+        "state": {
+          "error_f01": "Fehler f01",
+          "error_f03": "Fehler f03",
+          "error_f04": "Fehler f04",
+          "error_f05": "Fehler f05",
+          "error_f06": "Fehler f06",
+          "error_f07": "Fehler f07",
+          "error_f13": "Fehler f13",
+          "error_f14": "Fehler f14",
+          "error_f15": "Fehler f15",
+          "error_f16": "Fehler f16",
+          "error_f17": "Fehler f17",
+          "error_f18": "Fehler f18",
+          "error_f23": "Fehler f23",
+          "error_f24": "Fehler f24",
+          "none": "Keine"
+        }
       },
       "error_read_out_1_code": {
         "name": "Fehlercode 1 auslesen"
@@ -1573,20 +2029,39 @@
       "f_votage": {
         "name": "Gemessene Netzspannung"
       },
+      "factory_reset": {
+        "name": "Werksreset"
+      },
       "fan_sequence_setting_status": {
         "name": "L\u00fcftersequenz"
       },
       "feedback_volumen_setting_status": {
         "name": "Feedback-Lautst\u00e4rke",
         "state": {
-          "mute": "Stumm",
+          "high": "Hoch",
           "low": "Niedrig",
           "mid": "Mittel",
-          "high": "Hoch"
+          "mute": "Stumm"
         }
+      },
+      "filter_state": {
+        "name": "Filterzustand"
       },
       "flexiblespintime_flag": {
         "name": "Flexible Schleuderzeit"
+      },
+      "fota": {
+        "name": "Firmware-Update",
+        "state": {
+          "confirm_fota": "Firmware-Update best\u00e4tigen",
+          "finished": "Abgeschlossen",
+          "in_progress": "In Bearbeitung",
+          "not_available": "Nicht verf\u00fcgbar",
+          "waiting_for_confirmation": "Warte auf Best\u00e4tigung"
+        }
+      },
+      "freeze_door_open_time": {
+        "name": "Gefrierfach T\u00fcr \u00d6ffnungszeit"
       },
       "freeze_max_temperature": {
         "name": "Maximale Gefriertemperatur"
@@ -1600,878 +2075,11 @@
       "freeze_sensor_real_temperature": {
         "name": "Reale Gefriersensor-Temperatur"
       },
-      "fruit_vegetables_temperature": {
-        "name": "Frucht- und Gem\u00fcse-Temperatur"
-      },
-      "heat_pump_setting_status": {
-        "name": "W\u00e4rmepumpe"
-      },
-      "high_humidity": {
-        "name": "Hohe Luftfeuchtigkeit"
-      },
-      "high_temperature": {
-        "name": "Hohe Temperatur"
-      },
-      "interior_light_at_power_off_setting_status": {
-        "name": "Innenbeleuchtung bei ausgeschaltetem Ger\u00e4t"
-      },
-      "interior_light_status": {
-        "name": "Innenbeleuchtungsstatus"
-      },
-      "language_status": {
-        "name": "Sprache"
-      },
-      "last_run_program_id": {
-        "name": "Letztes ausgef\u00fchrtes Programm"
-      },
-      "low_humidity": {
-        "name": "Niedrige Luftfeuchtigkeit"
-      },
-      "low_temperature": {
-        "name": "Niedrige Temperatur"
-      },
-      "machine_status": {
-        "name": "Maschinenstatus",
-        "state": {
-          "off": "Aus",
-          "standby": "Standby",
-          "running": "L\u00e4uft",
-          "paused": "Pausiert"
-        }
-      },
-      "mainwashtimeuseindex": {
-        "name": "Nutzungsindex der Hauptwaschzeit"
-      },
-      "measured_vibrations": {
-        "name": "Gemessene Vibrationen"
-      },
-      "meat_probe_measured_temperature": {
-        "name": "Gemessene Temperatur der Fleischsonde"
-      },
-      "meat_probe_set_temperature": {
-        "name": "Eingestellte Temperatur der Fleischsonde"
-      },
-      "medium_humidity": {
-        "name": "Mittlere Luftfeuchtigkeit"
-      },
-      "medium_temperature": {
-        "name": "Mittlere Temperatur"
-      },
-      "mian_wash_time": {
-        "name": "Hauptwaschzeit"
-      },
-      "notification_volumen_setting_status": {
-        "name": "Benachrichtigungslautst\u00e4rke"
-      },
-      "order_time_minimum_hour": {
-        "name": "Mindestbestellzeit in Stunden"
-      },
-      "oven_temperature": {
-        "name": "Ofentemperatur"
-      },
-      "parse_lib_ver": {
-        "name": "Bibliotheksversion analysieren"
-      },
-      "pressure_calibration_setting_status": {
-        "name": "Druckkalibrierung"
-      },
-      "program_end_to_shutdown_time_in_minutes": {
-        "name": "Zeit bis zum Herunterfahren nach Programmende (Minuten)"
-      },
-      "real_humidity": {
-        "name": "Reale Luftfeuchtigkeit"
-      },
-      "real_humidity_b": {
-        "name": "Reale Luftfeuchtigkeit B"
-      },
-      "real_humidity_c": {
-        "name": "Reale Luftfeuchtigkeit C"
-      },
-      "refrigerator_max_temperature": {
-        "name": "Maximale K\u00fchlschranktemperatur"
-      },
-      "refrigerator_min_temperature": {
-        "name": "Minimale K\u00fchlschranktemperatur"
-      },
-      "refrigerator_real_temperature": {
-        "name": "Reale K\u00fchlschranktemperatur"
-      },
-      "refrigerator_sensor_real_temperature": {
-        "name": "Reale Sensor-Temperatur des K\u00fchlschranks"
-      },
-      "rinse_aid_setting_status": {
-        "name": "Klarsp\u00fcler"
-      },
-      "rinsenum": {
-        "name": "Anzahl der Sp\u00fclg\u00e4nge"
-      },
-      "running_status": {
-        "name": "Laufstatus"
-      },
-      "sand_timer1_duration_in_seconds": {
-        "name": "Sanduhr 1 Dauer in Sekunden"
-      },
-      "sand_timer1_status": {
-        "name": "Status der Sanduhr 1",
-        "state": {
-          "started": "Gestartet",
-          "paused": "Pausiert",
-          "stopped": "Gestoppt"
-        }
-      },
-      "sand_timer2_duration_in_seconds": {
-        "name": "Dauer der Sanduhr 2"
-      },
-      "sand_timer2_status": {
-        "name": "Status der Sanduhr 2",
-        "state": {
-          "started": "Gestartet",
-          "paused": "Pausiert",
-          "stopped": "Gestoppt"
-        }
-      },
-      "sand_timer3_duration_in_seconds": {
-        "name": "Dauer der Sanduhr 3"
-      },
-      "sand_timer3_status": {
-        "name": "Status der Sanduhr 3",
-        "state": {
-          "started": "Gestartet",
-          "paused": "Pausiert",
-          "stopped": "Gestoppt"
-        }
-      },
-      "selected_program_duration_in_minutes": {
-        "name": "Programmdauer Gesamt"
-      },
-      "selected_program_id": {
-        "name": "Programm",
-        "state": {
-          "cotton_storage": "Baumwollspeicherung",
-          "standard": "Standard",
-          "iron": "B\u00fcgeln",
-          "mix": "Mischprogramm",
-          "synthetic": "Synthetik",
-          "wool": "Wolle",
-          "bed_linen": "Bettw\u00e4sche",
-          "time": "Zeitprogramm",
-          "baby": "Babymodus",
-          "sensitive": "Sensitiv",
-          "shirts": "Hemdprogramm",
-          "sports": "Sportmodus",
-          "fast89": "Schnell 89",
-          "extra_hygiene": "Extra Hygiene",
-          "remote": "Fernsteuerung",
-          "none": "Kein Programm"
-        }
-      },
-      "selected_program_id_status": {
-        "name": "Programm",
-        "state": {
-          "auto": "Automatisch",
-          "eco": "Eco",
-          "one_hour": "1 Stunde",
-          "intensive": "Intensiv",
-          "glass": "Glas",
-          "hygiene": "Hygiene",
-          "night": "Nacht",
-          "clean": "Reinigung",
-          "eco_40_60": "Eco 40-60",
-          "white_cotton": "Wei\u00dfe Baumwolle",
-          "color": "Farbig",
-          "wool_manual": "Wolle & Manuell",
-          "mix_synthetic": "Mix/Synthetik",
-          "extra_hygiene": "Extra Hygiene",
-          "fast_20": "Schnell 20'",
-          "intensive_59_32": "Intensiv 59'/32'",
-          "sport": "Sport",
-          "baby": "Baby",
-          "shirts": "Hemden",
-          "drum_cleaning": "Trommelreinigung",
-          "spinning_draining": "Schleudern & Abpumpen",
-          "rinsing_softening": "Sp\u00fclen & Weichsp\u00fclen",
-          "no_program_selected": "Kein Programm ausgew\u00e4hlt",
-          "pet_hair_removal": "Tierhaarentfernung",
-          "draining": "Abpumpen",
-          "down_feathers": "Daunenfedern"
-        }
-      },
-      "selected_program_mode": {
-        "name": "Programm Modus",
-        "state": {
-          "normal": "Normal",
-          "fast": "Schnell"
-        }
-      },
-      "selected_program_mode_status": {
-        "name": "Programm Modus",
-        "state": {
-          "not_available": "Nicht verf\u00fcgbar",
-          "normal": "Normal",
-          "fast": "Schnell",
-          "extra_fast": "Extra Schnell"
-        }
-      },
-      "selected_program_remaining_time_in_minutes": {
-        "name": "Programmdauer Verbleibend"
-      },
-      "selected_program_set_temperature_status": {
-        "name": "Programm Temperatur",
-        "state": {
-          "not_available": "Nicht verf\u00fcgbar",
-          "cold": "Kalt",
-          "20_c": "20 \u00b0C",
-          "30_c": "30 \u00b0C",
-          "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C"
-        }
-      },
-      "selected_program_total_running_time_in_minutes": {
-        "name": "Programmdauer Gesamt"
-      },
-      "selected_program_total_time_in_minutes": {
-        "name": "Programmdauer Gesamt"
-      },
-      "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Programm Schleuderdrehzahl",
-        "state": {
-          "not_available": "Nicht verf\u00fcgbar",
-          "no_spin": "Kein Schleudern",
-          "0_rpm": "0 U/min",
-          "800_rpm": "800 U/min",
-          "400_rpm": "400 U/min",
-          "1000_rpm": "1000 U/min",
-          "1200_rpm": "1200 U/min",
-          "1400_rpm": "1400 U/min"
-        }
-      },
-      "selected_programduration_inminutes": {
-        "name": "Programmdauer Gesamt"
-      },
-      "selected_programremaining_time_inminutes": {
-        "name": "Programmdauer Verbleibend"
-      },
-      "set_progress_type": {
-        "name": "Fortschrittstyp einstellen",
-        "state": {
-          "oven_set": "Ofen eingestellt",
-          "mw_set": "Mikrowelle eingestellt",
-          "mwc_set": "Mikrowelle-Kombi eingestellt",
-          "st_set": "Dampf eingestellt",
-          "stc_set": "Dampf-Kombi eingestellt",
-          "fast_set": "Schnelleinstellung",
-          "stage_set": "Stufenmodus",
-          "culi_set": "Kochmodus",
-          "warming": "Aufw\u00e4rmen",
-          "defrost": "Auftauen",
-          "cleaning": "Reinigung",
-          "pyrolysis": "Pyrolyse",
-          "none": "Kein Modus"
-        }
-      },
-      "sl1_active_timer": {
-        "name": "Aktiver Timer f\u00fcr Zone 1",
-        "state": {
-          "inactive": "Inaktiv",
-          "stopwatch": "Stoppuhr",
-          "timer": "Timer"
-        }
-      },
-      "sl1_functions": {
-        "name": "Funktion f\u00fcr Zone 1",
-        "state": {
-          "none": "Keine",
-          "boil": "Kochen",
-          "simmer": "Sanft k\u00f6cheln",
-          "keep_warm": "Warmhalten",
-          "wok": "Wok",
-          "roast": "Braten",
-          "grill": "Grillen"
-        }
-      },
-      "sl1_ntc_sensor": {
-        "name": "NTC-Sensor f\u00fcr Zone 1"
-      },
-      "sl1_power_level": {
-        "name": "Leistungsstufe f\u00fcr Zone 1"
-      },
-      "sl1_power_level_max": {
-        "name": "Maximale Leistungsstufe Zone 1"
-      },
-      "sl1_zone_shape": {
-        "name": "Form von Zone 1",
-        "state": {
-          "round": "Rund",
-          "square": "Quadratisch",
-          "rectangle_vertical": "Vertikales Rechteck",
-          "rectangle_horizontal": "Horizontales Rechteck",
-          "no_shape": "Keine Form"
-        }
-      },
-      "sl2_active_timer": {
-        "name": "Aktiver Timer f\u00fcr Zone 2",
-        "state": {
-          "inactive": "Inaktiv",
-          "stopwatch": "Stoppuhr",
-          "timer": "Timer"
-        }
-      },
-      "sl2_functions": {
-        "name": "Funktion f\u00fcr Zone 2",
-        "state": {
-          "none": "Keine",
-          "boil": "Kochen",
-          "simmer": "Sanft k\u00f6cheln",
-          "keep_warm": "Warmhalten",
-          "wok": "Wok",
-          "roast": "Braten",
-          "grill": "Grillen"
-        }
-      },
-      "sl2_ntc_sensor": {
-        "name": "NTC-Sensor f\u00fcr Zone 2"
-      },
-      "sl2_power_level": {
-        "name": "Leistungsstufe f\u00fcr Zone 2"
-      },
-      "sl2_power_level_max": {
-        "name": "Maximale Leistungsstufe Zone 2"
-      },
-      "sl2_zone_shape": {
-        "name": "Form von Zone 2",
-        "state": {
-          "round": "Rund",
-          "square": "Quadratisch",
-          "rectangle_vertical": "Vertikales Rechteck",
-          "rectangle_horizontal": "Horizontales Rechteck",
-          "no_shape": "Keine Form"
-        }
-      },
-      "sl3_active_timer": {
-        "name": "Aktiver Timer f\u00fcr Zone 3",
-        "state": {
-          "inactive": "Inaktiv",
-          "stopwatch": "Stoppuhr",
-          "timer": "Timer"
-        }
-      },
-      "sl3_functions": {
-        "name": "Funktion f\u00fcr Zone 3",
-        "state": {
-          "none": "Keine",
-          "boil": "Kochen",
-          "simmer": "Sanft k\u00f6cheln",
-          "keep_warm": "Warmhalten",
-          "wok": "Wok",
-          "roast": "Braten",
-          "grill": "Grillen"
-        }
-      },
-      "sl3_ntc_sensor": {
-        "name": "NTC-Sensor f\u00fcr Zone 3"
-      },
-      "sl3_power_level": {
-        "name": "Leistungsstufe f\u00fcr Zone 3"
-      },
-      "sl3_power_level_max": {
-        "name": "Maximale Leistungsstufe Zone 3"
-      },
-      "sl3_zone_shape": {
-        "name": "Form von Zone 3",
-        "state": {
-          "round": "Rund",
-          "square": "Quadratisch",
-          "rectangle_vertical": "Vertikales Rechteck",
-          "rectangle_horizontal": "Horizontales Rechteck",
-          "no_shape": "Keine Form"
-        }
-      },
-      "sl4_active_timer": {
-        "name": "Aktiver Timer f\u00fcr Zone 4",
-        "state": {
-          "inactive": "Inaktiv",
-          "stopwatch": "Stoppuhr",
-          "timer": "Timer"
-        }
-      },
-      "sl4_functions": {
-        "name": "Funktion f\u00fcr Zone 4",
-        "state": {
-          "none": "Keine",
-          "boil": "Kochen",
-          "simmer": "Sanft k\u00f6cheln",
-          "keep_warm": "Warmhalten",
-          "wok": "Wok",
-          "roast": "Braten",
-          "grill": "Grillen"
-        }
-      },
-      "sl4_ntc_sensor": {
-        "name": "NTC-Sensor f\u00fcr Zone 4"
-      },
-      "sl4_power_level": {
-        "name": "Leistungsstufe f\u00fcr Zone 4"
-      },
-      "sl4_power_level_max": {
-        "name": "Maximale Leistungsstufe Zone 4"
-      },
-      "sl4_zone_shape": {
-        "name": "Form von Zone 4",
-        "state": {
-          "round": "Rund",
-          "square": "Quadratisch",
-          "rectangle_vertical": "Vertikales Rechteck",
-          "rectangle_horizontal": "Horizontales Rechteck",
-          "no_shape": "Keine Form"
-        }
-      },
-      "sl5_active_timer": {
-        "name": "Aktiver Timer f\u00fcr Zone 5",
-        "state": {
-          "inactive": "Inaktiv",
-          "stopwatch": "Stoppuhr",
-          "timer": "Timer"
-        }
-      },
-      "sl5_functions": {
-        "name": "Funktion f\u00fcr Zone 5",
-        "state": {
-          "none": "Keine",
-          "boil": "Kochen",
-          "simmer": "Sanft k\u00f6cheln",
-          "keep_warm": "Warmhalten",
-          "wok": "Wok",
-          "roast": "Braten",
-          "grill": "Grillen"
-        }
-      },
-      "sl5_ntc_sensor": {
-        "name": "NTC-Sensor f\u00fcr Zone 5"
-      },
-      "sl5_power_level": {
-        "name": "Leistungsstufe f\u00fcr Zone 5"
-      },
-      "sl5_power_level_max": {
-        "name": "Maximale Leistungsstufe Zone 5"
-      },
-      "sl5_zone_shape": {
-        "name": "Form von Zone 5",
-        "state": {
-          "round": "Rund",
-          "square": "Quadratisch",
-          "rectangle_vertical": "Vertikales Rechteck",
-          "rectangle_horizontal": "Horizontales Rechteck",
-          "no_shape": "Keine Form"
-        }
-      },
-      "sl6_active_timer": {
-        "name": "Aktiver Timer f\u00fcr Zone 6",
-        "state": {
-          "inactive": "Inaktiv",
-          "stopwatch": "Stoppuhr",
-          "timer": "Timer"
-        }
-      },
-      "sl6_functions": {
-        "name": "Funktion f\u00fcr Zone 6",
-        "state": {
-          "none": "Keine",
-          "boil": "Kochen",
-          "simmer": "Sanft k\u00f6cheln",
-          "keep_warm": "Warmhalten",
-          "wok": "Wok",
-          "roast": "Braten",
-          "grill": "Grillen"
-        }
-      },
-      "sl6_ntc_sensor": {
-        "name": "NTC-Sensor f\u00fcr Zone 6"
-      },
-      "sl6_power_level": {
-        "name": "Leistungsstufe f\u00fcr Zone 6"
-      },
-      "sl6_power_level_max": {
-        "name": "Maximale Leistungsstufe Zone 6"
-      },
-      "sl6_zone_shape": {
-        "name": "Form von Zone 6",
-        "state": {
-          "round": "Rund",
-          "square": "Quadratisch",
-          "rectangle_vertical": "Vertikales Rechteck",
-          "rectangle_horizontal": "Horizontales Rechteck",
-          "no_shape": "Keine Form"
-        }
-      },
-      "softer_display": {
-        "name": "Sanfte Anzeige"
-      },
-      "sound_setting": {
-        "name": "Klangeinstellung"
-      },
-      "spin_speed_rpm": {
-        "name": "Schleudergeschwindigkeit (U/min)"
-      },
-      "spin_time": {
-        "name": "Schleuderzeit"
-      },
-      "spintime_index": {
-        "name": "Schleuderzeit-Index"
-      },
-      "status": {
-        "name": "Ger\u00e4testatus",
-        "state": {
-          "off": "Aus",
-          "standby": "Standby",
-          "running": "L\u00e4uft",
-          "not_avaliable": "Nicht verf\u00fcgbar",
-          "idle": "Bereit",
-          "pause": "Pause",
-          "production": "Produktion",
-          "delay_time_waiting": "Startverz\u00f6gerung",
-          "error": "Fehler"
-        }
-      },
-      "step1_duration": {
-        "name": "Dauer Schritt 1"
-      },
-      "step1_heater_system": {
-        "name": "Heizsystem Schritt 1",
-        "state": {
-          "hot_air": "Hei\u00dfluft",
-          "eco_hot_air": "Eco-Hei\u00dfluft",
-          "top_bottom": "Ober-/Unterhitze",
-          "hot_air_bottom": "Hei\u00dfluft unten",
-          "bottom_fan": "Unterhitze mit Ventilator",
-          "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "small_grill": "Kleiner Grill",
-          "large_grill": "Gro\u00dfer Grill",
-          "large_grill_fan": "Gro\u00dfer Grill mit Ventilator",
-          "pro_roasting": "Pro-Braten",
-          "hotairmicro": "Hei\u00dfluft-Mikrowelle",
-          "grillfanmicro": "Grillventilator-Mikrowelle",
-          "micro": "Mikrowelle",
-          "hot_air_steam_1": "Hei\u00dfluft-Dampf 1",
-          "hot_air_steam_2": "Hei\u00dfluft-Dampf 2",
-          "hot_air_steam_3": "Hei\u00dfluft-Dampf 3",
-          "fast_preheat": "Schnelles Vorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
-          "keep_warm": "Warmhalten",
-          "plates": "Tellerw\u00e4rmer",
-          "aqua_clean": "Aqua-Clean",
-          "steam_clean": "Dampf-Reinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "microwave_defrost": "Mikrowellen-Auftauen",
-          "sous_vide": "Sous-Vide",
-          "low_temp_steam": "Niedrigtemperatur-Dampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "clean_air": "Luft-Reinigung",
-          "defrost_auto": "Automatisches Auftauen",
-          "sabbath": "Sabbatmodus",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "microwave_clean": "Mikrowellen-Reinigung",
-          "hot_air_micro": "Hei\u00dfluft-Mikrowelle",
-          "grill_fan_micro": "Grillventilator-Mikrowelle"
-        }
-      },
-      "step1_remaining_time": {
-        "name": "Verbleibende Zeit Schritt 1"
-      },
-      "step1_set_temperature": {
-        "name": "Eingestellte Temperatur Schritt 1"
-      },
-      "step2_duration": {
-        "name": "Dauer Schritt 2"
-      },
-      "step2_heater_system": {
-        "name": "Heizsystem Schritt 2",
-        "state": {
-          "hot_air": "Hei\u00dfluft",
-          "eco_hot_air": "Eco-Hei\u00dfluft",
-          "top_bottom": "Ober-/Unterhitze",
-          "hot_air_bottom": "Hei\u00dfluft unten",
-          "bottom_fan": "Unterhitze mit Ventilator",
-          "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "small_grill": "Kleiner Grill",
-          "large_grill": "Gro\u00dfer Grill",
-          "large_grill_fan": "Gro\u00dfer Grill mit Ventilator",
-          "pro_roasting": "Pro-Braten",
-          "hot_air_micro": "Hei\u00dfluft-Mikrowelle",
-          "grill_fan_micro": "Grillventilator-Mikrowelle",
-          "micro": "Mikrowelle",
-          "hot_air_steam_1": "Hei\u00dfluft-Dampf 1",
-          "hot_air_steam_2": "Hei\u00dfluft-Dampf 2",
-          "hot_air_steam_3": "Hei\u00dfluft-Dampf 3",
-          "fast_preheat": "Schnelles Vorheizen",
-          "pyrolysis": "Pyrolyse",
-          "defrost": "Auftauen",
-          "keep_warm": "Warmhalten",
-          "plates": "Tellerw\u00e4rmer",
-          "aqua_clean": "Aqua-Clean",
-          "steam_clean": "Dampf-Reinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "microwave_defrost": "Mikrowellen-Auftauen",
-          "sous_vide": "Sous-Vide",
-          "low_temp_steam": "Niedrigtemperatur-Dampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "clean_air": "Luft-Reinigung",
-          "defrost_auto": "Automatisches Auftauen",
-          "sabbath": "Sabbatmodus",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "microwave_clean": "Mikrowellen-Reinigung"
-        }
-      },
-      "step2_remaining_time": {
-        "name": "Verbleibende Zeit Schritt 2"
-      },
-      "step2_set_temperature": {
-        "name": "Eingestellte Temperatur Schritt 2"
-      },
-      "step3_duration": {
-        "name": "Dauer Schritt 3"
-      },
-      "step3_heater_system": {
-        "name": "Heizsystem Schritt 3",
-        "state": {
-          "hot_air": "Hei\u00dfluft",
-          "eco_hot_air": "Eco-Hei\u00dfluft",
-          "top_bottom": "Ober-/Unterhitze",
-          "hot_air_bottom": "Hei\u00dfluft unten",
-          "bottom_fan": "Unterhitze mit Ventilator",
-          "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "small_grill": "Kleiner Grill",
-          "large_grill": "Gro\u00dfer Grill",
-          "large_grill_fan": "Gro\u00dfer Grill mit Ventilator",
-          "pro_roasting": "Pro-Braten",
-          "hot_air_micro": "Hei\u00dfluft-Mikrowelle",
-          "grill_fan_micro": "Grillventilator-Mikrowelle",
-          "micro": "Mikrowelle",
-          "hot_air_steam_1": "Hei\u00dfluft-Dampf 1",
-          "hot_air_steam_2": "Hei\u00dfluft-Dampf 2",
-          "hot_air_steam_3": "Hei\u00dfluft-Dampf 3",
-          "fast_preheat": "Schnelles Vorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
-          "keep_warm": "Warmhalten",
-          "plates": "Tellerw\u00e4rmer",
-          "aqua_clean": "Aqua-Clean",
-          "steam_clean": "Dampf-Reinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "microwave_defrost": "Mikrowellen-Auftauen",
-          "sous_vide": "Sous-Vide",
-          "low_temp_steam": "Niedrigtemperatur-Dampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "clean_air": "Luft-Reinigung",
-          "defrost_auto": "Automatisches Auftauen",
-          "sabbath": "Sabbatmodus",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "microwave_clean": "Mikrowellen-Reinigung"
-        }
-      },
-      "step3_remaining_time": {
-        "name": "Verbleibende Zeit Schritt 3"
-      },
-      "step3_set_temperature": {
-        "name": "Eingestellte Temperatur Schritt 3"
-      },
-      "super_rinse_setting_status": {
-        "name": "Super-Sp\u00fclung"
-      },
-      "t_sleep": {
-        "name": "Schlafmodus"
-      },
-      "temperature": {
-        "name": "Temperatur"
-      },
-      "temperature_default_defaultmainwashtime": {
-        "name": "Standardtemperatur f\u00fcr Hauptwaschzeit"
-      },
-      "temperature_room_judge": {
-        "name": "Temperaturraum-Beurteilung"
-      },
-      "total_energy_consumption": {
-        "name": "Gesamter Energieverbrauch"
-      },
-      "total_number_of_cycles": {
-        "name": "Gesamtanzahl der Zyklen"
-      },
-      "total_passed_time": {
-        "name": "Gesamte vergangene Zeit"
-      },
-      "total_remaining_time": {
-        "name": "Gesamte verbleibende Zeit"
-      },
-      "total_run_time": {
-        "name": "Gesamtlaufzeit"
-      },
-      "total_time_of_cooking_in_hours": {
-        "name": "Gesamte Kochzeit"
-      },
-      "total_water_consumption": {
-        "name": "Gesamter Wasserverbrauch"
-      },
-      "utc_datetime_bdc_delaystart_delayend_timestamp": {
-        "name": "BDC Verz\u00f6gerungsstart Verz\u00f6gerungsende"
-      },
-      "variation_max_temperature": {
-        "name": "Maximale Temperatur der Variation"
-      },
-      "variation_min_temperature": {
-        "name": "Minimale Temperatur der Variation"
-      },
-      "variation_real_temperature": {
-        "name": "Reale Temperatur der Variation"
-      },
-      "variation_sensor_real_temperature": {
-        "name": "Reale Sensortemperatur der Variation"
-      },
-      "variation_temperature": {
-        "name": "Temperatur der Variation"
-      },
-      "washing_machine_type_kg": {
-        "name": "Waschmaschinentyp (kg)"
-      },
-      "washing_machine_type_max_speed": {
-        "name": "Maximale Geschwindigkeit des Waschmaschinentyps"
-      },
-      "water_consumption": {
-        "name": "Wasserverbrauch"
-      },
-      "water_consumption_in_running_program": {
-        "name": "Wasserverbrauch im laufenden Programm"
-      },
-      "water_consumption_int": {
-        "name": "Wasserverbrauch"
-      },
-      "water_hardness_setting_status": {
-        "name": "Wasserh\u00e4rte",
-        "state": {
-          "not_set": "Nicht eingestellt"
-        }
-      },
-      "water_inlet_setting_status": {
-        "name": "Wasserzulauf"
-      },
-      "water_save_setting_status": {
-        "name": "Wassersparmodus"
-      },
-      "zone_number": {
-        "name": "Anzahl der Zonen"
-      },
-      "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Bald-fertig-Benachrichtigung Timer"
-      },
-      "autodose_flag": {
-        "name": "Autodosierung Kennzeichen",
-        "state": {
-          "unavailable": "Nicht verf\u00fcgbar",
-          "available": "Verf\u00fcgbar"
-        }
-      },
-      "crisp_function_available": {
-        "name": "Knusperfunktion verf\u00fcgbar",
-        "state": {
-          "function_available": "Funktion verf\u00fcgbar",
-          "function_not_available": "Funktion nicht verf\u00fcgbar"
-        }
-      },
-      "detergent": {
-        "name": "Waschmittel",
-        "state": {
-          "less": "Weniger",
-          "standard": "Standard",
-          "more": "Mehr"
-        }
-      },
-      "detergentstandarddosage": {
-        "name": "Waschmittel Standarddosierung",
-        "state": {
-          "10ml": "10 ml",
-          "15ml": "15 ml",
-          "20ml": "20 ml",
-          "25ml": "25 ml",
-          "30ml": "30 ml",
-          "35ml": "35 ml",
-          "40ml": "40 ml",
-          "45ml": "45 ml",
-          "50ml": "50 ml",
-          "55ml": "55 ml",
-          "60ml": "60 ml",
-          "65ml": "65 ml",
-          "70ml": "70 ml",
-          "75ml": "75 ml",
-          "80ml": "80 ml",
-          "85ml": "85 ml",
-          "90ml": "90 ml",
-          "95ml": "95 ml",
-          "100ml": "100 ml"
-        }
-      },
-      "display_switch_to_standby_after_minutes": {
-        "name": "Display Standby nach Minuten",
-        "state": {
-          "5_min": "5 min",
-          "15_min": "15 min",
-          "30_min": "30 min"
-        }
-      },
-      "dryopen_defaultspinspeed": {
-        "name": "Standard Schleudergeschwindigkeit"
-      },
-      "error_code": {
-        "name": "Fehlercode",
-        "state": {
-          "none": "Keine",
-          "error_f01": "Fehler f01",
-          "error_f03": "Fehler f03",
-          "error_f04": "Fehler f04",
-          "error_f05": "Fehler f05",
-          "error_f06": "Fehler f06",
-          "error_f07": "Fehler f07",
-          "error_f13": "Fehler f13",
-          "error_f14": "Fehler f14",
-          "error_f15": "Fehler f15",
-          "error_f16": "Fehler f16",
-          "error_f17": "Fehler f17",
-          "error_f18": "Fehler f18",
-          "error_f23": "Fehler f23",
-          "error_f24": "Fehler f24"
-        }
-      },
-      "factory_reset": {
-        "name": "Werksreset"
-      },
-      "filter_state": {
-        "name": "Filterzustand"
-      },
-      "fota": {
-        "name": "Firmware-Update",
-        "state": {
-          "not_available": "Nicht verf\u00fcgbar",
-          "waiting_for_confirmation": "Warte auf Best\u00e4tigung",
-          "in_progress": "In Bearbeitung",
-          "finished": "Abgeschlossen",
-          "confirm_fota": "Firmware-Update best\u00e4tigen"
-        }
-      },
-      "freeze_door_open_time": {
-        "name": "Gefrierfach T\u00fcr \u00d6ffnungszeit"
-      },
       "freeze_temperature": {
         "name": "Gefriertemperatur"
+      },
+      "fruit_vegetables_temperature": {
+        "name": "Frucht- und Gem\u00fcse-Temperatur"
       },
       "gratin_total_allowed_time_in_minutes": {
         "name": "Gratin erlaubte Gesamtzeit"
@@ -2485,18 +2093,27 @@
       "hardpairingstatus": {
         "name": "Hard-Kopplung Status",
         "state": {
-          "not_active": "Nicht aktiv",
           "active": "Aktiv",
-          "unpair_all_users": "Alle Benutzer entkoppeln",
-          "reserved": "Reserviert"
+          "not_active": "Nicht aktiv",
+          "reserved": "Reserviert",
+          "unpair_all_users": "Alle Benutzer entkoppeln"
         }
+      },
+      "heat_pump_setting_status": {
+        "name": "W\u00e4rmepumpe"
+      },
+      "high_humidity": {
+        "name": "Hohe Luftfeuchtigkeit"
+      },
+      "high_temperature": {
+        "name": "Hohe Temperatur"
       },
       "hob_warming_zone_power_level": {
         "name": "Kochfeld Warmhaltezone Leistungsstufe",
         "state": {
+          "high": "Hoch",
           "low": "Niedrig",
-          "medium": "Mittel",
-          "high": "Hoch"
+          "medium": "Mittel"
         }
       },
       "hob_zone_1_status": {
@@ -2529,16 +2146,64 @@
           "off_hot": "Aus (hei\u00df)"
         }
       },
+      "interior_light_at_power_off_setting_status": {
+        "name": "Innenbeleuchtung bei ausgeschaltetem Ger\u00e4t"
+      },
+      "interior_light_status": {
+        "name": "Innenbeleuchtungsstatus"
+      },
+      "language_status": {
+        "name": "Sprache"
+      },
+      "last_run_program_id": {
+        "name": "Letztes ausgef\u00fchrtes Programm"
+      },
+      "low_humidity": {
+        "name": "Niedrige Luftfeuchtigkeit"
+      },
+      "low_temperature": {
+        "name": "Niedrige Temperatur"
+      },
+      "machine_status": {
+        "name": "Maschinenstatus",
+        "state": {
+          "off": "Aus",
+          "paused": "Pausiert",
+          "running": "L\u00e4uft",
+          "standby": "Standby"
+        }
+      },
       "mainwashtime": {
         "name": "Hauptwaschzeit"
+      },
+      "mainwashtimeuseindex": {
+        "name": "Nutzungsindex der Hauptwaschzeit"
+      },
+      "measured_vibrations": {
+        "name": "Gemessene Vibrationen"
+      },
+      "meat_probe_measured_temperature": {
+        "name": "Gemessene Temperatur der Fleischsonde"
+      },
+      "meat_probe_set_temperature": {
+        "name": "Eingestellte Temperatur der Fleischsonde"
       },
       "meat_probe_status": {
         "name": "Fleischthermometer Status",
         "state": {
-          "not_active": "Nicht aktiv",
+          "active_hob": "Kochfeld aktiv",
           "active_oven": "Ofen aktiv",
-          "active_hob": "Kochfeld aktiv"
+          "not_active": "Nicht aktiv"
         }
+      },
+      "medium_humidity": {
+        "name": "Mittlere Luftfeuchtigkeit"
+      },
+      "medium_temperature": {
+        "name": "Mittlere Temperatur"
+      },
+      "mian_wash_time": {
+        "name": "Hauptwaschzeit"
       },
       "night_mode_off_hour": {
         "name": "Nachtmodus Aus Stunde"
@@ -2552,8 +2217,17 @@
       "night_mode_on_minute": {
         "name": "Nachtmodus Ein Minute"
       },
+      "notification_volumen_setting_status": {
+        "name": "Benachrichtigungslautst\u00e4rke"
+      },
+      "order_time_minimum_hour": {
+        "name": "Mindestbestellzeit in Stunden"
+      },
       "oven_measured_temperature": {
         "name": "Ofentemperatur gemessen"
+      },
+      "oven_temperature": {
+        "name": "Ofentemperatur"
       },
       "oven_temperature_unit_setting": {
         "name": "Ofen Temperatureinheit",
@@ -2571,14 +2245,86 @@
       "parse_lib_ota": {
         "name": "Parse-Lib OTA"
       },
+      "parse_lib_ver": {
+        "name": "Bibliotheksversion analysieren"
+      },
+      "pressure_calibration_setting_status": {
+        "name": "Druckkalibrierung"
+      },
+      "program_end_to_shutdown_time_in_minutes": {
+        "name": "Zeit bis zum Herunterfahren nach Programmende (Minuten)"
+      },
+      "real_humidity": {
+        "name": "Reale Luftfeuchtigkeit"
+      },
+      "real_humidity_b": {
+        "name": "Reale Luftfeuchtigkeit B"
+      },
+      "real_humidity_c": {
+        "name": "Reale Luftfeuchtigkeit C"
+      },
       "refrigerator_door_open_time": {
         "name": "K\u00fchlschrankt\u00fcr \u00d6ffnungszeit"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Maximale K\u00fchlschranktemperatur"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Minimale K\u00fchlschranktemperatur"
+      },
+      "refrigerator_real_temperature": {
+        "name": "Reale K\u00fchlschranktemperatur"
+      },
+      "refrigerator_sensor_real_temperature": {
+        "name": "Reale Sensor-Temperatur des K\u00fchlschranks"
       },
       "refrigerator_temperature": {
         "name": "K\u00fchlschranktemperatur"
       },
       "remaining_time_of_selected_program": {
         "name": "Verbleibende Zeit des gew\u00e4hlten Programms"
+      },
+      "rinse_aid_setting_status": {
+        "name": "Klarsp\u00fcler"
+      },
+      "rinsenum": {
+        "name": "Anzahl der Sp\u00fclg\u00e4nge"
+      },
+      "running_status": {
+        "name": "Laufstatus"
+      },
+      "sand_timer1_duration_in_seconds": {
+        "name": "Sanduhr 1 Dauer in Sekunden"
+      },
+      "sand_timer1_status": {
+        "name": "Status der Sanduhr 1",
+        "state": {
+          "paused": "Pausiert",
+          "started": "Gestartet",
+          "stopped": "Gestoppt"
+        }
+      },
+      "sand_timer2_duration_in_seconds": {
+        "name": "Dauer der Sanduhr 2"
+      },
+      "sand_timer2_status": {
+        "name": "Status der Sanduhr 2",
+        "state": {
+          "paused": "Pausiert",
+          "started": "Gestartet",
+          "stopped": "Gestoppt"
+        }
+      },
+      "sand_timer3_duration_in_seconds": {
+        "name": "Dauer der Sanduhr 3"
+      },
+      "sand_timer3_status": {
+        "name": "Status der Sanduhr 3",
+        "state": {
+          "paused": "Pausiert",
+          "started": "Gestartet",
+          "stopped": "Gestoppt"
+        }
       },
       "sand_timer_1_duration_hours": {
         "name": "Timer 1 Dauer Stunden"
@@ -2601,11 +2347,11 @@
       "sand_timer_1_status": {
         "name": "Timer 1 Status",
         "state": {
+          "ended": "Beendet",
           "not_active": "Nicht aktiv",
-          "running": "L\u00e4uft",
           "paused": "Pausiert",
-          "stopped": "Gestoppt",
-          "ended": "Beendet"
+          "running": "L\u00e4uft",
+          "stopped": "Gestoppt"
         }
       },
       "sand_timer_2_duration_hours": {
@@ -2629,11 +2375,11 @@
       "sand_timer_2_status": {
         "name": "Timer 2 Status",
         "state": {
+          "ended": "Beendet",
           "not_active": "Nicht aktiv",
-          "running": "L\u00e4uft",
           "paused": "Pausiert",
-          "stopped": "Gestoppt",
-          "ended": "Beendet"
+          "running": "L\u00e4uft",
+          "stopped": "Gestoppt"
         }
       },
       "sand_timer_3_duration_hours": {
@@ -2657,23 +2403,151 @@
       "sand_timer_3_status": {
         "name": "Timer 3 Status",
         "state": {
+          "ended": "Beendet",
           "not_active": "Nicht aktiv",
-          "running": "L\u00e4uft",
           "paused": "Pausiert",
-          "stopped": "Gestoppt",
-          "ended": "Beendet"
+          "running": "L\u00e4uft",
+          "stopped": "Gestoppt"
         }
       },
       "scanned_ean_code": {
         "name": "Gescannter EAN-Code"
       },
+      "selected_program_duration_in_minutes": {
+        "name": "Programmdauer Gesamt"
+      },
+      "selected_program_id": {
+        "name": "Programm",
+        "state": {
+          "baby": "Babymodus",
+          "bed_linen": "Bettw\u00e4sche",
+          "cotton_storage": "Baumwollspeicherung",
+          "extra_hygiene": "Extra Hygiene",
+          "fast89": "Schnell 89",
+          "iron": "B\u00fcgeln",
+          "mix": "Mischprogramm",
+          "none": "Kein Programm",
+          "remote": "Fernsteuerung",
+          "sensitive": "Sensitiv",
+          "shirts": "Hemdprogramm",
+          "sports": "Sportmodus",
+          "standard": "Standard",
+          "synthetic": "Synthetik",
+          "time": "Zeitprogramm",
+          "wool": "Wolle"
+        }
+      },
+      "selected_program_id_status": {
+        "name": "Programm",
+        "state": {
+          "auto": "Automatisch",
+          "baby": "Baby",
+          "clean": "Reinigung",
+          "color": "Farbig",
+          "down_feathers": "Daunenfedern",
+          "draining": "Abpumpen",
+          "drum_cleaning": "Trommelreinigung",
+          "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Extra Hygiene",
+          "fast_20": "Schnell 20'",
+          "glass": "Glas",
+          "hygiene": "Hygiene",
+          "intensive": "Intensiv",
+          "intensive_59_32": "Intensiv 59'/32'",
+          "mix_synthetic": "Mix/Synthetik",
+          "night": "Nacht",
+          "no_program_selected": "Kein Programm ausgew\u00e4hlt",
+          "one_hour": "1 Stunde",
+          "pet_hair_removal": "Tierhaarentfernung",
+          "rinsing_softening": "Sp\u00fclen & Weichsp\u00fclen",
+          "shirts": "Hemden",
+          "spinning_draining": "Schleudern & Abpumpen",
+          "sport": "Sport",
+          "white_cotton": "Wei\u00dfe Baumwolle",
+          "wool_manual": "Wolle & Manuell"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Programm Modus",
+        "state": {
+          "fast": "Schnell",
+          "normal": "Normal"
+        }
+      },
+      "selected_program_mode_status": {
+        "name": "Programm Modus",
+        "state": {
+          "extra_fast": "Extra Schnell",
+          "fast": "Schnell",
+          "normal": "Normal",
+          "not_available": "Nicht verf\u00fcgbar"
+        }
+      },
+      "selected_program_remaining_time_in_minutes": {
+        "name": "Programmdauer Verbleibend"
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Programm Temperatur",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "cold": "Kalt",
+          "not_available": "Nicht verf\u00fcgbar"
+        }
+      },
+      "selected_program_total_running_time_in_minutes": {
+        "name": "Programmdauer Gesamt"
+      },
+      "selected_program_total_time_in_minutes": {
+        "name": "Programmdauer Gesamt"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Programm Schleuderdrehzahl",
+        "state": {
+          "0_rpm": "0 U/min",
+          "1000_rpm": "1000 U/min",
+          "1200_rpm": "1200 U/min",
+          "1400_rpm": "1400 U/min",
+          "400_rpm": "400 U/min",
+          "800_rpm": "800 U/min",
+          "no_spin": "Kein Schleudern",
+          "not_available": "Nicht verf\u00fcgbar"
+        }
+      },
+      "selected_programduration_inminutes": {
+        "name": "Programmdauer Gesamt"
+      },
+      "selected_programremaining_time_inminutes": {
+        "name": "Programmdauer Verbleibend"
+      },
       "session_pairing_active": {
         "name": "Sitzungskopplung aktiv",
         "state": {
+          "close_session": "Sitzung schlie\u00dfen",
           "no_active_session": "Keine aktive Sitzung",
           "request_denied": "Anfrage abgelehnt",
-          "session_is_active": "Sitzung ist aktiv",
-          "close_session": "Sitzung schlie\u00dfen"
+          "session_is_active": "Sitzung ist aktiv"
+        }
+      },
+      "set_progress_type": {
+        "name": "Fortschrittstyp einstellen",
+        "state": {
+          "cleaning": "Reinigung",
+          "culi_set": "Kochmodus",
+          "defrost": "Auftauen",
+          "fast_set": "Schnelleinstellung",
+          "mw_set": "Mikrowelle eingestellt",
+          "mwc_set": "Mikrowelle-Kombi eingestellt",
+          "none": "Kein Modus",
+          "oven_set": "Ofen eingestellt",
+          "pyrolysis": "Pyrolyse",
+          "st_set": "Dampf eingestellt",
+          "stage_set": "Stufenmodus",
+          "stc_set": "Dampf-Kombi eingestellt",
+          "warming": "Aufw\u00e4rmen"
         }
       },
       "set_time_hour": {
@@ -2697,17 +2571,255 @@
       "settings_year": {
         "name": "Einstellungen Jahr"
       },
+      "sl1_active_timer": {
+        "name": "Aktiver Timer f\u00fcr Zone 1",
+        "state": {
+          "inactive": "Inaktiv",
+          "stopwatch": "Stoppuhr",
+          "timer": "Timer"
+        }
+      },
+      "sl1_functions": {
+        "name": "Funktion f\u00fcr Zone 1",
+        "state": {
+          "boil": "Kochen",
+          "grill": "Grillen",
+          "keep_warm": "Warmhalten",
+          "none": "Keine",
+          "roast": "Braten",
+          "simmer": "Sanft k\u00f6cheln",
+          "wok": "Wok"
+        }
+      },
+      "sl1_ntc_sensor": {
+        "name": "NTC-Sensor f\u00fcr Zone 1"
+      },
+      "sl1_power_level": {
+        "name": "Leistungsstufe f\u00fcr Zone 1"
+      },
+      "sl1_power_level_max": {
+        "name": "Maximale Leistungsstufe Zone 1"
+      },
+      "sl1_zone_shape": {
+        "name": "Form von Zone 1",
+        "state": {
+          "no_shape": "Keine Form",
+          "rectangle_horizontal": "Horizontales Rechteck",
+          "rectangle_vertical": "Vertikales Rechteck",
+          "round": "Rund",
+          "square": "Quadratisch"
+        }
+      },
+      "sl2_active_timer": {
+        "name": "Aktiver Timer f\u00fcr Zone 2",
+        "state": {
+          "inactive": "Inaktiv",
+          "stopwatch": "Stoppuhr",
+          "timer": "Timer"
+        }
+      },
+      "sl2_functions": {
+        "name": "Funktion f\u00fcr Zone 2",
+        "state": {
+          "boil": "Kochen",
+          "grill": "Grillen",
+          "keep_warm": "Warmhalten",
+          "none": "Keine",
+          "roast": "Braten",
+          "simmer": "Sanft k\u00f6cheln",
+          "wok": "Wok"
+        }
+      },
+      "sl2_ntc_sensor": {
+        "name": "NTC-Sensor f\u00fcr Zone 2"
+      },
+      "sl2_power_level": {
+        "name": "Leistungsstufe f\u00fcr Zone 2"
+      },
+      "sl2_power_level_max": {
+        "name": "Maximale Leistungsstufe Zone 2"
+      },
+      "sl2_zone_shape": {
+        "name": "Form von Zone 2",
+        "state": {
+          "no_shape": "Keine Form",
+          "rectangle_horizontal": "Horizontales Rechteck",
+          "rectangle_vertical": "Vertikales Rechteck",
+          "round": "Rund",
+          "square": "Quadratisch"
+        }
+      },
+      "sl3_active_timer": {
+        "name": "Aktiver Timer f\u00fcr Zone 3",
+        "state": {
+          "inactive": "Inaktiv",
+          "stopwatch": "Stoppuhr",
+          "timer": "Timer"
+        }
+      },
+      "sl3_functions": {
+        "name": "Funktion f\u00fcr Zone 3",
+        "state": {
+          "boil": "Kochen",
+          "grill": "Grillen",
+          "keep_warm": "Warmhalten",
+          "none": "Keine",
+          "roast": "Braten",
+          "simmer": "Sanft k\u00f6cheln",
+          "wok": "Wok"
+        }
+      },
+      "sl3_ntc_sensor": {
+        "name": "NTC-Sensor f\u00fcr Zone 3"
+      },
+      "sl3_power_level": {
+        "name": "Leistungsstufe f\u00fcr Zone 3"
+      },
+      "sl3_power_level_max": {
+        "name": "Maximale Leistungsstufe Zone 3"
+      },
+      "sl3_zone_shape": {
+        "name": "Form von Zone 3",
+        "state": {
+          "no_shape": "Keine Form",
+          "rectangle_horizontal": "Horizontales Rechteck",
+          "rectangle_vertical": "Vertikales Rechteck",
+          "round": "Rund",
+          "square": "Quadratisch"
+        }
+      },
+      "sl4_active_timer": {
+        "name": "Aktiver Timer f\u00fcr Zone 4",
+        "state": {
+          "inactive": "Inaktiv",
+          "stopwatch": "Stoppuhr",
+          "timer": "Timer"
+        }
+      },
+      "sl4_functions": {
+        "name": "Funktion f\u00fcr Zone 4",
+        "state": {
+          "boil": "Kochen",
+          "grill": "Grillen",
+          "keep_warm": "Warmhalten",
+          "none": "Keine",
+          "roast": "Braten",
+          "simmer": "Sanft k\u00f6cheln",
+          "wok": "Wok"
+        }
+      },
+      "sl4_ntc_sensor": {
+        "name": "NTC-Sensor f\u00fcr Zone 4"
+      },
+      "sl4_power_level": {
+        "name": "Leistungsstufe f\u00fcr Zone 4"
+      },
+      "sl4_power_level_max": {
+        "name": "Maximale Leistungsstufe Zone 4"
+      },
+      "sl4_zone_shape": {
+        "name": "Form von Zone 4",
+        "state": {
+          "no_shape": "Keine Form",
+          "rectangle_horizontal": "Horizontales Rechteck",
+          "rectangle_vertical": "Vertikales Rechteck",
+          "round": "Rund",
+          "square": "Quadratisch"
+        }
+      },
+      "sl5_active_timer": {
+        "name": "Aktiver Timer f\u00fcr Zone 5",
+        "state": {
+          "inactive": "Inaktiv",
+          "stopwatch": "Stoppuhr",
+          "timer": "Timer"
+        }
+      },
+      "sl5_functions": {
+        "name": "Funktion f\u00fcr Zone 5",
+        "state": {
+          "boil": "Kochen",
+          "grill": "Grillen",
+          "keep_warm": "Warmhalten",
+          "none": "Keine",
+          "roast": "Braten",
+          "simmer": "Sanft k\u00f6cheln",
+          "wok": "Wok"
+        }
+      },
+      "sl5_ntc_sensor": {
+        "name": "NTC-Sensor f\u00fcr Zone 5"
+      },
+      "sl5_power_level": {
+        "name": "Leistungsstufe f\u00fcr Zone 5"
+      },
+      "sl5_power_level_max": {
+        "name": "Maximale Leistungsstufe Zone 5"
+      },
+      "sl5_zone_shape": {
+        "name": "Form von Zone 5",
+        "state": {
+          "no_shape": "Keine Form",
+          "rectangle_horizontal": "Horizontales Rechteck",
+          "rectangle_vertical": "Vertikales Rechteck",
+          "round": "Rund",
+          "square": "Quadratisch"
+        }
+      },
+      "sl6_active_timer": {
+        "name": "Aktiver Timer f\u00fcr Zone 6",
+        "state": {
+          "inactive": "Inaktiv",
+          "stopwatch": "Stoppuhr",
+          "timer": "Timer"
+        }
+      },
+      "sl6_functions": {
+        "name": "Funktion f\u00fcr Zone 6",
+        "state": {
+          "boil": "Kochen",
+          "grill": "Grillen",
+          "keep_warm": "Warmhalten",
+          "none": "Keine",
+          "roast": "Braten",
+          "simmer": "Sanft k\u00f6cheln",
+          "wok": "Wok"
+        }
+      },
+      "sl6_ntc_sensor": {
+        "name": "NTC-Sensor f\u00fcr Zone 6"
+      },
+      "sl6_power_level": {
+        "name": "Leistungsstufe f\u00fcr Zone 6"
+      },
+      "sl6_power_level_max": {
+        "name": "Maximale Leistungsstufe Zone 6"
+      },
+      "sl6_zone_shape": {
+        "name": "Form von Zone 6",
+        "state": {
+          "no_shape": "Keine Form",
+          "rectangle_horizontal": "Horizontales Rechteck",
+          "rectangle_vertical": "Vertikales Rechteck",
+          "round": "Rund",
+          "square": "Quadratisch"
+        }
+      },
       "softener": {
         "name": "Weichsp\u00fcler",
         "state": {
           "less": "Weniger",
-          "standard": "Standard",
-          "more": "Mehr"
+          "more": "Mehr",
+          "standard": "Standard"
         }
+      },
+      "softer_display": {
+        "name": "Sanfte Anzeige"
       },
       "softnerstandarddosage": {
         "name": "Weichsp\u00fcler Standarddosierung",
         "state": {
+          "100ml": "100 ml",
           "10ml": "10 ml",
           "15ml": "15 ml",
           "20ml": "20 ml",
@@ -2725,44 +2837,224 @@
           "80ml": "80 ml",
           "85ml": "85 ml",
           "90ml": "90 ml",
-          "95ml": "95 ml",
-          "100ml": "100 ml"
+          "95ml": "95 ml"
+        }
+      },
+      "sound_setting": {
+        "name": "Klangeinstellung"
+      },
+      "spin_speed_rpm": {
+        "name": "Schleudergeschwindigkeit (U/min)"
+      },
+      "spin_time": {
+        "name": "Schleuderzeit"
+      },
+      "spintime_index": {
+        "name": "Schleuderzeit-Index"
+      },
+      "status": {
+        "name": "Ger\u00e4testatus",
+        "state": {
+          "delay_time_waiting": "Startverz\u00f6gerung",
+          "error": "Fehler",
+          "idle": "Bereit",
+          "not_avaliable": "Nicht verf\u00fcgbar",
+          "off": "Aus",
+          "pause": "Pause",
+          "production": "Produktion",
+          "running": "L\u00e4uft",
+          "standby": "Standby"
         }
       },
       "steam_assist_time_used": {
         "name": "Dampfunterst\u00fctzung verwendete Zeit"
       },
+      "step1_duration": {
+        "name": "Dauer Schritt 1"
+      },
+      "step1_heater_system": {
+        "name": "Heizsystem Schritt 1",
+        "state": {
+          "aqua_clean": "Aqua-Clean",
+          "bottom": "Unterhitze",
+          "bottom_fan": "Unterhitze mit Ventilator",
+          "clean_air": "Luft-Reinigung",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisches Auftauen",
+          "descale": "Entkalken",
+          "eco_hot_air": "Eco-Hei\u00dfluft",
+          "fast_preheat": "Schnelles Vorheizen",
+          "grill_fan_micro": "Grillventilator-Mikrowelle",
+          "grillfanmicro": "Grillventilator-Mikrowelle",
+          "hot_air": "Hei\u00dfluft",
+          "hot_air_bottom": "Hei\u00dfluft unten",
+          "hot_air_micro": "Hei\u00dfluft-Mikrowelle",
+          "hot_air_steam_1": "Hei\u00dfluft-Dampf 1",
+          "hot_air_steam_2": "Hei\u00dfluft-Dampf 2",
+          "hot_air_steam_3": "Hei\u00dfluft-Dampf 3",
+          "hotairmicro": "Hei\u00dfluft-Mikrowelle",
+          "keep_warm": "Warmhalten",
+          "large_grill": "Gro\u00dfer Grill",
+          "large_grill_fan": "Gro\u00dfer Grill mit Ventilator",
+          "low_temp_steam": "Niedrigtemperatur-Dampf",
+          "micro": "Mikrowelle",
+          "microwave_clean": "Mikrowellen-Reinigung",
+          "microwave_defrost": "Mikrowellen-Auftauen",
+          "plates": "Tellerw\u00e4rmer",
+          "pro_roasting": "Pro-Braten",
+          "programs": "Programme",
+          "pyro": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbatmodus",
+          "small_grill": "Kleiner Grill",
+          "sous_vide": "Sous-Vide",
+          "steam": "Dampf",
+          "steam_clean": "Dampf-Reinigung",
+          "top": "Oberhitze",
+          "top_bottom": "Ober-/Unterhitze",
+          "warming": "Aufw\u00e4rmen"
+        }
+      },
+      "step1_remaining_time": {
+        "name": "Verbleibende Zeit Schritt 1"
+      },
+      "step1_set_temperature": {
+        "name": "Eingestellte Temperatur Schritt 1"
+      },
       "step1_steam_assist_intensity": {
         "name": "Schritt 1 Dampfunterst\u00fctzung Intensit\u00e4t",
         "state": {
-          "not_active": "Nicht aktiv",
+          "high": "Hoch",
           "low": "Niedrig",
           "medium": "Mittel",
-          "high": "Hoch"
+          "not_active": "Nicht aktiv"
         }
       },
       "step1_steam_assistset_time_in_minutes": {
         "name": "Schritt 1 Dampfunterst\u00fctzung Zeiteinstellung"
       },
+      "step2_duration": {
+        "name": "Dauer Schritt 2"
+      },
+      "step2_heater_system": {
+        "name": "Heizsystem Schritt 2",
+        "state": {
+          "aqua_clean": "Aqua-Clean",
+          "bottom": "Unterhitze",
+          "bottom_fan": "Unterhitze mit Ventilator",
+          "clean_air": "Luft-Reinigung",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisches Auftauen",
+          "descale": "Entkalken",
+          "eco_hot_air": "Eco-Hei\u00dfluft",
+          "fast_preheat": "Schnelles Vorheizen",
+          "grill_fan_micro": "Grillventilator-Mikrowelle",
+          "hot_air": "Hei\u00dfluft",
+          "hot_air_bottom": "Hei\u00dfluft unten",
+          "hot_air_micro": "Hei\u00dfluft-Mikrowelle",
+          "hot_air_steam_1": "Hei\u00dfluft-Dampf 1",
+          "hot_air_steam_2": "Hei\u00dfluft-Dampf 2",
+          "hot_air_steam_3": "Hei\u00dfluft-Dampf 3",
+          "keep_warm": "Warmhalten",
+          "large_grill": "Gro\u00dfer Grill",
+          "large_grill_fan": "Gro\u00dfer Grill mit Ventilator",
+          "low_temp_steam": "Niedrigtemperatur-Dampf",
+          "micro": "Mikrowelle",
+          "microwave_clean": "Mikrowellen-Reinigung",
+          "microwave_defrost": "Mikrowellen-Auftauen",
+          "plates": "Tellerw\u00e4rmer",
+          "pro_roasting": "Pro-Braten",
+          "programs": "Programme",
+          "pyrolysis": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbatmodus",
+          "small_grill": "Kleiner Grill",
+          "sous_vide": "Sous-Vide",
+          "steam": "Dampf",
+          "steam_clean": "Dampf-Reinigung",
+          "top": "Oberhitze",
+          "top_bottom": "Ober-/Unterhitze",
+          "warming": "Aufw\u00e4rmen"
+        }
+      },
+      "step2_remaining_time": {
+        "name": "Verbleibende Zeit Schritt 2"
+      },
+      "step2_set_temperature": {
+        "name": "Eingestellte Temperatur Schritt 2"
+      },
       "step2_steam_assist_intensity": {
         "name": "Schritt 2 Dampfunterst\u00fctzung Intensit\u00e4t",
         "state": {
-          "not_active": "Nicht aktiv",
+          "high": "Hoch",
           "low": "Niedrig",
           "medium": "Mittel",
-          "high": "Hoch"
+          "not_active": "Nicht aktiv"
         }
       },
       "step2_steam_assistset_time_in_minutes": {
         "name": "Schritt 2 Dampfunterst\u00fctzung Zeiteinstellung"
       },
+      "step3_duration": {
+        "name": "Dauer Schritt 3"
+      },
+      "step3_heater_system": {
+        "name": "Heizsystem Schritt 3",
+        "state": {
+          "aqua_clean": "Aqua-Clean",
+          "bottom": "Unterhitze",
+          "bottom_fan": "Unterhitze mit Ventilator",
+          "clean_air": "Luft-Reinigung",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisches Auftauen",
+          "descale": "Entkalken",
+          "eco_hot_air": "Eco-Hei\u00dfluft",
+          "fast_preheat": "Schnelles Vorheizen",
+          "grill_fan_micro": "Grillventilator-Mikrowelle",
+          "hot_air": "Hei\u00dfluft",
+          "hot_air_bottom": "Hei\u00dfluft unten",
+          "hot_air_micro": "Hei\u00dfluft-Mikrowelle",
+          "hot_air_steam_1": "Hei\u00dfluft-Dampf 1",
+          "hot_air_steam_2": "Hei\u00dfluft-Dampf 2",
+          "hot_air_steam_3": "Hei\u00dfluft-Dampf 3",
+          "keep_warm": "Warmhalten",
+          "large_grill": "Gro\u00dfer Grill",
+          "large_grill_fan": "Gro\u00dfer Grill mit Ventilator",
+          "low_temp_steam": "Niedrigtemperatur-Dampf",
+          "micro": "Mikrowelle",
+          "microwave_clean": "Mikrowellen-Reinigung",
+          "microwave_defrost": "Mikrowellen-Auftauen",
+          "plates": "Tellerw\u00e4rmer",
+          "pro_roasting": "Pro-Braten",
+          "programs": "Programme",
+          "pyro": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbatmodus",
+          "small_grill": "Kleiner Grill",
+          "sous_vide": "Sous-Vide",
+          "steam": "Dampf",
+          "steam_clean": "Dampf-Reinigung",
+          "top": "Oberhitze",
+          "top_bottom": "Ober-/Unterhitze",
+          "warming": "Aufw\u00e4rmen"
+        }
+      },
+      "step3_remaining_time": {
+        "name": "Verbleibende Zeit Schritt 3"
+      },
+      "step3_set_temperature": {
+        "name": "Eingestellte Temperatur Schritt 3"
+      },
       "step3_steam_assist_intensity": {
         "name": "Schritt 3 Dampfunterst\u00fctzung Intensit\u00e4t",
         "state": {
-          "not_active": "Nicht aktiv",
+          "high": "Hoch",
           "low": "Niedrig",
           "medium": "Mittel",
-          "high": "Hoch"
+          "not_active": "Nicht aktiv"
         }
       },
       "step3_steam_assistset_time_in_minutes": {
@@ -2771,18 +3063,18 @@
       "step_1_bake_mode": {
         "name": "Schritt 1 Backmodus",
         "state": {
-          "undefined": "Undefiniert",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake \u2013 Reinigung",
+          "extrabake_fastpreheat": "ExtraBake \u2013 Schnellvorheizen",
+          "extrabake_warming": "ExtraBake \u2013 Aufw\u00e4rmen",
+          "meatprobebake": "MeatProbeBake",
+          "probake": "ProBake",
           "recipe": "Rezept",
           "steambake": "SteamBake",
           "steamcombibake": "SteamCombiBake",
-          "extrabake_fastpreheat": "ExtraBake \u2013 Schnellvorheizen",
-          "extrabake_warming": "ExtraBake \u2013 Aufw\u00e4rmen",
-          "extrabake_cleaning": "ExtraBake \u2013 Reinigung",
-          "meatprobebake": "MeatProbeBake"
+          "stepbake": "StepBake",
+          "undefined": "Undefiniert"
         }
       },
       "step_1_duration": {
@@ -2797,79 +3089,79 @@
       "step_1_set_heater_system": {
         "name": "Schritt 1 Heizsystem",
         "state": {
-          "hotair": "Hei\u00dfluft",
-          "ecohotair": "Eco Hei\u00dfluft",
-          "topbottom": "Ober-/Unterhitze",
-          "hotairbottom": "Hei\u00dfluft + Unterhitze",
-          "bottomfan": "Unterhitze + Ventilator",
+          "3d_hot_ai": "3D-Hei\u00dfluft",
+          "air_fry": "Hei\u00dfluftfritteuse",
+          "aquaclean": "AquaClean",
+          "bake": "Backen",
           "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "smallgrill": "Kleiner Grill",
-          "largegrill": "Gro\u00dfer Grill",
-          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
-          "proroasting": "Profi-Braten",
-          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
+          "bottom_infra": "Unterhitze + Infrarot",
+          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
+          "bottom_top_heat": "Unter-/Oberhitze",
+          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
+          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
+          "bottomfan": "Unterhitze + Ventilator",
+          "broil": "Grillen",
+          "cleanair": "Reine Luft",
+          "convection_bake": "Umluft backen",
+          "convection_roast": "Umluft braten",
+          "count": "Z\u00e4hler",
+          "crisp": "Knusprig backen",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisch auftauen",
+          "dehydrate": "D\u00f6rren",
+          "descale": "Entkalken",
+          "eco": "Eco",
+          "ecohotair": "Eco Hei\u00dfluft",
+          "fastpreheat": "Schnellvorheizen",
+          "frozen_bake": "Tiefk\u00fchl backen",
+          "gentle_bake": "Sanftes Backen",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + Ventilator + Mikrowelle",
-          "micro": "Mikrowelle",
+          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
+          "hot_air_infra": "Hei\u00dfluft + Infrarot",
+          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
+          "hotair": "Hei\u00dfluft",
+          "hotairbottom": "Hei\u00dfluft + Unterhitze",
+          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
           "hotairsteam1": "Hei\u00dfluft + Dampf 1",
           "hotairsteam2": "Hei\u00dfluft + Dampf 2",
           "hotairsteam3": "Hei\u00dfluft + Dampf 3",
-          "fastpreheat": "Schnellvorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
           "keepwarm": "Warmhalten",
-          "plates": "Teller",
-          "aquaclean": "AquaClean",
-          "steamclean": "Dampfreinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "mwdefrost": "Mikrowelle Auftauen",
-          "sousvide": "Sous-vide",
-          "lowtempsteam": "Niedrigtemperaturdampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "cleanair": "Reine Luft",
-          "defrost_auto": "Automatisch auftauen",
-          "sabbath": "Sabbat",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "mwclean": "Mikrowelle reinigen",
-          "count": "Z\u00e4hler",
-          "undefined": "Undefiniert",
-          "pyrolize": "Pyrolyse",
-          "gentle_bake": "Sanftes Backen",
-          "air_fry": "Hei\u00dfluftfritteuse",
-          "bottom_top_heat": "Unter-/Oberhitze",
+          "large_grill": "Gro\u00dfer Grill",
           "large_grill_bottom": "Gro\u00dfer Grill + Unterhitze",
           "large_grill_bottom_fan": "Gro\u00dfer Grill + Unterhitze + Ventilator",
-          "large_grill": "Gro\u00dfer Grill",
-          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
-          "3d_hot_ai": "3D-Hei\u00dfluft",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
-          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
-          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
-          "hot_air_infra": "Hei\u00dfluft + Infrarot",
-          "bottom_infra": "Unterhitze + Infrarot",
-          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
-          "pizza": "Pizza",
-          "frozen_bake": "Tiefk\u00fchl backen",
-          "gratin": "Gratin",
-          "bake": "Backen",
-          "convection_bake": "Umluft backen",
-          "broil": "Grillen",
-          "self_clean": "Selbstreinigung",
-          "convection_roast": "Umluft braten",
-          "proof": "G\u00e4ren",
-          "dehydrate": "D\u00f6rren",
-          "crisp": "Knusprig backen",
           "large_grill_bottom_hot_air": "Gro\u00dfer Grill + Unterhitze + Hei\u00dfluft",
-          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
-          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
+          "largegrill": "Gro\u00dfer Grill",
           "largegrill_pyro": "Gro\u00dfer Grill Pyrolyse",
+          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
           "largegrillfan_pyro": "Gro\u00dfer Grill + Ventilator Pyrolyse",
+          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "lowtempsteam": "Niedrigtemperaturdampf",
+          "micro": "Mikrowelle",
+          "mwclean": "Mikrowelle reinigen",
+          "mwdefrost": "Mikrowelle Auftauen",
+          "none": "Keine",
+          "pizza": "Pizza",
+          "plates": "Teller",
+          "programs": "Programme",
+          "proof": "G\u00e4ren",
+          "proroasting": "Profi-Braten",
+          "pyro": "Pyrolyse",
+          "pyrolize": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbat",
+          "self_clean": "Selbstreinigung",
+          "smallgrill": "Kleiner Grill",
           "smallgrill_pyro": "Kleiner Grill Pyrolyse",
-          "none": "Keine"
+          "sousvide": "Sous-vide",
+          "steam": "Dampf",
+          "steamclean": "Dampfreinigung",
+          "top": "Oberhitze",
+          "topbottom": "Ober-/Unterhitze",
+          "undefined": "Undefiniert",
+          "warming": "Aufw\u00e4rmen"
         }
       },
       "step_1_set_microwave_wattage": {
@@ -2884,30 +3176,30 @@
       "step_1_steam_available": {
         "name": "Schritt 1 Dampf verf\u00fcgbar",
         "state": {
-          "not_active": "Nicht aktiv",
           "active": "Aktiv",
-          "available": "Verf\u00fcgbar"
+          "available": "Verf\u00fcgbar",
+          "not_active": "Nicht aktiv"
         }
       },
       "step_1_time_unit": {
         "name": "Schritt 1 Zeiteinheit",
         "state": {
-          "seconds": "Sekunden",
+          "hours": "Stunden",
           "minutes": "Minuten",
-          "hours": "Stunden"
+          "seconds": "Sekunden"
         }
       },
       "step_2_bake_mode": {
         "name": "Schritt 2 Backmodus",
         "state": {
-          "undefined": "Undefiniert",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
           "recipe": "Rezept",
           "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefiniert"
         }
       },
       "step_2_duration": {
@@ -2922,79 +3214,79 @@
       "step_2_set_heater_system": {
         "name": "Schritt 2 Heizsystem",
         "state": {
-          "hotair": "Hei\u00dfluft",
-          "ecohotair": "Eco Hei\u00dfluft",
-          "topbottom": "Ober-/Unterhitze",
-          "hotairbottom": "Hei\u00dfluft + Unterhitze",
-          "bottomfan": "Unterhitze + Ventilator",
+          "3d_hot_ai": "3D-Hei\u00dfluft",
+          "air_fry": "Hei\u00dfluftfritteuse",
+          "aquaclean": "AquaClean",
+          "bake": "Backen",
           "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "smallgrill": "Kleiner Grill",
-          "largegrill": "Gro\u00dfer Grill",
-          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
-          "proroasting": "Profi-Braten",
-          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
+          "bottom_infra": "Unterhitze + Infrarot",
+          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
+          "bottom_top_heat": "Unter-/Oberhitze",
+          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
+          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
+          "bottomfan": "Unterhitze + Ventilator",
+          "broil": "Grillen",
+          "cleanair": "Reine Luft",
+          "convection_bake": "Umluft backen",
+          "convection_roast": "Umluft braten",
+          "count": "Z\u00e4hler",
+          "crisp": "Knusprig backen",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisch auftauen",
+          "dehydrate": "D\u00f6rren",
+          "descale": "Entkalken",
+          "eco": "Eco",
+          "ecohotair": "Eco Hei\u00dfluft",
+          "fastpreheat": "Schnellvorheizen",
+          "frozen_bake": "Tiefk\u00fchl backen",
+          "gentle_bake": "Sanftes Backen",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + Ventilator + Mikrowelle",
-          "micro": "Mikrowelle",
+          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
+          "hot_air_infra": "Hei\u00dfluft + Infrarot",
+          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
+          "hotair": "Hei\u00dfluft",
+          "hotairbottom": "Hei\u00dfluft + Unterhitze",
+          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
           "hotairsteam1": "Hei\u00dfluft + Dampf 1",
           "hotairsteam2": "Hei\u00dfluft + Dampf 2",
           "hotairsteam3": "Hei\u00dfluft + Dampf 3",
-          "fastpreheat": "Schnellvorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
           "keepwarm": "Warmhalten",
-          "plates": "Teller",
-          "aquaclean": "AquaClean",
-          "steamclean": "Dampfreinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "mwdefrost": "Mikrowelle Auftauen",
-          "sousvide": "Sous-vide",
-          "lowtempsteam": "Niedrigtemperaturdampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "cleanair": "Reine Luft",
-          "defrost_auto": "Automatisch auftauen",
-          "sabbath": "Sabbat",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "mwclean": "Mikrowelle reinigen",
-          "count": "Z\u00e4hler",
-          "undefined": "Undefiniert",
-          "pyrolize": "Pyrolyse",
-          "gentle_bake": "Sanftes Backen",
-          "air_fry": "Hei\u00dfluftfritteuse",
-          "bottom_top_heat": "Unter-/Oberhitze",
+          "large_grill": "Gro\u00dfer Grill",
           "large_grill_bottom": "Gro\u00dfer Grill + Unterhitze",
           "large_grill_bottom_fan": "Gro\u00dfer Grill + Unterhitze + Ventilator",
-          "large_grill": "Gro\u00dfer Grill",
-          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
-          "3d_hot_ai": "3D-Hei\u00dfluft",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
-          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
-          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
-          "hot_air_infra": "Hei\u00dfluft + Infrarot",
-          "bottom_infra": "Unterhitze + Infrarot",
-          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
-          "pizza": "Pizza",
-          "frozen_bake": "Tiefk\u00fchl backen",
-          "gratin": "Gratin",
-          "bake": "Backen",
-          "convection_bake": "Umluft backen",
-          "broil": "Grillen",
-          "self_clean": "Selbstreinigung",
-          "convection_roast": "Umluft braten",
-          "proof": "G\u00e4ren",
-          "dehydrate": "D\u00f6rren",
-          "crisp": "Knusprig backen",
           "large_grill_bottom_hot_air": "Gro\u00dfer Grill + Unterhitze + Hei\u00dfluft",
-          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
-          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
+          "largegrill": "Gro\u00dfer Grill",
           "largegrill_pyro": "Gro\u00dfer Grill Pyrolyse",
+          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
           "largegrillfan_pyro": "Gro\u00dfer Grill + Ventilator Pyrolyse",
+          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "lowtempsteam": "Niedrigtemperaturdampf",
+          "micro": "Mikrowelle",
+          "mwclean": "Mikrowelle reinigen",
+          "mwdefrost": "Mikrowelle Auftauen",
+          "none": "Keine",
+          "pizza": "Pizza",
+          "plates": "Teller",
+          "programs": "Programme",
+          "proof": "G\u00e4ren",
+          "proroasting": "Profi-Braten",
+          "pyro": "Pyrolyse",
+          "pyrolize": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbat",
+          "self_clean": "Selbstreinigung",
+          "smallgrill": "Kleiner Grill",
           "smallgrill_pyro": "Kleiner Grill Pyrolyse",
-          "none": "Keine"
+          "sousvide": "Sous-vide",
+          "steam": "Dampf",
+          "steamclean": "Dampfreinigung",
+          "top": "Oberhitze",
+          "topbottom": "Ober-/Unterhitze",
+          "undefined": "Undefiniert",
+          "warming": "Aufw\u00e4rmen"
         }
       },
       "step_2_set_microwave_wattage": {
@@ -3009,30 +3301,30 @@
       "step_2_steam_available": {
         "name": "Schritt 2 Dampf verf\u00fcgbar",
         "state": {
-          "not_active": "Nicht aktiv",
           "active": "Aktiv",
-          "available": "Verf\u00fcgbar"
+          "available": "Verf\u00fcgbar",
+          "not_active": "Nicht aktiv"
         }
       },
       "step_2_time_unit": {
         "name": "Schritt 2 Zeiteinheit",
         "state": {
-          "seconds": "Sekunden",
+          "hours": "Stunden",
           "minutes": "Minuten",
-          "hours": "Stunden"
+          "seconds": "Sekunden"
         }
       },
       "step_3_bake_mode": {
         "name": "Schritt 3 Backmodus",
         "state": {
-          "undefined": "Undefiniert",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
           "recipe": "Rezept",
           "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefiniert"
         }
       },
       "step_3_duration": {
@@ -3047,79 +3339,79 @@
       "step_3_set_heater_system": {
         "name": "Schritt 3 Heizsystem",
         "state": {
-          "hotair": "Hei\u00dfluft",
-          "ecohotair": "Eco Hei\u00dfluft",
-          "topbottom": "Ober-/Unterhitze",
-          "hotairbottom": "Hei\u00dfluft + Unterhitze",
-          "bottomfan": "Unterhitze + Ventilator",
+          "3d_hot_ai": "3D-Hei\u00dfluft",
+          "air_fry": "Hei\u00dfluftfritteuse",
+          "aquaclean": "AquaClean",
+          "bake": "Backen",
           "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "smallgrill": "Kleiner Grill",
-          "largegrill": "Gro\u00dfer Grill",
-          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
-          "proroasting": "Profi-Braten",
-          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
+          "bottom_infra": "Unterhitze + Infrarot",
+          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
+          "bottom_top_heat": "Unter-/Oberhitze",
+          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
+          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
+          "bottomfan": "Unterhitze + Ventilator",
+          "broil": "Grillen",
+          "cleanair": "Reine Luft",
+          "convection_bake": "Umluft backen",
+          "convection_roast": "Umluft braten",
+          "count": "Z\u00e4hler",
+          "crisp": "Knusprig backen",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisch auftauen",
+          "dehydrate": "D\u00f6rren",
+          "descale": "Entkalken",
+          "eco": "Eco",
+          "ecohotair": "Eco Hei\u00dfluft",
+          "fastpreheat": "Schnellvorheizen",
+          "frozen_bake": "Tiefk\u00fchl backen",
+          "gentle_bake": "Sanftes Backen",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + Ventilator + Mikrowelle",
-          "micro": "Mikrowelle",
+          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
+          "hot_air_infra": "Hei\u00dfluft + Infrarot",
+          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
+          "hotair": "Hei\u00dfluft",
+          "hotairbottom": "Hei\u00dfluft + Unterhitze",
+          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
           "hotairsteam1": "Hei\u00dfluft + Dampf 1",
           "hotairsteam2": "Hei\u00dfluft + Dampf 2",
           "hotairsteam3": "Hei\u00dfluft + Dampf 3",
-          "fastpreheat": "Schnellvorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
           "keepwarm": "Warmhalten",
-          "plates": "Teller",
-          "aquaclean": "AquaClean",
-          "steamclean": "Dampfreinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "mwdefrost": "Mikrowelle Auftauen",
-          "sousvide": "Sous-vide",
-          "lowtempsteam": "Niedrigtemperaturdampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "cleanair": "Reine Luft",
-          "defrost_auto": "Automatisch auftauen",
-          "sabbath": "Sabbat",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "mwclean": "Mikrowelle reinigen",
-          "count": "Z\u00e4hler",
-          "undefined": "Undefiniert",
-          "pyrolize": "Pyrolyse",
-          "gentle_bake": "Sanftes Backen",
-          "air_fry": "Hei\u00dfluftfritteuse",
-          "bottom_top_heat": "Unter-/Oberhitze",
+          "large_grill": "Gro\u00dfer Grill",
           "large_grill_bottom": "Gro\u00dfer Grill + Unterhitze",
           "large_grill_bottom_fan": "Gro\u00dfer Grill + Unterhitze + Ventilator",
-          "large_grill": "Gro\u00dfer Grill",
-          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
-          "3d_hot_ai": "3D-Hei\u00dfluft",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
-          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
-          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
-          "hot_air_infra": "Hei\u00dfluft + Infrarot",
-          "bottom_infra": "Unterhitze + Infrarot",
-          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
-          "pizza": "Pizza",
-          "frozen_bake": "Tiefk\u00fchl backen",
-          "gratin": "Gratin",
-          "bake": "Backen",
-          "convection_bake": "Umluft backen",
-          "broil": "Grillen",
-          "self_clean": "Selbstreinigung",
-          "convection_roast": "Umluft braten",
-          "proof": "G\u00e4ren",
-          "dehydrate": "D\u00f6rren",
-          "crisp": "Knusprig backen",
           "large_grill_bottom_hot_air": "Gro\u00dfer Grill + Unterhitze + Hei\u00dfluft",
-          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
-          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
+          "largegrill": "Gro\u00dfer Grill",
           "largegrill_pyro": "Gro\u00dfer Grill Pyrolyse",
+          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
           "largegrillfan_pyro": "Gro\u00dfer Grill + Ventilator Pyrolyse",
+          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "lowtempsteam": "Niedrigtemperaturdampf",
+          "micro": "Mikrowelle",
+          "mwclean": "Mikrowelle reinigen",
+          "mwdefrost": "Mikrowelle Auftauen",
+          "none": "Keine",
+          "pizza": "Pizza",
+          "plates": "Teller",
+          "programs": "Programme",
+          "proof": "G\u00e4ren",
+          "proroasting": "Profi-Braten",
+          "pyro": "Pyrolyse",
+          "pyrolize": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbat",
+          "self_clean": "Selbstreinigung",
+          "smallgrill": "Kleiner Grill",
           "smallgrill_pyro": "Kleiner Grill Pyrolyse",
-          "none": "Keine"
+          "sousvide": "Sous-vide",
+          "steam": "Dampf",
+          "steamclean": "Dampfreinigung",
+          "top": "Oberhitze",
+          "topbottom": "Ober-/Unterhitze",
+          "undefined": "Undefiniert",
+          "warming": "Aufw\u00e4rmen"
         }
       },
       "step_3_set_microwave_wattage": {
@@ -3134,25 +3426,25 @@
       "step_3_status": {
         "name": "Schritt 3 Status",
         "state": {
-          "not_active": "Nicht aktiv",
           "active": "Aktiv",
-          "available": "Verf\u00fcgbar"
+          "available": "Verf\u00fcgbar",
+          "not_active": "Nicht aktiv"
         }
       },
       "step_3_steam_available": {
         "name": "Schritt 3 Dampf verf\u00fcgbar",
         "state": {
-          "not_active": "Nicht aktiv",
           "active": "Aktiv",
-          "available": "Verf\u00fcgbar"
+          "available": "Verf\u00fcgbar",
+          "not_active": "Nicht aktiv"
         }
       },
       "step_3_time_unit": {
         "name": "Schritt 3 Zeiteinheit",
         "state": {
-          "seconds": "Sekunden",
+          "hours": "Stunden",
           "minutes": "Minuten",
-          "hours": "Stunden"
+          "seconds": "Sekunden"
         }
       },
       "step_after_bake_duration": {
@@ -3173,79 +3465,79 @@
       "step_after_bake_set_heater_system": {
         "name": "Nachbackphase Heizsystem",
         "state": {
-          "hotair": "Hei\u00dfluft",
-          "ecohotair": "Eco Hei\u00dfluft",
-          "topbottom": "Ober-/Unterhitze",
-          "hotairbottom": "Hei\u00dfluft + Unterhitze",
-          "bottomfan": "Unterhitze + Ventilator",
+          "3d_hot_ai": "3D-Hei\u00dfluft",
+          "air_fry": "Hei\u00dfluftfritteuse",
+          "aquaclean": "AquaClean",
+          "bake": "Backen",
           "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "smallgrill": "Kleiner Grill",
-          "largegrill": "Gro\u00dfer Grill",
-          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
-          "proroasting": "Profi-Braten",
-          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
+          "bottom_infra": "Unterhitze + Infrarot",
+          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
+          "bottom_top_heat": "Unter-/Oberhitze",
+          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
+          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
+          "bottomfan": "Unterhitze + Ventilator",
+          "broil": "Grillen",
+          "cleanair": "Reine Luft",
+          "convection_bake": "Umluft backen",
+          "convection_roast": "Umluft braten",
+          "count": "Z\u00e4hler",
+          "crisp": "Knusprig backen",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisch auftauen",
+          "dehydrate": "D\u00f6rren",
+          "descale": "Entkalken",
+          "eco": "Eco",
+          "ecohotair": "Eco Hei\u00dfluft",
+          "fastpreheat": "Schnellvorheizen",
+          "frozen_bake": "Tiefk\u00fchl backen",
+          "gentle_bake": "Sanftes Backen",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + Ventilator + Mikrowelle",
-          "micro": "Mikrowelle",
+          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
+          "hot_air_infra": "Hei\u00dfluft + Infrarot",
+          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
+          "hotair": "Hei\u00dfluft",
+          "hotairbottom": "Hei\u00dfluft + Unterhitze",
+          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
           "hotairsteam1": "Hei\u00dfluft + Dampf 1",
           "hotairsteam2": "Hei\u00dfluft + Dampf 2",
           "hotairsteam3": "Hei\u00dfluft + Dampf 3",
-          "fastpreheat": "Schnellvorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
           "keepwarm": "Warmhalten",
-          "plates": "Teller",
-          "aquaclean": "AquaClean",
-          "steamclean": "Dampfreinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "mwdefrost": "Mikrowelle Auftauen",
-          "sousvide": "Sous-vide",
-          "lowtempsteam": "Niedrigtemperaturdampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "cleanair": "Reine Luft",
-          "defrost_auto": "Automatisch auftauen",
-          "sabbath": "Sabbat",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "mwclean": "Mikrowelle reinigen",
-          "count": "Z\u00e4hler",
-          "undefined": "Undefiniert",
-          "pyrolize": "Pyrolyse",
-          "gentle_bake": "Sanftes Backen",
-          "air_fry": "Hei\u00dfluftfritteuse",
-          "bottom_top_heat": "Unter-/Oberhitze",
+          "large_grill": "Gro\u00dfer Grill",
           "large_grill_bottom": "Gro\u00dfer Grill + Unterhitze",
           "large_grill_bottom_fan": "Gro\u00dfer Grill + Unterhitze + Ventilator",
-          "large_grill": "Gro\u00dfer Grill",
-          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
-          "3d_hot_ai": "3D-Hei\u00dfluft",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
-          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
-          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
-          "hot_air_infra": "Hei\u00dfluft + Infrarot",
-          "bottom_infra": "Unterhitze + Infrarot",
-          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
-          "pizza": "Pizza",
-          "frozen_bake": "Tiefk\u00fchl backen",
-          "gratin": "Gratin",
-          "bake": "Backen",
-          "convection_bake": "Umluft backen",
-          "broil": "Grillen",
-          "self_clean": "Selbstreinigung",
-          "convection_roast": "Umluft braten",
-          "proof": "G\u00e4ren",
-          "dehydrate": "D\u00f6rren",
-          "crisp": "Knusprig backen",
           "large_grill_bottom_hot_air": "Gro\u00dfer Grill + Unterhitze + Hei\u00dfluft",
-          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
-          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
+          "largegrill": "Gro\u00dfer Grill",
           "largegrill_pyro": "Gro\u00dfer Grill Pyrolyse",
+          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
           "largegrillfan_pyro": "Gro\u00dfer Grill + Ventilator Pyrolyse",
+          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "lowtempsteam": "Niedrigtemperaturdampf",
+          "micro": "Mikrowelle",
+          "mwclean": "Mikrowelle reinigen",
+          "mwdefrost": "Mikrowelle Auftauen",
+          "none": "Keine",
+          "pizza": "Pizza",
+          "plates": "Teller",
+          "programs": "Programme",
+          "proof": "G\u00e4ren",
+          "proroasting": "Profi-Braten",
+          "pyro": "Pyrolyse",
+          "pyrolize": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbat",
+          "self_clean": "Selbstreinigung",
+          "smallgrill": "Kleiner Grill",
           "smallgrill_pyro": "Kleiner Grill Pyrolyse",
-          "none": "Keine"
+          "sousvide": "Sous-vide",
+          "steam": "Dampf",
+          "steamclean": "Dampfreinigung",
+          "top": "Oberhitze",
+          "topbottom": "Ober-/Unterhitze",
+          "undefined": "Undefiniert",
+          "warming": "Aufw\u00e4rmen"
         }
       },
       "step_after_bake_set_temperature": {
@@ -3254,9 +3546,9 @@
       "step_after_bake_time_unit": {
         "name": "Nachbackphase Zeiteinheit",
         "state": {
-          "seconds": "Sekunden",
+          "hours": "Stunden",
           "minutes": "Minuten",
-          "hours": "Stunden"
+          "seconds": "Sekunden"
         }
       },
       "step_pre_bake_duration": {
@@ -3265,9 +3557,9 @@
       "step_pre_bake_mode": {
         "name": "Vorbackphase Modus",
         "state": {
+          "delay_start_waiting": "Warte auf Startverz\u00f6gerung",
           "not_active": "Nicht aktiv",
-          "preheat": "Vorheizen",
-          "delay_start_waiting": "Warte auf Startverz\u00f6gerung"
+          "preheat": "Vorheizen"
         }
       },
       "step_pre_bake_passed_time": {
@@ -3279,79 +3571,79 @@
       "step_pre_bake_set_heater_system": {
         "name": "Vorbackphase Heizsystem",
         "state": {
-          "hotair": "Hei\u00dfluft",
-          "ecohotair": "Eco Hei\u00dfluft",
-          "topbottom": "Ober-/Unterhitze",
-          "hotairbottom": "Hei\u00dfluft + Unterhitze",
-          "bottomfan": "Unterhitze + Ventilator",
+          "3d_hot_ai": "3D-Hei\u00dfluft",
+          "air_fry": "Hei\u00dfluftfritteuse",
+          "aquaclean": "AquaClean",
+          "bake": "Backen",
           "bottom": "Unterhitze",
-          "top": "Oberhitze",
-          "smallgrill": "Kleiner Grill",
-          "largegrill": "Gro\u00dfer Grill",
-          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
-          "proroasting": "Profi-Braten",
-          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
+          "bottom_infra": "Unterhitze + Infrarot",
+          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
+          "bottom_top_heat": "Unter-/Oberhitze",
+          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
+          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
+          "bottomfan": "Unterhitze + Ventilator",
+          "broil": "Grillen",
+          "cleanair": "Reine Luft",
+          "convection_bake": "Umluft backen",
+          "convection_roast": "Umluft braten",
+          "count": "Z\u00e4hler",
+          "crisp": "Knusprig backen",
+          "defrost": "Auftauen",
+          "defrost_auto": "Automatisch auftauen",
+          "dehydrate": "D\u00f6rren",
+          "descale": "Entkalken",
+          "eco": "Eco",
+          "ecohotair": "Eco Hei\u00dfluft",
+          "fastpreheat": "Schnellvorheizen",
+          "frozen_bake": "Tiefk\u00fchl backen",
+          "gentle_bake": "Sanftes Backen",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + Ventilator + Mikrowelle",
-          "micro": "Mikrowelle",
+          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
+          "hot_air_infra": "Hei\u00dfluft + Infrarot",
+          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
+          "hotair": "Hei\u00dfluft",
+          "hotairbottom": "Hei\u00dfluft + Unterhitze",
+          "hotairmicro": "Hei\u00dfluft + Mikrowelle",
           "hotairsteam1": "Hei\u00dfluft + Dampf 1",
           "hotairsteam2": "Hei\u00dfluft + Dampf 2",
           "hotairsteam3": "Hei\u00dfluft + Dampf 3",
-          "fastpreheat": "Schnellvorheizen",
-          "pyro": "Pyrolyse",
-          "defrost": "Auftauen",
           "keepwarm": "Warmhalten",
-          "plates": "Teller",
-          "aquaclean": "AquaClean",
-          "steamclean": "Dampfreinigung",
-          "regenerate": "Regenerieren",
-          "descale": "Entkalken",
-          "mwdefrost": "Mikrowelle Auftauen",
-          "sousvide": "Sous-vide",
-          "lowtempsteam": "Niedrigtemperaturdampf",
-          "steam": "Dampf",
-          "quick": "Schnell",
-          "cleanair": "Reine Luft",
-          "defrost_auto": "Automatisch auftauen",
-          "sabbath": "Sabbat",
-          "programs": "Programme",
-          "warming": "Aufw\u00e4rmen",
-          "mwclean": "Mikrowelle reinigen",
-          "count": "Z\u00e4hler",
-          "undefined": "Undefiniert",
-          "pyrolize": "Pyrolyse",
-          "gentle_bake": "Sanftes Backen",
-          "air_fry": "Hei\u00dfluftfritteuse",
-          "bottom_top_heat": "Unter-/Oberhitze",
+          "large_grill": "Gro\u00dfer Grill",
           "large_grill_bottom": "Gro\u00dfer Grill + Unterhitze",
           "large_grill_bottom_fan": "Gro\u00dfer Grill + Unterhitze + Ventilator",
-          "large_grill": "Gro\u00dfer Grill",
-          "hot_air_bottomheat": "Hei\u00dfluft + Unterhitze",
-          "3d_hot_ai": "3D-Hei\u00dfluft",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Unter-/Oberhitze + Ventilator + Dampf",
-          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
-          "hot_air_upper": "Hei\u00dfluft + Oberhitze",
-          "hot_air_infra": "Hei\u00dfluft + Infrarot",
-          "bottom_infra": "Unterhitze + Infrarot",
-          "bottom_infra_fan": "Unterhitze + Infrarot + Ventilator",
-          "pizza": "Pizza",
-          "frozen_bake": "Tiefk\u00fchl backen",
-          "gratin": "Gratin",
-          "bake": "Backen",
-          "convection_bake": "Umluft backen",
-          "broil": "Grillen",
-          "self_clean": "Selbstreinigung",
-          "convection_roast": "Umluft braten",
-          "proof": "G\u00e4ren",
-          "dehydrate": "D\u00f6rren",
-          "crisp": "Knusprig backen",
           "large_grill_bottom_hot_air": "Gro\u00dfer Grill + Unterhitze + Hei\u00dfluft",
-          "bottom_top_heat_fan": "Unter-/Oberhitze + Ventilator",
-          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "large_grill_fan_steam": "Gro\u00dfer Grill + Ventilator + Dampf",
+          "largegrill": "Gro\u00dfer Grill",
           "largegrill_pyro": "Gro\u00dfer Grill Pyrolyse",
+          "largegrillfan": "Gro\u00dfer Grill + Ventilator",
           "largegrillfan_pyro": "Gro\u00dfer Grill + Ventilator Pyrolyse",
+          "largegrillsteak_pyro": "Gro\u00dfer Grill Steak Pyrolyse",
+          "lowtempsteam": "Niedrigtemperaturdampf",
+          "micro": "Mikrowelle",
+          "mwclean": "Mikrowelle reinigen",
+          "mwdefrost": "Mikrowelle Auftauen",
+          "none": "Keine",
+          "pizza": "Pizza",
+          "plates": "Teller",
+          "programs": "Programme",
+          "proof": "G\u00e4ren",
+          "proroasting": "Profi-Braten",
+          "pyro": "Pyrolyse",
+          "pyrolize": "Pyrolyse",
+          "quick": "Schnell",
+          "regenerate": "Regenerieren",
+          "sabbath": "Sabbat",
+          "self_clean": "Selbstreinigung",
+          "smallgrill": "Kleiner Grill",
           "smallgrill_pyro": "Kleiner Grill Pyrolyse",
-          "none": "Keine"
+          "sousvide": "Sous-vide",
+          "steam": "Dampf",
+          "steamclean": "Dampfreinigung",
+          "top": "Oberhitze",
+          "topbottom": "Ober-/Unterhitze",
+          "undefined": "Undefiniert",
+          "warming": "Aufw\u00e4rmen"
         }
       },
       "step_pre_bake_set_temperature": {
@@ -3360,10 +3652,25 @@
       "step_pre_bake_time_unit": {
         "name": "Vorbackphase Zeiteinheit",
         "state": {
-          "seconds": "Sekunden",
+          "hours": "Stunden",
           "minutes": "Minuten",
-          "hours": "Stunden"
+          "seconds": "Sekunden"
         }
+      },
+      "super_rinse_setting_status": {
+        "name": "Super-Sp\u00fclung"
+      },
+      "t_sleep": {
+        "name": "Schlafmodus"
+      },
+      "temperature": {
+        "name": "Temperatur"
+      },
+      "temperature_default_defaultmainwashtime": {
+        "name": "Standardtemperatur f\u00fcr Hauptwaschzeit"
+      },
+      "temperature_room_judge": {
+        "name": "Temperaturraum-Beurteilung"
       },
       "temperature_unit": {
         "name": "Temperatureinheit",
@@ -3382,17 +3689,56 @@
       "total_duration_in_seconds": {
         "name": "Gesamtdauer"
       },
+      "total_energy_consumption": {
+        "name": "Gesamter Energieverbrauch"
+      },
+      "total_number_of_cycles": {
+        "name": "Gesamtanzahl der Zyklen"
+      },
       "total_oven_usage_value": {
         "name": "Gesamte Ofennutzungszeit"
+      },
+      "total_passed_time": {
+        "name": "Gesamte vergangene Zeit"
       },
       "total_passed_time_seconds": {
         "name": "Verstrichene Gesamtzeit"
       },
+      "total_remaining_time": {
+        "name": "Gesamte verbleibende Zeit"
+      },
       "total_remaining_time_seconds": {
         "name": "Verbleibende Gesamtzeit"
       },
+      "total_run_time": {
+        "name": "Gesamtlaufzeit"
+      },
+      "total_time_of_cooking_in_hours": {
+        "name": "Gesamte Kochzeit"
+      },
+      "total_water_consumption": {
+        "name": "Gesamter Wasserverbrauch"
+      },
+      "utc_datetime_bdc_delaystart_delayend_timestamp": {
+        "name": "BDC Verz\u00f6gerungsstart Verz\u00f6gerungsende"
+      },
       "variation_door_open_time": {
         "name": "Variabler Raum T\u00fcr \u00d6ffnungszeit"
+      },
+      "variation_max_temperature": {
+        "name": "Maximale Temperatur der Variation"
+      },
+      "variation_min_temperature": {
+        "name": "Minimale Temperatur der Variation"
+      },
+      "variation_real_temperature": {
+        "name": "Reale Temperatur der Variation"
+      },
+      "variation_sensor_real_temperature": {
+        "name": "Reale Sensortemperatur der Variation"
+      },
+      "variation_temperature": {
+        "name": "Temperatur der Variation"
       },
       "volume": {
         "name": "Lautst\u00e4rke"
@@ -3400,16 +3746,43 @@
       "warming_drawer_power_level": {
         "name": "Warmhalteschublade Leistungsstufe",
         "state": {
+          "high": "Hoch",
           "low": "Niedrig",
-          "medium": "Mittel",
-          "high": "Hoch"
+          "medium": "Mittel"
         }
+      },
+      "washing_machine_type_kg": {
+        "name": "Waschmaschinentyp (kg)"
+      },
+      "washing_machine_type_max_speed": {
+        "name": "Maximale Geschwindigkeit des Waschmaschinentyps"
+      },
+      "water_consumption": {
+        "name": "Wasserverbrauch"
       },
       "water_consumption_decimal": {
         "name": "Wasserverbrauch (Dezimal)"
       },
+      "water_consumption_in_running_program": {
+        "name": "Wasserverbrauch im laufenden Programm"
+      },
+      "water_consumption_int": {
+        "name": "Wasserverbrauch"
+      },
       "water_hardness": {
         "name": "Wasserh\u00e4rte"
+      },
+      "water_hardness_setting_status": {
+        "name": "Wasserh\u00e4rte",
+        "state": {
+          "not_set": "Nicht eingestellt"
+        }
+      },
+      "water_inlet_setting_status": {
+        "name": "Wasserzulauf"
+      },
+      "water_save_setting_status": {
+        "name": "Wassersparmodus"
       },
       "water_tank": {
         "name": "Wassertank",
@@ -3417,14 +3790,23 @@
           "not_detected": "Nicht erkannt",
           "present": "Vorhanden"
         }
+      },
+      "zone_number": {
+        "name": "Anzahl der Zonen"
       }
     },
     "switch": {
+      "adaptive_sense_setting": {
+        "name": "Adaptive Sensorik"
+      },
       "anticrease": {
         "name": "Anti-Knitter"
       },
       "auto_dose_setting_status": {
         "name": "Automatische Dosierung"
+      },
+      "auto_fast_preheat": {
+        "name": "Automatisches Schnellvorheizen"
       },
       "autodose": {
         "name": "Automatische Dosierung"
@@ -3438,8 +3820,32 @@
       "child_lock": {
         "name": "Kindersicherung"
       },
+      "coldwash": {
+        "name": "Kaltw\u00e4sche"
+      },
+      "crisp_function_status": {
+        "name": "Knusperfunktion Status"
+      },
+      "demo_mode": {
+        "name": "Demomodus"
+      },
+      "display_standby": {
+        "name": "Display Standby"
+      },
+      "downlight": {
+        "name": "Beleuchtung"
+      },
       "drum_light": {
         "name": "Trommelbeleuchtung"
+      },
+      "extra_rinse": {
+        "name": "Extra Sp\u00fclen"
+      },
+      "fota_cmd": {
+        "name": "Firmwareaktualisierung"
+      },
+      "hide_setting": {
+        "name": "Einstellung ausblenden"
       },
       "holiday_mode": {
         "name": "Urlaubsmodus"
@@ -3450,14 +3856,23 @@
       "ice_making_state": {
         "name": "Status der Eisherstellung"
       },
+      "interior_light": {
+        "name": "Innenbeleuchtung"
+      },
       "interior_light_at_power_off_setting_status": {
         "name": "Innenbeleuchtung bei ausgeschaltetem Ger\u00e4t"
+      },
+      "key_sound": {
+        "name": "Tastenton"
       },
       "mute": {
         "name": "Stumm"
       },
       "natural_dry": {
         "name": "Nat\u00fcrliches Trocknen"
+      },
+      "night_mode_status": {
+        "name": "Nachtmodus"
       },
       "odor_control_setting": {
         "name": "Geruchskontrolle"
@@ -3479,6 +3894,15 @@
       },
       "steam": {
         "name": "Dampf"
+      },
+      "step_1_fastpreheat_function": {
+        "name": "Schritt 1 Schnellvorheizen"
+      },
+      "step_after_bake_status": {
+        "name": "Nachbackphase Status"
+      },
+      "step_pre_bake_status": {
+        "name": "Vorbackphase Status"
       },
       "super_rinse_setting_status": {
         "name": "Super-Sp\u00fclung"
@@ -3516,493 +3940,11 @@
       "tab_setting_status": {
         "name": "Tab-Einstellung"
       },
-      "adaptive_sense_setting": {
-        "name": "Adaptive Sensorik"
-      },
-      "auto_fast_preheat": {
-        "name": "Automatisches Schnellvorheizen"
-      },
-      "coldwash": {
-        "name": "Kaltw\u00e4sche"
-      },
-      "crisp_function_status": {
-        "name": "Knusperfunktion Status"
-      },
-      "demo_mode": {
-        "name": "Demomodus"
-      },
-      "display_standby": {
-        "name": "Display Standby"
-      },
-      "downlight": {
-        "name": "Beleuchtung"
-      },
-      "extra_rinse": {
-        "name": "Extra Sp\u00fclen"
-      },
-      "fota_cmd": {
-        "name": "Firmwareaktualisierung"
-      },
-      "hide_setting": {
-        "name": "Einstellung ausblenden"
-      },
-      "interior_light": {
-        "name": "Innenbeleuchtung"
-      },
-      "key_sound": {
-        "name": "Tastenton"
-      },
-      "night_mode_status": {
-        "name": "Nachtmodus"
-      },
-      "step_1_fastpreheat_function": {
-        "name": "Schritt 1 Schnellvorheizen"
-      },
-      "step_after_bake_status": {
-        "name": "Nachbackphase Status"
-      },
-      "step_pre_bake_status": {
-        "name": "Vorbackphase Status"
-      },
       "time_save": {
         "name": "Zeitsparen"
       },
       "welcome": {
         "name": "Willkommen"
-      }
-    },
-    "select": {
-      "auto_dose_quantity_setting_status": {
-        "name": "Automatische Dosierungsmenge"
-      },
-      "dry_level": {
-        "name": "Trocknungsstufe",
-        "state": {
-          "low": "Niedrig",
-          "medium": "Mittel",
-          "high": "Hoch"
-        }
-      },
-      "dry_time": {
-        "name": "Trocknungszeit",
-        "state": {
-          "wardrobe": "Schranktrocken",
-          "pre-ironing": "Vor B\u00fcgeln",
-          "extra_dry": "Extra Trocken",
-          "30_min": "30 min",
-          "60_min": "60 min",
-          "90_min": "90 min",
-          "120_min": "120 min",
-          "180_min": "180 min",
-          "240_min": "240 min",
-          "iron": "B\u00fcgelfeucht",
-          "cupboard": "Schranktrocken",
-          "none": "Keine"
-        }
-      },
-      "extrarinsenum": {
-        "name": "Zus\u00e4tzliche Sp\u00fclg\u00e4nge",
-        "state": {
-          "none": "Keine"
-        }
-      },
-      "motorlevel": {
-        "name": "Motorleistung"
-      },
-      "selected_program_id": {
-        "name": "Programm",
-        "state": {
-          "auto": "Automatisch",
-          "anti_allergy": "Anti-Allergie",
-          "refresh": "Auffrischen",
-          "sports": "Sport",
-          "towels": "Handt\u00fccher",
-          "time": "Zeitprogramm",
-          "cotton": "Baumwolle",
-          "baby": "Babyprogramm",
-          "synthetic": "Synthetik",
-          "wool": "Wolle",
-          "delicates": "Feinw\u00e4sche",
-          "fast30": "Schnell 30'",
-          "shirts": "Hemdprogramm",
-          "bed_linen": "Bettw\u00e4sche",
-          "down": "Daunen",
-          "cotton_dry": "Baumwolle trocken",
-          "synthetic_dry": "Synthetik trocken",
-          "drum_cleaning": "Trommelreinigung",
-          "eco_40_60": "Eco 40-60",
-          "fast15": "Schnell 15'",
-          "spin-dry": "Schleudern & Trocknen",
-          "rinse_spin": "Sp\u00fclen & Schleudern",
-          "clean_dry_60": "Sauber & Trocken 60'",
-          "power49": "Power 49'",
-          "allergy_care": "Allergiepflege",
-          "wash_and_dry_49": "Waschen und Trocknen 49",
-          "bedding": "Bettw\u00e4sche",
-          "power_30": "Power 30",
-          "pets": "Haustiere",
-          "full_load_49": "Volle Ladung 49",
-          "mix": "Mischgewebe",
-          "jeans": "Jeans",
-          "sportswear": "Sportkleidung",
-          "hand_wash": "Handw\u00e4sche"
-        }
-      },
-      "spin_speed_rpm": {
-        "name": "Schleudergeschwindigkeit",
-        "state": {
-          "none": "Keine"
-        }
-      },
-      "t_fan_speed": {
-        "name": "L\u00fcftergeschwindigkeit",
-        "state": {
-          "auto": "Automatisch",
-          "low": "Niedrig",
-          "high": "Hoch"
-        }
-      },
-      "t_sleep": {
-        "name": "Schlafmodus",
-        "state": {
-          "off": "Aus",
-          "general": "Allgemein",
-          "for_old": "F\u00fcr \u00e4ltere Menschen",
-          "for_young": "F\u00fcr junge Menschen",
-          "for_kid": "F\u00fcr Kinder"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Schwenkwinkel",
-        "state": {
-          "swing": "Schwenken",
-          "auto": "Automatisch",
-          "angle_1": "Winkel 1",
-          "angle_2": "Winkel 2",
-          "angle_3": "Winkel 3",
-          "angle_4": "Winkel 4",
-          "angle_5": "Winkel 5",
-          "angle_6": "Winkel 6"
-        }
-      },
-      "t_swing_follow": {
-        "name": "KI-Bel\u00fcftung",
-        "state": {
-          "off": "Aus",
-          "follow": "Folgen",
-          "not_follow": "Nicht folgen"
-        }
-      },
-      "temperature": {
-        "name": "Temperatur",
-        "state": {
-          "cold": "Kalt"
-        }
-      },
-      "actions": {
-        "name": "Aktionen",
-        "state": {
-          "start": "Start",
-          "pause": "Pause",
-          "stop_finish": "Stopp / Fertig",
-          "add_duration": "Dauer hinzuf\u00fcgen",
-          "add_gratin": "Gratin hinzuf\u00fcgen",
-          "steam_shot": "Dampfsto\u00df",
-          "none": "Keine",
-          "stop": "Stopp"
-        }
-      },
-      "baking_steps_intensity_levels": {
-        "name": "Backschritte Intensit\u00e4tsstufen",
-        "state": {
-          "none": "Keine"
-        }
-      },
-      "baking_steps_intensity_levels_type": {
-        "name": "Backschritte Intensit\u00e4tsstufen Typ",
-        "state": {
-          "none": "Keine",
-          "not_used": "Nicht verwendet",
-          "low_mid_high": "Niedrig Mittel Hoch",
-          "rare_medium_well_done": "Rare Medium Well done"
-        }
-      },
-      "brightness": {
-        "name": "Helligkeit"
-      },
-      "cooking_intensity": {
-        "name": "Kochintensit\u00e4t"
-      },
-      "delayendtime": {
-        "name": "Startverz\u00f6gerung Endzeit",
-        "state": {
-          "none": "Keine",
-          "1_hour": "1 Stunde",
-          "2_hours": "2 Stunden",
-          "3_hours": "3 Stunden",
-          "4_hours": "4 Stunden",
-          "5_hours": "5 Stunden",
-          "6_hours": "6 Stunden",
-          "7_hours": "7 Stunden",
-          "8_hours": "8 Stunden",
-          "9_hours": "9 Stunden",
-          "10_hours": "10 Stunden",
-          "11_hours": "11 Stunden",
-          "12_hours": "12 Stunden",
-          "13_hours": "13 Stunden",
-          "14_hours": "14 Stunden",
-          "15_hours": "15 Stunden",
-          "16_hours": "16 Stunden",
-          "17_hours": "17 Stunden",
-          "18_hours": "18 Stunden",
-          "19_hours": "19 Stunden",
-          "20_hours": "20 Stunden",
-          "21_hours": "21 Stunden",
-          "22_hours": "22 Stunden",
-          "23_hours": "23 Stunden",
-          "24_hours": "24 Stunden"
-        }
-      },
-      "detergent": {
-        "name": "Waschmittel",
-        "state": {
-          "auto": "Automatisch",
-          "less": "Weniger",
-          "standard": "Standard",
-          "more": "Mehr"
-        }
-      },
-      "drymodel": {
-        "name": "Trocknungsmodus",
-        "state": {
-          "wash": "Waschen",
-          "wash_and_dry": "Waschen und Trocknen",
-          "dry_only": "Nur Trocknen"
-        }
-      },
-      "language_status": {
-        "name": "Sprache",
-        "state": {
-          "english": "Englisch",
-          "simplified_chinese": "Vereinfachtes Chinesisch"
-        }
-      },
-      "oven_temperature_unit": {
-        "name": "Ofen Temperatureinheit",
-        "state": {
-          "celsius": "Celsius",
-          "fahrenheit": "Fahrenheit"
-        }
-      },
-      "sand_timer_1_status_cmd": {
-        "name": "Timer 1 Steuerung",
-        "state": {
-          "start": "Start",
-          "stop": "Stopp",
-          "pause": "Pause",
-          "cancel": "Abbrechen"
-        }
-      },
-      "sand_timer_2_status_cmd": {
-        "name": "Timer 2 Steuerung",
-        "state": {
-          "start": "Start",
-          "stop": "Stopp",
-          "pause": "Pause",
-          "cancel": "Abbrechen"
-        }
-      },
-      "sand_timer_3_status_cmd": {
-        "name": "Timer 3 Steuerung",
-        "state": {
-          "start": "Start",
-          "stop": "Stopp",
-          "pause": "Pause",
-          "cancel": "Abbrechen"
-        }
-      },
-      "softener": {
-        "name": "Weichsp\u00fcler",
-        "state": {
-          "auto": "Automatisch",
-          "less": "Weniger",
-          "standard": "Standard",
-          "more": "Mehr"
-        }
-      },
-      "stain_removal": {
-        "name": "Fleckenentfernung",
-        "state": {
-          "wine": "Wein",
-          "grass": "Gras",
-          "soil": "Erde",
-          "coffee": "Kaffee",
-          "milk": "Milch",
-          "juice": "Saft",
-          "sweat": "Schwei\u00df",
-          "blood": "Blut",
-          "oil": "\u00d6l"
-        }
-      },
-      "steam_123": {
-        "name": "Steam 123",
-        "state": {
-          "steam123_0": "Steam123 0",
-          "steam123_1": "Steam123 1",
-          "steam123_2": "Steam123 2",
-          "steam123_3": "Steam123 3"
-        }
-      },
-      "step_1_bake_mode": {
-        "name": "Schritt 1 Backmodus",
-        "state": {
-          "undefined": "Undefiniert",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Rezept",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake",
-          "extrabake_fastpreheat": "ExtraBake \u2013 Schnellvorheizen",
-          "extrabake_warming": "ExtraBake \u2013 Aufw\u00e4rmen",
-          "extrabake_cleaning": "ExtraBake \u2013 Reinigung",
-          "meatprobebake": "MeatProbeBake"
-        }
-      },
-      "step_1_set_microwave_wattage": {
-        "name": "Schritt 1 Mikrowellenleistung",
-        "state": {
-          "none": "Keine"
-        }
-      },
-      "step_1_time_unit": {
-        "name": "Schritt 1 Zeiteinheit",
-        "state": {
-          "seconds": "Sekunden",
-          "minutes": "Minuten",
-          "hours": "Stunden"
-        }
-      },
-      "step_2_bake_mode": {
-        "name": "Schritt 2 Backmodus",
-        "state": {
-          "undefined": "Undefiniert",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Rezept",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
-        }
-      },
-      "step_2_set_microwave_wattage": {
-        "name": "Schritt 2 Mikrowellenleistung",
-        "state": {
-          "none": "Keine"
-        }
-      },
-      "step_2_time_unit": {
-        "name": "Schritt 2 Zeiteinheit",
-        "state": {
-          "seconds": "Sekunden",
-          "minutes": "Minuten",
-          "hours": "Stunden"
-        }
-      },
-      "step_3_bake_mode": {
-        "name": "Schritt 3 Backmodus",
-        "state": {
-          "undefined": "Undefiniert",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Rezept",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
-        }
-      },
-      "step_3_set_microwave_wattage": {
-        "name": "Schritt 3 Mikrowellenleistung",
-        "state": {
-          "none": "Keine"
-        }
-      },
-      "step_3_status": {
-        "name": "Schritt 3 Status",
-        "state": {
-          "not_active": "Nicht aktiv",
-          "active": "Aktiv",
-          "available": "Verf\u00fcgbar"
-        }
-      },
-      "step_3_time_unit": {
-        "name": "Schritt 3 Zeiteinheit",
-        "state": {
-          "seconds": "Sekunden",
-          "minutes": "Minuten",
-          "hours": "Stunden"
-        }
-      },
-      "step_after_bake_mode": {
-        "name": "Nachbackphase Modus",
-        "state": {
-          "gratine": "Gratinieren"
-        }
-      },
-      "step_after_bake_time_unit": {
-        "name": "Nachbackphase Zeiteinheit",
-        "state": {
-          "seconds": "Sekunden",
-          "minutes": "Minuten",
-          "hours": "Stunden"
-        }
-      },
-      "step_pre_bake_mode": {
-        "name": "Vorbackphase Modus",
-        "state": {
-          "not_active": "Nicht aktiv",
-          "preheat": "Vorheizen",
-          "delay_start_waiting": "Warte auf Startverz\u00f6gerung"
-        }
-      },
-      "step_pre_bake_time_unit": {
-        "name": "Vorbackphase Zeiteinheit",
-        "state": {
-          "seconds": "Sekunden",
-          "minutes": "Minuten",
-          "hours": "Stunden"
-        }
-      },
-      "temperature_unit": {
-        "name": "Temperatureinheit",
-        "state": {
-          "celsius": "Celsius",
-          "fahrenheit": "Fahrenheit"
-        }
-      },
-      "time_format": {
-        "name": "Zeitformat",
-        "state": {
-          "12h": "12h",
-          "24h": "24h"
-        }
-      },
-      "volume": {
-        "name": "Lautst\u00e4rke"
-      },
-      "warming_drawer_power_level": {
-        "name": "Warmhalteschublade Leistungsstufe",
-        "state": {
-          "low": "Niedrig",
-          "medium": "Mittel",
-          "high": "Hoch"
-        }
-      },
-      "water_hardness": {
-        "name": "Wasserh\u00e4rte"
       }
     },
     "water_heater": {
@@ -4011,47 +3953,105 @@
           "auto": "Automatisch"
         }
       }
+    }
+  },
+  "issues": {
+    "unavailable_device": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "\"{device_name} nicht mehr verf\u00fcgbar\" wurde ignoriert. Das Ger\u00e4t und alle zugeh\u00f6rigen Eintr\u00e4ge bleiben im Verzeichnis."
+        },
+        "step": {
+          "init": {
+            "description": "Das Ger\u00e4t \"{device_name}\" ist nicht mehr in deinem ConnectLife-Konto verf\u00fcgbar. Wenn du das Ger\u00e4t nicht mehr besitzt, kannst du es aus Home Assistant entfernen.",
+            "menu_options": {
+              "ignore": "Ignorieren",
+              "remove": "Entfernen"
+            },
+            "title": "{device_name} nicht mehr verf\u00fcgbar"
+          },
+          "remove": {
+            "description": "Das Ger\u00e4t \"{device_name}\" und alle zugeh\u00f6rigen Entit\u00e4ten werden aus Home Assistant entfernt.",
+            "title": "{device_name} entfernen"
+          }
+        }
+      },
+      "title": "{device_name} nicht mehr verf\u00fcgbar"
+    }
+  },
+  "options": {
+    "error": {
+      "test_server_invalid": "Ung\u00fcltige Test-Server-URL",
+      "test_server_required": "Entwicklungsmodus erfordert eine Test-Server-URL"
     },
-    "number": {
-      "freeze_max_temperature": {
-        "name": "Maximale Gefriertemperatur"
+    "step": {
+      "configure_device": {
+        "data": {
+          "disable_beep": "Signalton deaktivieren"
+        },
+        "description": "Ein Ger\u00e4t konfigurieren."
       },
-      "freeze_min_temperature": {
-        "name": "Minimale Gefriertemperatur"
+      "development": {
+        "data": {
+          "development_mode": "Entwicklungsmodus",
+          "test_server_url": "Test-Server-URL"
+        },
+        "description": "Aktiviere den Entwicklungsmodus, um eine Verbindung zum Testserver anstelle der ConnectLife-API herzustellen."
       },
-      "freeze_temperature": {
-        "name": "Gefriertemperatur"
+      "init": {
+        "menu_options": {
+          "development": "Entwicklungsmodus konfigurieren",
+          "select_device": "Ger\u00e4t konfigurieren"
+        }
       },
-      "lightbrightness": {
-        "name": "Lichthelligkeit"
-      },
-      "lightcolortemperature": {
-        "name": "Lichtfarbtemperatur"
-      },
-      "refrigerator_max_temperature": {
-        "name": "Maximale K\u00fchlschranktemperatur"
-      },
-      "refrigerator_min_temperature": {
-        "name": "Minimale K\u00fchlschranktemperatur"
-      },
-      "refrigerator_temperature": {
-        "name": "K\u00fchlschranktemperatur"
-      },
-      "variation_max_temperature": {
-        "name": "Maximale Temperaturvariation"
-      },
-      "variation_min_temperature": {
-        "name": "Minimale Temperaturvariation"
-      },
-      "variation_temperature": {
-        "name": "Temperaturvariation"
-      },
-      "gratin_from_below_functionset_time_in_seconds": {
-        "name": "Gratin von unten Zeiteinstellung"
-      },
-      "gratin_function_set_time_in_seconds": {
-        "name": "Gratin Zeiteinstellung"
+      "select_device": {
+        "data": {
+          "device": "Ger\u00e4t ausw\u00e4hlen"
+        },
+        "description": "Ein Ger\u00e4t konfigurieren."
       }
+    }
+  },
+  "selector": {
+    "actions": {
+      "options": {
+        "1": "Stopp",
+        "2": "Start",
+        "3": "Pause",
+        "4": "T\u00fcr \u00f6ffnen"
+      }
+    }
+  },
+  "services": {
+    "set_action": {
+      "description": "Setzt eine Aktion f\u00fcr das Ger\u00e4t. Vorsicht bei der Verwendung.",
+      "fields": {
+        "action": {
+          "description": "Zu setzende Aktion.",
+          "name": "Aktion"
+        }
+      },
+      "name": "Aktion setzen"
+    },
+    "set_value": {
+      "description": "Setzt einen Wert f\u00fcr den Status. Vorsicht bei der Verwendung. Es wird kein Multiplikator angewendet.",
+      "fields": {
+        "value": {
+          "description": "Zu setzender Wert.",
+          "name": "Wert"
+        }
+      },
+      "name": "Wert setzen"
+    },
+    "update": {
+      "description": "Aktualisiert alle Eigenschaften, die im Datenfeld definiert sind.",
+      "fields": {
+        "data": {
+          "description": "Eigenschaften, die aktualisiert werden sollen",
+          "name": "Daten"
+        }
+      },
+      "name": "Ger\u00e4t aktualisieren"
     }
   }
 }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1,135 +1,18 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
     "step": {
       "user": {
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
-        }
-      }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    }
-  },
-  "issues": {
-    "unavailable_device": {
-      "title": "{device_name} no longer available",
-      "fix_flow": {
-        "abort": {
-          "issue_ignored": "Ignored \"{device_name} no longer available\". The device and all its entities will still be listed in the regiestry."
-        },
-        "step": {
-          "init": {
-            "title": "{device_name} no longer available",
-            "description": "The device \"{device_name}\" is now longer available in your ConnectLife account. If you no longer have this device, you can delete it from Home Assistant.",
-            "menu_options": {
-              "ignore": "Ignore",
-              "remove": "Remove"
-            }
-          },
-          "remove": {
-            "title": "Remove {device_name}",
-            "description": "The device \"{device_name}\" and all its entities will be removed from Home Assistant."
-          }
-        }
-      }
-    },
-    "unsupported_beep": {
-      "title": "Disable beep not supported by {device_name}",
-      "fix_flow": {
-        "abort": {
-          "issue_ignored": "Ignored \"Disable beep not supported by {device_name}\"."
-        },
-        "step": {
-          "init": {
-            "title": "Disable beep not supported by {device_name}",
-            "description": "The device \"{device_name}\" does not support the disable beep option.",
-            "menu_options": {
-              "confirm": "Update configuration",
-              "ignore": "Ignore"
-            }
-          }
-        }
-      }
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "menu_options": {
-          "select_device": "Configure a device",
-          "development": "Configure development mode"
-        }
-      },
-      "select_device": {
-        "data": {
-          "device": "Select device"
-        },
-        "description": "Configure a device."
-      },
-      "configure_device": {
-        "data": {
-          "disable_beep": "Disable beep"
-        },
-        "description": "Configure a device."
-      },
-      "development": {
-        "data": {
-          "development_mode": "Development mode",
-          "test_server_url": "Test server URL"
-        },
-        "description": "Enable development mode to connect to test server instead of the ConnectLife API."
-      }
-    },
-    "error": {
-      "test_server_invalid": "Invalid test server URL",
-      "test_server_required": "Development mode requires test server URL"
-    }
-  },
-  "selector": {
-    "actions": {
-      "options": {
-        "1": "Stop",
-        "2": "Start",
-        "3": "Pause",
-        "4": "Open door"
-      }
-    }
-  },
-  "services": {
-    "set_value": {
-      "name": "Set value",
-      "description": "Sets a value for the status. Use with care. Does not apply multiplier when setting.",
-      "fields": {
-        "value": {
-          "name": "Value",
-          "description": "Value to set."
-        }
-      }
-    },
-    "set_action": {
-      "name": "Set action",
-      "description": "Sets action for device. Use with care.",
-      "fields": {
-        "action": {
-          "name": "Action",
-          "description": "Action to set."
-        }
-      }
-    },
-    "update": {
-      "name": "Update device",
-      "description": "Updates all properties defined in the data field.",
-      "fields": {
-        "data": {
-          "name": "Data",
-          "description": "Properties that should be updated"
+          "password": "Password",
+          "username": "Username"
         }
       }
     }
@@ -1330,30 +1213,27 @@
         "state_attributes": {
           "fan_mode": {
             "state": {
-              "middle_low": "Middle low",
-              "middle_high": "Middle high"
+              "middle_high": "Middle high",
+              "middle_low": "Middle low"
             }
           },
           "preset_mode": {
             "state": {
               "ai": "AI",
-              "off": "Off",
-              "mute": "Mute",
+              "bedtime": "Bedtime",
               "eco_mute": "Eco mute",
-              "super": "Super",
-              "sleep_1": "Sleep 1",
-              "sleep_2": "Sleep 2",
-              "sleep_3": "Sleep 3",
-              "sleep_4": "Sleep 4",
               "eco_sleep_1": "Eco sleep 1",
               "eco_sleep_2": "Eco sleep 2",
               "eco_sleep_3": "Eco sleep 3",
               "eco_sleep_4": "Eco sleep 4",
-              "bedtime": "Bedtime"
+              "mute": "Mute",
+              "off": "Off",
+              "sleep_1": "Sleep 1",
+              "sleep_2": "Sleep 2",
+              "sleep_3": "Sleep 3",
+              "sleep_4": "Sleep 4",
+              "super": "Super"
             }
-          },
-          "swing_mode": {
-            "state": {}
           },
           "swing_horizontal_mode": {
             "state": {
@@ -1363,6 +1243,9 @@
               "right": "Right",
               "swing": "Swing"
             }
+          },
+          "swing_mode": {
+            "state": {}
           }
         }
       }
@@ -1373,12 +1256,506 @@
           "mode": {
             "state": {
               "auto": "Auto",
+              "clothes_dry": "Clothes dry",
               "continuous": "Continuous",
-              "manual": "Manual",
-              "clothes_dry": "Clothes dry"
+              "manual": "Manual"
             }
           }
         }
+      }
+    },
+    "number": {
+      "delayendtime_hour": {
+        "name": "Delayendtime hour"
+      },
+      "freeze_max_temperature": {
+        "name": "Freezeer max temperature"
+      },
+      "freeze_min_temperature": {
+        "name": "Freezeer min temperature"
+      },
+      "freeze_temperature": {
+        "name": "Freezeer temperature"
+      },
+      "gratin_from_below_functionset_time_in_seconds": {
+        "name": "Gratin from below function set time"
+      },
+      "gratin_function_set_time_in_seconds": {
+        "name": "Gratin function set time"
+      },
+      "lightbrightness": {
+        "name": "Light brightness"
+      },
+      "lightcolortemperature": {
+        "name": "Light color temperature"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Refrigerator max temperature"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Refrigerator min temperature"
+      },
+      "refrigerator_temperature": {
+        "name": "Refrigerator temperature"
+      },
+      "variation_max_temperature": {
+        "name": "Variation max temperature"
+      },
+      "variation_min_temperature": {
+        "name": "Variation min temperature"
+      },
+      "variation_temperature": {
+        "name": "Variation temperature"
+      }
+    },
+    "select": {
+      "actions": {
+        "name": "Actions",
+        "state": {
+          "add_duration": "Add duration",
+          "add_gratin": "Add gratin",
+          "none": "None",
+          "pause": "Pause",
+          "start": "Start",
+          "steam_shot": "Steam shot",
+          "stop": "Stop",
+          "stop_finish": "Stop finish"
+        }
+      },
+      "auto_dose_quantity_setting_status": {
+        "name": "Auto dose quantity"
+      },
+      "baking_steps_intensity_levels": {
+        "name": "Baking steps intensity levels",
+        "state": {
+          "none": "None"
+        }
+      },
+      "baking_steps_intensity_levels_type": {
+        "name": "Baking steps intensity levels type",
+        "state": {
+          "low_mid_high": "Low mid high",
+          "none": "None",
+          "not_used": "Not used",
+          "rare_medium_well_done": "Rare medium well done"
+        }
+      },
+      "brightness": {
+        "name": "Brightness"
+      },
+      "cooking_intensity": {
+        "name": "Cooking intensity"
+      },
+      "delayendtime": {
+        "name": "Delay end time",
+        "state": {
+          "10_hours": "10 hours",
+          "11_hours": "11 hours",
+          "12_hours": "12 hours",
+          "13_hours": "13 hours",
+          "14_hours": "14 hours",
+          "15_hours": "15 hours",
+          "16_hours": "16 hours",
+          "17_hours": "17 hours",
+          "18_hours": "18 hours",
+          "19_hours": "19 hours",
+          "1_hour": "1 hour",
+          "20_hours": "20 hours",
+          "21_hours": "21 hours",
+          "22_hours": "22 hours",
+          "23_hours": "23 hours",
+          "24_hours": "24 hours",
+          "2_hours": "2 hours",
+          "3_hours": "3 hours",
+          "4_hours": "4 hours",
+          "5_hours": "5 hours",
+          "6_hours": "6 hours",
+          "7_hours": "7 hours",
+          "8_hours": "8 hours",
+          "9_hours": "9 hours",
+          "none": "None"
+        }
+      },
+      "detergent": {
+        "name": "Detergent",
+        "state": {
+          "auto": "Auto",
+          "less": "Less",
+          "more": "More",
+          "standard": "Standard"
+        }
+      },
+      "dry_level": {
+        "name": "Drying level",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
+      "dry_time": {
+        "name": "Dry time",
+        "state": {
+          "10_min": "10 min",
+          "120_min": "120 min",
+          "15_min": "15 min",
+          "180_min": "180 min",
+          "240_min": "240 min",
+          "30_min": "30 min",
+          "5_min": "5 min",
+          "60_min": "60 min",
+          "90_min": "90 min",
+          "cupboard": "Cupboard",
+          "extra_dry": "Extra dry",
+          "iron": "Iron",
+          "none": "None",
+          "pre-ironing": "Pre-ironing",
+          "wardrobe": "Wardrobe"
+        }
+      },
+      "drymodel": {
+        "name": "Dry model",
+        "state": {
+          "dry_only": "Dry only",
+          "wash": "Wash",
+          "wash_and_dry": "Wash and dry"
+        }
+      },
+      "extrarinsenum": {
+        "name": "Extra rinse",
+        "state": {
+          "none": "None"
+        }
+      },
+      "language_status": {
+        "name": "Language",
+        "state": {
+          "english": "English",
+          "simplified_chinese": "Simplified chinese"
+        }
+      },
+      "motorlevel": {
+        "name": "Motor level"
+      },
+      "oven_temperature_unit": {
+        "name": "Oven temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "sand_timer_1_status_cmd": {
+        "name": "Sand timer 1 control",
+        "state": {
+          "cancel": "Cancel",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
+      "sand_timer_2_status_cmd": {
+        "name": "Sand timer 2 control",
+        "state": {
+          "cancel": "Cancel",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
+      "sand_timer_3_status_cmd": {
+        "name": "Sand timer 3 control",
+        "state": {
+          "cancel": "Cancel",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
+      "selected_program_id": {
+        "name": "Selected program",
+        "state": {
+          "allergy_care": "Allergy care",
+          "anti_allergy": "Anti allergy",
+          "auto": "Auto",
+          "baby": "Baby",
+          "baby_care": "Baby care",
+          "bed_linen": "Bed linen",
+          "bedding": "Bedding",
+          "clean_dry_60": "Clean dry 60",
+          "cotton": "Cotton",
+          "cotton_dry": "Cotton dry",
+          "delicates": "Delicates",
+          "down": "Down",
+          "drum_clean": "Drum clean",
+          "drum_cleaning": "Drum cleaning",
+          "duvet": "Duvet",
+          "eco": "Eco",
+          "eco_40_60": "Eco 40 60",
+          "fast15": "Fast15",
+          "fast30": "Quick 30",
+          "full_load_49": "Full load 49",
+          "hand_wash": "Hand wash",
+          "ion_refresh": "Ion refresh",
+          "jeans": "Jeans",
+          "mix": "Mix",
+          "pets": "Pets",
+          "power49": "Power49",
+          "power_30": "Power 30",
+          "power_49": "Power 49",
+          "quick_15": "Quick 15",
+          "quick_30": "Quick 30",
+          "rack_dry": "Rack dry",
+          "refresh": "Refresh",
+          "rinse_spin": "Rinse spin",
+          "shirts": "Shirts",
+          "silk_delicate": "Silk delicate",
+          "spin": "Spin",
+          "spin-dry": "Spin-dry",
+          "sports": "Sports",
+          "sportswear": "Sportswear",
+          "synthetic": "Synthetics",
+          "synthetic_dry": "Synthetic dry",
+          "synthetics": "Synthetics",
+          "time": "Time",
+          "time_dry": "Time dry",
+          "towels": "Towels",
+          "wash_and_dry_49": "Wash and dry 49",
+          "wool": "Wool"
+        }
+      },
+      "softener": {
+        "name": "Softener",
+        "state": {
+          "auto": "Auto",
+          "less": "Less",
+          "more": "More",
+          "standard": "Standard"
+        }
+      },
+      "spin_speed_rpm": {
+        "name": "Spin speed",
+        "state": {
+          "none": "None"
+        }
+      },
+      "stain_removal": {
+        "name": "Stain removal",
+        "state": {
+          "blood": "Blood",
+          "coffee": "Coffee",
+          "grass": "Grass",
+          "juice": "Juice",
+          "milk": "Milk",
+          "oil": "Oil",
+          "soil": "Soil",
+          "sweat": "Sweat",
+          "wine": "Wine"
+        }
+      },
+      "steam_123": {
+        "name": "Steam 123",
+        "state": {
+          "steam123_0": "Steam123 0",
+          "steam123_1": "Steam123 1",
+          "steam123_2": "Steam123 2",
+          "steam123_3": "Steam123 3"
+        }
+      },
+      "step_1_bake_mode": {
+        "name": "Step 1 bake mode",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake - Cleaning",
+          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
+          "extrabake_warming": "ExtraBake - Warming",
+          "meatprobebake": "MeatProbeBake",
+          "probake": "ProBake",
+          "recipe": "Recipe",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
+        }
+      },
+      "step_1_set_microwave_wattage": {
+        "name": "Step 1 set microwave wattage",
+        "state": {
+          "none": "None"
+        }
+      },
+      "step_1_time_unit": {
+        "name": "Step 1 time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_2_bake_mode": {
+        "name": "Step 2 bake mode",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Recipe",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
+        }
+      },
+      "step_2_set_microwave_wattage": {
+        "name": "Step 2 set microwave wattage",
+        "state": {
+          "none": "None"
+        }
+      },
+      "step_2_time_unit": {
+        "name": "Step 2 time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_3_bake_mode": {
+        "name": "Step 3 bake mode",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Recipe",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
+        }
+      },
+      "step_3_set_microwave_wattage": {
+        "name": "Step 3 set microwave wattage",
+        "state": {
+          "none": "None"
+        }
+      },
+      "step_3_status": {
+        "name": "Step 3 status",
+        "state": {
+          "active": "Active",
+          "available": "Available",
+          "not_active": "Not active"
+        }
+      },
+      "step_3_time_unit": {
+        "name": "Step 3 time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_after_bake_mode": {
+        "name": "Step after bake mode",
+        "state": {
+          "gratine": "Gratine"
+        }
+      },
+      "step_after_bake_time_unit": {
+        "name": "Step after bake time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "step_pre_bake_mode": {
+        "name": "Step pre bake mode",
+        "state": {
+          "delay_start_waiting": "Delay start waiting",
+          "not_active": "Not active",
+          "preheat": "Preheat"
+        }
+      },
+      "step_pre_bake_time_unit": {
+        "name": "Step pre bake time unit",
+        "state": {
+          "hours": "Hours",
+          "minutes": "Minutes",
+          "seconds": "Seconds"
+        }
+      },
+      "t_fan_speed": {
+        "name": "Fan speed",
+        "state": {
+          "auto": "Auto",
+          "high": "High",
+          "low": "Low"
+        }
+      },
+      "t_sleep": {
+        "name": "Sleep Mode",
+        "state": {
+          "for_kid": "For kid",
+          "for_old": "For old",
+          "for_young": "For young",
+          "general": "General",
+          "off": "Off"
+        }
+      },
+      "t_swing_angle": {
+        "name": "Swing angle",
+        "state": {
+          "angle_1": "Angle 1",
+          "angle_2": "Angle 2",
+          "angle_3": "Angle 3",
+          "angle_4": "Angle 4",
+          "angle_5": "Angle 5",
+          "angle_6": "Angle 6",
+          "auto": "Auto",
+          "swing": "Swing"
+        }
+      },
+      "t_swing_follow": {
+        "name": "AI ventilation",
+        "state": {
+          "follow": "Follow",
+          "not_follow": "Not Follow",
+          "off": "Off"
+        }
+      },
+      "temperature": {
+        "name": "Temperature",
+        "state": {
+          "cold": "Cold"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "time_format": {
+        "name": "Time format",
+        "state": {
+          "12h": "12h",
+          "24h": "24h"
+        }
+      },
+      "volume": {
+        "name": "Volume"
+      },
+      "warming_drawer_power_level": {
+        "name": "Warming drawer power level",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
+      "water_hardness": {
+        "name": "Water hardness"
       }
     },
     "sensor": {
@@ -1406,8 +1783,8 @@
       "applicationpermissions": {
         "name": "Application permissions",
         "state": {
-          "not_granted": "Not granted",
-          "granted": "Granted"
+          "granted": "Granted",
+          "not_granted": "Not granted"
         }
       },
       "auto_dose_duration": {
@@ -1419,8 +1796,8 @@
       "autodose_flag": {
         "name": "Auto dose flag",
         "state": {
-          "unavailable": "Unavailable",
-          "available": "Available"
+          "available": "Available",
+          "unavailable": "Unavailable"
         }
       },
       "bundling_humidity": {
@@ -1448,38 +1825,38 @@
       "current_baking_step": {
         "name": "Current baking step",
         "state": {
-          "preheat": "Preheat",
-          "step_1": "Step 1",
-          "step_2": "Step 2",
-          "step_3": "Step 3",
+          "after_bake": "After bake",
           "after_bake_finished": "After bake finished",
           "pre_bake": "Pre bake",
-          "after_bake": "After bake",
-          "special": "Special"
+          "preheat": "Preheat",
+          "special": "Special",
+          "step_1": "Step 1",
+          "step_2": "Step 2",
+          "step_3": "Step 3"
         }
       },
       "current_program_phase": {
         "state": {
-          "not_available": "Not available",
-          "program_not_selected": "Program not selected",
-          "program_selected": "Program selected",
+          "anti_crease": "Anti crease",
+          "delay": "Delay",
           "delay_start_waiting": "Delay start waiting",
+          "drying": "Drying",
+          "finished": "Finished",
+          "idle": "Idle",
+          "main_wash": "Main wash",
+          "not_available": "Not available",
           "preheat": "Preheat",
           "preheat_finished": "Preheat finished",
           "prewash": "Pre-wash",
-          "main_wash": "Main wash",
-          "drying": "Drying",
           "program_finished": "Finished",
-          "ventilating": "Ventilating",
-          "idle": "Idle",
-          "running": "Running",
-          "anti_crease": "Anti crease",
-          "delay": "Delay",
-          "finished": "Finished",
-          "weigh": "Weigh",
-          "wash": "Wash",
+          "program_not_selected": "Program not selected",
+          "program_selected": "Program selected",
           "rinse": "Rinse",
-          "spin-dry": "Spin-dry"
+          "running": "Running",
+          "spin-dry": "Spin-dry",
+          "ventilating": "Ventilating",
+          "wash": "Wash",
+          "weigh": "Weigh"
         }
       },
       "current_programphase": {
@@ -1534,8 +1911,8 @@
         "name": "Detergent",
         "state": {
           "less": "Less",
-          "standard": "Standard",
-          "more": "More"
+          "more": "More",
+          "standard": "Standard"
         }
       },
       "detergent_display": {
@@ -1544,6 +1921,7 @@
       "detergentstandarddosage": {
         "name": "Detergent standard dosage",
         "state": {
+          "100ml": "100 ml",
           "10ml": "10 ml",
           "15ml": "15 ml",
           "20ml": "20 ml",
@@ -1561,13 +1939,15 @@
           "80ml": "80 ml",
           "85ml": "85 ml",
           "90ml": "90 ml",
-          "95ml": "95 ml",
-          "100ml": "100 ml"
+          "95ml": "95 ml"
         }
       },
       "device_status": {
         "state": {
+          "after_bake_finished": "After bake finished",
+          "delay_time_waiting": "Delay time waiting",
           "demo_mode": "Demo mode",
+          "error": "Error",
           "failure": "Failure",
           "idle": "Idle",
           "iq": "IQ",
@@ -1575,14 +1955,11 @@
           "not_available": "Not available",
           "pause": "Paused",
           "pause_mode": "Paused",
+          "paused": "Paused",
           "production": "Production",
           "running": "Running",
           "service": "Service",
-          "stand_by": "Stand by",
-          "paused": "Paused",
-          "delay_time_waiting": "Delay time waiting",
-          "error": "Error",
-          "after_bake_finished": "After bake finished"
+          "stand_by": "Stand by"
         }
       },
       "display_brightness_setting_status": {
@@ -1597,19 +1974,19 @@
       "display_switch_to_standby_after_minutes": {
         "name": "Display switch to standby after minutes",
         "state": {
-          "5_min": "5 min",
           "15_min": "15 min",
-          "30_min": "30 min"
+          "30_min": "30 min",
+          "5_min": "5 min"
         }
       },
       "door_status": {
         "name": "Door status",
         "state": {
+          "closed": "Closed",
+          "locked": "Locked",
           "not_available": "Not available",
           "open": "Open",
-          "closed": "Closed",
-          "other": "Other",
-          "locked": "Locked"
+          "other": "Other"
         }
       },
       "dryopen_defaultspinspeed": {
@@ -1639,7 +2016,6 @@
       "error_code": {
         "name": "Error code",
         "state": {
-          "none": "None",
           "error_f01": "Error f01",
           "error_f03": "Error f03",
           "error_f04": "Error f04",
@@ -1653,7 +2029,8 @@
           "error_f17": "Error f17",
           "error_f18": "Error f18",
           "error_f23": "Error f23",
-          "error_f24": "Error f24"
+          "error_f24": "Error f24",
+          "none": "None"
         }
       },
       "error_read_out_1_code": {
@@ -1698,10 +2075,10 @@
       "feedback_volumen_setting_status": {
         "name": "Feedback volume",
         "state": {
-          "mute": "Mute",
+          "high": "High",
           "low": "Low",
           "mid": "Mid",
-          "high": "High"
+          "mute": "Mute"
         }
       },
       "filter_state": {
@@ -1713,11 +2090,11 @@
       "fota": {
         "name": "Fota",
         "state": {
-          "not_available": "Not available",
-          "waiting_for_confirmation": "Waiting for confirmation",
-          "in_progress": "In progress",
+          "confirm_fota": "Confirm fota",
           "finished": "Finished",
-          "confirm_fota": "Confirm fota"
+          "in_progress": "In progress",
+          "not_available": "Not available",
+          "waiting_for_confirmation": "Waiting for confirmation"
         }
       },
       "freeze_door_open_time": {
@@ -1753,10 +2130,10 @@
       "hardpairingstatus": {
         "name": "Hard pairing status",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "unpair_all_users": "Unpair all users",
-          "reserved": "Reserved"
+          "not_active": "Not active",
+          "reserved": "Reserved",
+          "unpair_all_users": "Unpair all users"
         }
       },
       "heat_pump_setting_status": {
@@ -1771,9 +2148,9 @@
       "hob_warming_zone_power_level": {
         "name": "Hob warming zone power level",
         "state": {
+          "high": "High",
           "low": "Low",
-          "medium": "Medium",
-          "high": "High"
+          "medium": "Medium"
         }
       },
       "hob_zone_1_status": {
@@ -1828,9 +2205,9 @@
         "name": "Machine status",
         "state": {
           "off": "Off",
-          "standby": "Standby",
+          "paused": "Paused",
           "running": "Running",
-          "paused": "Paused"
+          "standby": "Standby"
         }
       },
       "mainwashtime": {
@@ -1854,9 +2231,9 @@
       "meat_probe_status": {
         "name": "Meat probe status",
         "state": {
-          "not_active": "Not active",
+          "active_hob": "Active hob",
           "active_oven": "Active oven",
-          "active_hob": "Active hob"
+          "not_active": "Not active"
         }
       },
       "medium_humidity": {
@@ -1962,8 +2339,8 @@
       "sand_timer1_status": {
         "name": "Timer 1 status",
         "state": {
-          "started": "Started",
           "paused": "Paused",
+          "started": "Started",
           "stopped": "Stopped"
         }
       },
@@ -1973,8 +2350,8 @@
       "sand_timer2_status": {
         "name": "Timer 2 status",
         "state": {
-          "started": "Started",
           "paused": "Paused",
+          "started": "Started",
           "stopped": "Stopped"
         }
       },
@@ -1984,8 +2361,8 @@
       "sand_timer3_status": {
         "name": "Timer 3 status",
         "state": {
-          "started": "Started",
           "paused": "Paused",
+          "started": "Started",
           "stopped": "Stopped"
         }
       },
@@ -2010,11 +2387,11 @@
       "sand_timer_1_status": {
         "name": "Sand timer 1 status",
         "state": {
+          "ended": "Ended",
           "not_active": "Not active",
-          "running": "Running",
           "paused": "Paused",
-          "stopped": "Stopped",
-          "ended": "Ended"
+          "running": "Running",
+          "stopped": "Stopped"
         }
       },
       "sand_timer_2_duration_hours": {
@@ -2038,11 +2415,11 @@
       "sand_timer_2_status": {
         "name": "Sand timer 2 status",
         "state": {
+          "ended": "Ended",
           "not_active": "Not active",
-          "running": "Running",
           "paused": "Paused",
-          "stopped": "Stopped",
-          "ended": "Ended"
+          "running": "Running",
+          "stopped": "Stopped"
         }
       },
       "sand_timer_3_duration_hours": {
@@ -2066,11 +2443,11 @@
       "sand_timer_3_status": {
         "name": "Sand timer 3 status",
         "state": {
+          "ended": "Ended",
           "not_active": "Not active",
-          "running": "Running",
           "paused": "Paused",
-          "stopped": "Stopped",
-          "ended": "Ended"
+          "running": "Running",
+          "stopped": "Stopped"
         }
       },
       "scanned_ean_code": {
@@ -2082,76 +2459,76 @@
       "selected_program_id": {
         "name": "Selected program",
         "state": {
+          "anti_allergy": "Anti allergy",
+          "auto": "Auto",
+          "baby": "Baby",
+          "bed_linen": "Bed linen",
+          "cotton": "Cotton",
           "cotton_storage": "Cotton storage",
-          "standard": "Standard",
+          "down": "Down",
+          "extra_hygiene": "Extra hygiene",
+          "fast30": "Fast30",
+          "fast89": "Fast89",
           "iron": "Iron",
           "mix": "Mix",
-          "synthetic": "Synthetic",
-          "wool": "Wool",
-          "bed_linen": "Bed linen",
-          "time": "Time",
-          "baby": "Baby",
+          "none": "None",
+          "refresh": "Refresh",
+          "remote": "Remote",
           "sensitive": "Sensitive",
           "shirts": "Shirts",
           "sports": "Sports",
-          "fast89": "Fast89",
-          "extra_hygiene": "Extra hygiene",
-          "remote": "Remote",
-          "none": "None",
-          "auto": "Auto",
-          "anti_allergy": "Anti allergy",
-          "refresh": "Refresh",
+          "standard": "Standard",
+          "synthetic": "Synthetic",
+          "time": "Time",
           "towels": "Towels",
-          "cotton": "Cotton",
-          "fast30": "Fast30",
-          "down": "Down"
+          "wool": "Wool"
         }
       },
       "selected_program_id_status": {
         "name": "Selected program",
         "state": {
           "auto": "Auto",
-          "eco": "Eco",
-          "one_hour": "1 hour",
-          "intensive": "Intensive",
-          "glass": "Glass",
-          "hygiene": "Hygiene",
-          "night": "Night",
+          "baby": "Baby",
           "clean": "Clean",
-          "eco_40_60": "Eco 40-60",
-          "white_cotton": "White Cotton",
           "color": "Color",
-          "wool_manual": "Wool & Manual",
-          "mix_synthetic": "Mix/Synthetic",
+          "down_feathers": "Down feathers",
+          "draining": "Draining",
+          "drum_cleaning": "Drum Cleaning",
+          "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra Hygiene",
           "fast_20": "Fast 20'",
+          "glass": "Glass",
+          "hygiene": "Hygiene",
+          "intensive": "Intensive",
           "intensive_59_32": "Intensive 59'/32'",
-          "sport": "Sport",
-          "baby": "Baby",
-          "shirts": "Shirts",
-          "drum_cleaning": "Drum Cleaning",
-          "spinning_draining": "Spinning & Draining",
-          "rinsing_softening": "Rinsing & Softening",
+          "mix_synthetic": "Mix/Synthetic",
+          "night": "Night",
           "no_program_selected": "No program selected",
+          "one_hour": "1 hour",
           "pet_hair_removal": "Pet hair removal",
-          "draining": "Draining",
-          "down_feathers": "Down feathers"
+          "rinsing_softening": "Rinsing & Softening",
+          "shirts": "Shirts",
+          "spinning_draining": "Spinning & Draining",
+          "sport": "Sport",
+          "white_cotton": "White Cotton",
+          "wool_manual": "Wool & Manual"
         }
       },
       "selected_program_mode": {
         "name": "Selected program mode",
         "state": {
-          "normal": "Normal",
-          "fast": "Fast"
+          "fast": "Fast",
+          "normal": "Normal"
         }
       },
       "selected_program_mode_status": {
         "name": "Program mode",
         "state": {
-          "not_available": "Not available",
-          "normal": "Normal",
+          "extra_fast": "Extra fast",
           "fast": "Fast",
-          "extra_fast": "Extra fast"
+          "normal": "Normal",
+          "not_available": "Not available"
         }
       },
       "selected_program_remaining_time_in_minutes": {
@@ -2160,12 +2537,12 @@
       "selected_program_set_temperature_status": {
         "name": "Temperature",
         "state": {
-          "not_available": "Not available",
-          "cold": "Cold",
           "20_c": "20 \u00b0C",
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C"
+          "60_c": "60 \u00b0C",
+          "cold": "Cold",
+          "not_available": "Not available"
         }
       },
       "selected_program_total_running_time": {
@@ -2183,14 +2560,14 @@
       "selected_program_washing_spin_speed_rpm_status": {
         "name": "Spin speed",
         "state": {
-          "not_available": "Not available",
-          "no_spin": "No spin",
           "0_rpm": "0",
-          "800_rpm": "800",
-          "400_rpm": "400",
           "1000_rpm": "1000",
           "1200_rpm": "1200",
-          "1400_rpm": "1400"
+          "1400_rpm": "1400",
+          "400_rpm": "400",
+          "800_rpm": "800",
+          "no_spin": "No spin",
+          "not_available": "Not available"
         }
       },
       "selected_programduration_inminutes": {
@@ -2202,28 +2579,28 @@
       "session_pairing_active": {
         "name": "Session pairing active",
         "state": {
+          "close_session": "Close session",
           "no_active_session": "No active session",
           "request_denied": "Request denied",
-          "session_is_active": "Session is active",
-          "close_session": "Close session"
+          "session_is_active": "Session is active"
         }
       },
       "set_progress_type": {
         "name": "Set progress type",
         "state": {
-          "oven_set": "Oven set",
+          "cleaning": "Cleaning",
+          "culi_set": "Culi set",
+          "defrost": "Defrost",
+          "fast_set": "Fast set",
           "mw_set": "Mw set",
           "mwc_set": "Mwc set",
-          "st_set": "St set",
-          "stc_set": "Stc set",
-          "fast_set": "Fast set",
-          "stage_set": "Stage set",
-          "culi_set": "Culi set",
-          "warming": "Warming",
-          "defrost": "Defrost",
-          "cleaning": "Cleaning",
+          "none": "None",
+          "oven_set": "Oven set",
           "pyrolysis": "Pyrolysis",
-          "none": "None"
+          "st_set": "St set",
+          "stage_set": "Stage set",
+          "stc_set": "Stc set",
+          "warming": "Warming"
         }
       },
       "set_time_hour": {
@@ -2258,13 +2635,13 @@
       "sl1_functions": {
         "name": "Zone 1 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl1_ntc_sensor": {
@@ -2279,11 +2656,11 @@
       "sl1_zone_shape": {
         "name": "Zone 1 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl2_active_timer": {
@@ -2297,13 +2674,13 @@
       "sl2_functions": {
         "name": "Zone 2 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl2_ntc_sensor": {
@@ -2318,11 +2695,11 @@
       "sl2_zone_shape": {
         "name": "Zone 2 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl3_active_timer": {
@@ -2336,13 +2713,13 @@
       "sl3_functions": {
         "name": "Zone 3 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl3_ntc_sensor": {
@@ -2357,11 +2734,11 @@
       "sl3_zone_shape": {
         "name": "Zone 3 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl4_active_timer": {
@@ -2375,13 +2752,13 @@
       "sl4_functions": {
         "name": "Zone 4 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl4_ntc_sensor": {
@@ -2396,11 +2773,11 @@
       "sl4_zone_shape": {
         "name": "Zone 4 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl5_active_timer": {
@@ -2414,13 +2791,13 @@
       "sl5_functions": {
         "name": "Zone 5 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl5_ntc_sensor": {
@@ -2435,11 +2812,11 @@
       "sl5_zone_shape": {
         "name": "Zone 5 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "sl6_active_timer": {
@@ -2453,13 +2830,13 @@
       "sl6_functions": {
         "name": "Zone 6 function",
         "state": {
-          "none": "None",
           "boil": "Boil",
-          "simmer": "Simmer",
+          "grill": "Grill",
           "keep_warm": "Keep warm",
-          "wok": "Wok",
+          "none": "None",
           "roast": "Roast",
-          "grill": "Grill"
+          "simmer": "Simmer",
+          "wok": "Wok"
         }
       },
       "sl6_ntc_sensor": {
@@ -2474,19 +2851,19 @@
       "sl6_zone_shape": {
         "name": "Zone 6 shape",
         "state": {
-          "round": "Round",
-          "square": "Square",
-          "rectangle_vertical": "Vertical rectangle",
+          "no_shape": "No shape",
           "rectangle_horizontal": "Horizontal Rectangle",
-          "no_shape": "No shape"
+          "rectangle_vertical": "Vertical rectangle",
+          "round": "Round",
+          "square": "Square"
         }
       },
       "softener": {
         "name": "Softener",
         "state": {
           "less": "Less",
-          "standard": "Standard",
-          "more": "More"
+          "more": "More",
+          "standard": "Standard"
         }
       },
       "softer_display": {
@@ -2495,6 +2872,7 @@
       "softnerstandarddosage": {
         "name": "Softener standard dosage",
         "state": {
+          "100ml": "100 ml",
           "10ml": "10 ml",
           "15ml": "15 ml",
           "20ml": "20 ml",
@@ -2512,8 +2890,7 @@
           "80ml": "80 ml",
           "85ml": "85 ml",
           "90ml": "90 ml",
-          "95ml": "95 ml",
-          "100ml": "100 ml"
+          "95ml": "95 ml"
         }
       },
       "sound_setting": {
@@ -2531,15 +2908,15 @@
       "status": {
         "name": "Device status",
         "state": {
-          "off": "Off",
-          "standby": "Standby",
-          "running": "Running",
-          "not_avaliable": "Not avaliable",
+          "delay_time_waiting": "Delay time waiting",
+          "error": "Error",
           "idle": "Idle",
+          "not_avaliable": "Not avaliable",
+          "off": "Off",
           "pause": "Pause",
           "production": "Production",
-          "delay_time_waiting": "Delay time waiting",
-          "error": "Error"
+          "running": "Running",
+          "standby": "Standby"
         }
       },
       "steam_assist_time_used": {
@@ -2551,45 +2928,45 @@
       "step1_heater_system": {
         "name": "Step 1 heater system",
         "state": {
-          "hot_air": "Hot air",
-          "eco_hot_air": "Eco hot air",
-          "top_bottom": "Top bottom",
-          "hot_air_bottom": "Hot air bottom",
-          "bottom_fan": "Bottom fan",
+          "aqua_clean": "Aqua clean",
           "bottom": "Bottom",
-          "top": "Top",
-          "small_grill": "Small grill",
-          "large_grill": "Large grill",
-          "large_grill_fan": "Large grill fan",
-          "pro_roasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_fan": "Bottom fan",
+          "clean_air": "Clean air",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "descale": "Descale",
+          "eco_hot_air": "Eco hot air",
+          "fast_preheat": "Fast preheat",
+          "grill_fan_micro": "Grill fan micro",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air": "Hot air",
+          "hot_air_bottom": "Hot air bottom",
+          "hot_air_micro": "Hot air micro",
           "hot_air_steam_1": "Hot air steam 1",
           "hot_air_steam_2": "Hot air steam 2",
           "hot_air_steam_3": "Hot air steam 3",
-          "fast_preheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
+          "hotairmicro": "Hot air + microwave",
           "keep_warm": "Keep warm",
-          "plates": "Plates",
-          "aqua_clean": "Aqua clean",
-          "steam_clean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "microwave_defrost": "Microwave defrost",
-          "sous_vide": "Sous vide",
+          "large_grill": "Large grill",
+          "large_grill_fan": "Large grill fan",
           "low_temp_steam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "clean_air": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
+          "micro": "Microwave",
           "microwave_clean": "Microwave clean",
-          "hot_air_micro": "Hot air micro",
-          "grill_fan_micro": "Grill fan micro"
+          "microwave_defrost": "Microwave defrost",
+          "plates": "Plates",
+          "pro_roasting": "Pro roasting",
+          "programs": "Programs",
+          "pyro": "Pyro",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "small_grill": "Small grill",
+          "sous_vide": "Sous vide",
+          "steam": "Steam",
+          "steam_clean": "Steam clean",
+          "top": "Top",
+          "top_bottom": "Top bottom",
+          "warming": "Warming"
         }
       },
       "step1_remaining_time": {
@@ -2601,10 +2978,10 @@
       "step1_steam_assist_intensity": {
         "name": "Step 1 steam assist intensity",
         "state": {
-          "not_active": "Not active",
+          "high": "High",
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "not_active": "Not active"
         }
       },
       "step1_steam_assistset_time_in_minutes": {
@@ -2616,43 +2993,43 @@
       "step2_heater_system": {
         "name": "Step 2 heater system",
         "state": {
-          "hot_air": "Hot air",
-          "eco_hot_air": "Eco hot air",
-          "top_bottom": "Top bottom",
-          "hot_air_bottom": "Hot air bottom",
-          "bottom_fan": "Bottom fan",
+          "aqua_clean": "Aqua clean",
           "bottom": "Bottom",
-          "top": "Top",
-          "small_grill": "Small grill",
-          "large_grill": "Large grill",
-          "large_grill_fan": "Large grill fan",
-          "pro_roasting": "Pro roasting",
-          "hot_air_micro": "Hot air micro",
+          "bottom_fan": "Bottom fan",
+          "clean_air": "Clean air",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "descale": "Descale",
+          "eco_hot_air": "Eco hot air",
+          "fast_preheat": "Fast preheat",
           "grill_fan_micro": "Grill fan micro",
-          "micro": "Microwave",
+          "hot_air": "Hot air",
+          "hot_air_bottom": "Hot air bottom",
+          "hot_air_micro": "Hot air micro",
           "hot_air_steam_1": "Hot air steam 1",
           "hot_air_steam_2": "Hot air steam 2",
           "hot_air_steam_3": "Hot air steam 3",
-          "fast_preheat": "Fast preheat",
-          "pyrolysis": "Pyrolysis",
-          "defrost": "Defrost",
           "keep_warm": "Keep warm",
-          "plates": "Plates",
-          "aqua_clean": "Aqua clean",
-          "steam_clean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "microwave_defrost": "Microwave defrost",
-          "sous_vide": "Sous vide",
+          "large_grill": "Large grill",
+          "large_grill_fan": "Large grill fan",
           "low_temp_steam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "clean_air": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
+          "micro": "Microwave",
+          "microwave_clean": "Microwave clean",
+          "microwave_defrost": "Microwave defrost",
+          "plates": "Plates",
+          "pro_roasting": "Pro roasting",
           "programs": "Programs",
-          "warming": "Warming",
-          "microwave_clean": "Microwave clean"
+          "pyrolysis": "Pyrolysis",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "small_grill": "Small grill",
+          "sous_vide": "Sous vide",
+          "steam": "Steam",
+          "steam_clean": "Steam clean",
+          "top": "Top",
+          "top_bottom": "Top bottom",
+          "warming": "Warming"
         }
       },
       "step2_remaining_time": {
@@ -2664,10 +3041,10 @@
       "step2_steam_assist_intensity": {
         "name": "Step 2 steam assist intensity",
         "state": {
-          "not_active": "Not active",
+          "high": "High",
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "not_active": "Not active"
         }
       },
       "step2_steam_assistset_time_in_minutes": {
@@ -2679,43 +3056,43 @@
       "step3_heater_system": {
         "name": "Step3 heater system",
         "state": {
-          "hot_air": "Hot air",
-          "eco_hot_air": "Eco hot air",
-          "top_bottom": "Top bottom",
-          "hot_air_bottom": "Hot air bottom",
-          "bottom_fan": "Bottom fan",
+          "aqua_clean": "Aqua clean",
           "bottom": "Bottom",
-          "top": "Top",
-          "small_grill": "Small grill",
-          "large_grill": "Large grill",
-          "large_grill_fan": "Large grill fan",
-          "pro_roasting": "Pro roasting",
-          "hot_air_micro": "Hot air micro",
+          "bottom_fan": "Bottom fan",
+          "clean_air": "Clean air",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "descale": "Descale",
+          "eco_hot_air": "Eco hot air",
+          "fast_preheat": "Fast preheat",
           "grill_fan_micro": "Grill fan micro",
-          "micro": "Microwave",
+          "hot_air": "Hot air",
+          "hot_air_bottom": "Hot air bottom",
+          "hot_air_micro": "Hot air micro",
           "hot_air_steam_1": "Hot air steam 1",
           "hot_air_steam_2": "Hot air steam 2",
           "hot_air_steam_3": "Hot air steam 3",
-          "fast_preheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keep_warm": "Keep warm",
-          "plates": "Plates",
-          "aqua_clean": "Aqua clean",
-          "steam_clean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "microwave_defrost": "Microwave defrost",
-          "sous_vide": "Sous vide",
+          "large_grill": "Large grill",
+          "large_grill_fan": "Large grill fan",
           "low_temp_steam": "Low temperature steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "clean_air": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
+          "micro": "Microwave",
+          "microwave_clean": "Microwave clean",
+          "microwave_defrost": "Microwave defrost",
+          "plates": "Plates",
+          "pro_roasting": "Pro roasting",
           "programs": "Programs",
-          "warming": "Warming",
-          "microwave_clean": "Microwave clean"
+          "pyro": "Pyro",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "small_grill": "Small grill",
+          "sous_vide": "Sous vide",
+          "steam": "Steam",
+          "steam_clean": "Steam clean",
+          "top": "Top",
+          "top_bottom": "Top bottom",
+          "warming": "Warming"
         }
       },
       "step3_remaining_time": {
@@ -2727,10 +3104,10 @@
       "step3_steam_assist_intensity": {
         "name": "Step 3 steam assist intensity",
         "state": {
-          "not_active": "Not active",
+          "high": "High",
           "low": "Low",
           "medium": "Medium",
-          "high": "High"
+          "not_active": "Not active"
         }
       },
       "step3_steam_assistset_time_in_minutes": {
@@ -2739,18 +3116,18 @@
       "step_1_bake_mode": {
         "name": "Step 1 bake mode",
         "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake - Cleaning",
+          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
+          "extrabake_warming": "ExtraBake - Warming",
+          "meatprobebake": "MeatProbeBake",
+          "probake": "ProBake",
           "recipe": "Recipe",
           "steambake": "SteamBake",
           "steamcombibake": "SteamCombiBake",
-          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
-          "extrabake_warming": "ExtraBake - Warming",
-          "extrabake_cleaning": "ExtraBake - Cleaning",
-          "meatprobebake": "MeatProbeBake"
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
         }
       },
       "step_1_duration": {
@@ -2765,79 +3142,79 @@
       "step_1_set_heater_system": {
         "name": "Step 1 set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_1_set_microwave_wattage": {
@@ -2852,30 +3229,30 @@
       "step_1_steam_available": {
         "name": "Step 1 steam available",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_1_time_unit": {
         "name": "Step 1 time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_2_bake_mode": {
         "name": "Step 2 bake mode",
         "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
           "recipe": "Recipe",
           "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
         }
       },
       "step_2_duration": {
@@ -2890,79 +3267,79 @@
       "step_2_set_heater_system": {
         "name": "Step 2 set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_2_set_microwave_wattage": {
@@ -2977,30 +3354,30 @@
       "step_2_steam_available": {
         "name": "Step 2 steam available",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_2_time_unit": {
         "name": "Step 2 time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_3_bake_mode": {
         "name": "Step 3 bake mode",
         "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
           "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
           "recipe": "Recipe",
           "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Undefined"
         }
       },
       "step_3_duration": {
@@ -3015,79 +3392,79 @@
       "step_3_set_heater_system": {
         "name": "Step 3 set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_3_set_microwave_wattage": {
@@ -3102,25 +3479,25 @@
       "step_3_status": {
         "name": "Step 3 status",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_3_steam_available": {
         "name": "Step 3 steam available",
         "state": {
-          "not_active": "Not active",
           "active": "Active",
-          "available": "Available"
+          "available": "Available",
+          "not_active": "Not active"
         }
       },
       "step_3_time_unit": {
         "name": "Step 3 time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_after_bake_duration": {
@@ -3141,79 +3518,79 @@
       "step_after_bake_set_heater_system": {
         "name": "Step after bake set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_after_bake_set_temperature": {
@@ -3222,9 +3599,9 @@
       "step_after_bake_time_unit": {
         "name": "Step after bake time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "step_pre_bake_duration": {
@@ -3233,9 +3610,9 @@
       "step_pre_bake_mode": {
         "name": "Step pre bake mode",
         "state": {
+          "delay_start_waiting": "Delay start waiting",
           "not_active": "Not active",
-          "preheat": "Preheat",
-          "delay_start_waiting": "Delay start waiting"
+          "preheat": "Preheat"
         }
       },
       "step_pre_bake_passed_time": {
@@ -3247,79 +3624,79 @@
       "step_pre_bake_set_heater_system": {
         "name": "Step pre bake set heater system",
         "state": {
-          "hotair": "Hot air",
-          "ecohotair": "Eco hot air",
-          "topbottom": "Top + bottom",
-          "hotairbottom": "Hot air + bottom",
-          "bottomfan": "Bottom + fan",
+          "3d_hot_ai": "3D hot air",
+          "air_fry": "Air fry",
+          "aquaclean": "AquaClean",
+          "bake": "Bake",
           "bottom": "Bottom",
-          "top": "Top",
-          "smallgrill": "Small grill",
-          "largegrill": "Large grill",
-          "largegrillfan": "Large grill + fan",
-          "proroasting": "Pro roasting",
-          "hotairmicro": "Hot air + microwave",
+          "bottom_infra": "Bottom + infra",
+          "bottom_infra_fan": "Bottom + infra + fan",
+          "bottom_top_heat": "Bottom + top heat",
+          "bottom_top_heat_fan": "Bottom + top heat + fan",
+          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
+          "bottomfan": "Bottom + fan",
+          "broil": "Broil",
+          "cleanair": "Clean air",
+          "convection_bake": "Convection bake",
+          "convection_roast": "Convection roast",
+          "count": "Count",
+          "crisp": "Crisp",
+          "defrost": "Defrost",
+          "defrost_auto": "Auto defrost",
+          "dehydrate": "Dehydrate",
+          "descale": "Descale",
+          "eco": "Eco",
+          "ecohotair": "Eco hot air",
+          "fastpreheat": "Fast preheat",
+          "frozen_bake": "Frozen bake",
+          "gentle_bake": "Gentle bake",
+          "gratin": "Gratin",
           "grillfanmicro": "Grill + fan + microwave",
-          "micro": "Microwave",
+          "hot_air_bottomheat": "Hot air + bottom heat",
+          "hot_air_infra": "Hot air + infra",
+          "hot_air_upper": "Hot air + upper",
+          "hotair": "Hot air",
+          "hotairbottom": "Hot air + bottom",
+          "hotairmicro": "Hot air + microwave",
           "hotairsteam1": "Hot air + steam 1",
           "hotairsteam2": "Hot air + steam 2",
           "hotairsteam3": "Hot air + steam 3",
-          "fastpreheat": "Fast preheat",
-          "pyro": "Pyro",
-          "defrost": "Defrost",
           "keepwarm": "Keep warm",
-          "plates": "Plates",
-          "aquaclean": "AquaClean",
-          "steamclean": "Steam clean",
-          "regenerate": "Regenerate",
-          "descale": "Descale",
-          "mwdefrost": "Microwave defrost",
-          "sousvide": "Sous vide",
-          "lowtempsteam": "Low temp steam",
-          "steam": "Steam",
-          "quick": "Quick",
-          "cleanair": "Clean air",
-          "defrost_auto": "Auto defrost",
-          "sabbath": "Sabbath",
-          "programs": "Programs",
-          "warming": "Warming",
-          "mwclean": "Microwave clean",
-          "count": "Count",
-          "undefined": "Undefined",
-          "pyrolize": "Pyrolize",
-          "gentle_bake": "Gentle bake",
-          "air_fry": "Air fry",
-          "bottom_top_heat": "Bottom + top heat",
+          "large_grill": "Large grill",
           "large_grill_bottom": "Large grill + bottom",
           "large_grill_bottom_fan": "Large grill + bottom + fan",
-          "large_grill": "Large grill",
-          "hot_air_bottomheat": "Hot air + bottom heat",
-          "3d_hot_ai": "3D hot air",
-          "eco": "Eco",
-          "bottom_top_heat_fan_steam": "Bottom + top heat + fan + steam",
-          "large_grill_fan_steam": "Large grill + fan + steam",
-          "hot_air_upper": "Hot air + upper",
-          "hot_air_infra": "Hot air + infra",
-          "bottom_infra": "Bottom + infra",
-          "bottom_infra_fan": "Bottom + infra + fan",
-          "pizza": "Pizza",
-          "frozen_bake": "Frozen bake",
-          "gratin": "Gratin",
-          "bake": "Bake",
-          "convection_bake": "Convection bake",
-          "broil": "Broil",
-          "self_clean": "Self clean",
-          "convection_roast": "Convection roast",
-          "proof": "Proof",
-          "dehydrate": "Dehydrate",
-          "crisp": "Crisp",
           "large_grill_bottom_hot_air": "Large grill + bottom + hot air",
-          "bottom_top_heat_fan": "Bottom + top heat + fan",
-          "largegrillsteak_pyro": "Large grill steak pyro",
+          "large_grill_fan_steam": "Large grill + fan + steam",
+          "largegrill": "Large grill",
           "largegrill_pyro": "Large grill pyro",
+          "largegrillfan": "Large grill + fan",
           "largegrillfan_pyro": "Large grill + fan pyro",
+          "largegrillsteak_pyro": "Large grill steak pyro",
+          "lowtempsteam": "Low temp steam",
+          "micro": "Microwave",
+          "mwclean": "Microwave clean",
+          "mwdefrost": "Microwave defrost",
+          "none": "None",
+          "pizza": "Pizza",
+          "plates": "Plates",
+          "programs": "Programs",
+          "proof": "Proof",
+          "proroasting": "Pro roasting",
+          "pyro": "Pyro",
+          "pyrolize": "Pyrolize",
+          "quick": "Quick",
+          "regenerate": "Regenerate",
+          "sabbath": "Sabbath",
+          "self_clean": "Self clean",
+          "smallgrill": "Small grill",
           "smallgrill_pyro": "Small grill pyro",
-          "none": "None"
+          "sousvide": "Sous vide",
+          "steam": "Steam",
+          "steamclean": "Steam clean",
+          "top": "Top",
+          "topbottom": "Top + bottom",
+          "undefined": "Undefined",
+          "warming": "Warming"
         }
       },
       "step_pre_bake_set_temperature": {
@@ -3328,9 +3705,9 @@
       "step_pre_bake_time_unit": {
         "name": "Step pre bake time unit",
         "state": {
-          "seconds": "Seconds",
+          "hours": "Hours",
           "minutes": "Minutes",
-          "hours": "Hours"
+          "seconds": "Seconds"
         }
       },
       "super_rinse_setting_status": {
@@ -3422,9 +3799,9 @@
       "warming_drawer_power_level": {
         "name": "Warming drawer power level",
         "state": {
+          "high": "High",
           "low": "Low",
-          "medium": "Medium",
-          "high": "High"
+          "medium": "Medium"
         }
       },
       "washing_machine_type_kg": {
@@ -3626,506 +4003,129 @@
         "name": "Welcome"
       }
     },
-    "select": {
-      "actions": {
-        "name": "Actions",
-        "state": {
-          "start": "Start",
-          "pause": "Pause",
-          "stop_finish": "Stop finish",
-          "add_duration": "Add duration",
-          "add_gratin": "Add gratin",
-          "steam_shot": "Steam shot",
-          "none": "None",
-          "stop": "Stop"
-        }
-      },
-      "auto_dose_quantity_setting_status": {
-        "name": "Auto dose quantity"
-      },
-      "baking_steps_intensity_levels": {
-        "name": "Baking steps intensity levels",
-        "state": {
-          "none": "None"
-        }
-      },
-      "baking_steps_intensity_levels_type": {
-        "name": "Baking steps intensity levels type",
-        "state": {
-          "none": "None",
-          "not_used": "Not used",
-          "low_mid_high": "Low mid high",
-          "rare_medium_well_done": "Rare medium well done"
-        }
-      },
-      "brightness": {
-        "name": "Brightness"
-      },
-      "cooking_intensity": {
-        "name": "Cooking intensity"
-      },
-      "delayendtime": {
-        "name": "Delay end time",
-        "state": {
-          "none": "None",
-          "1_hour": "1 hour",
-          "2_hours": "2 hours",
-          "3_hours": "3 hours",
-          "4_hours": "4 hours",
-          "5_hours": "5 hours",
-          "6_hours": "6 hours",
-          "7_hours": "7 hours",
-          "8_hours": "8 hours",
-          "9_hours": "9 hours",
-          "10_hours": "10 hours",
-          "11_hours": "11 hours",
-          "12_hours": "12 hours",
-          "13_hours": "13 hours",
-          "14_hours": "14 hours",
-          "15_hours": "15 hours",
-          "16_hours": "16 hours",
-          "17_hours": "17 hours",
-          "18_hours": "18 hours",
-          "19_hours": "19 hours",
-          "20_hours": "20 hours",
-          "21_hours": "21 hours",
-          "22_hours": "22 hours",
-          "23_hours": "23 hours",
-          "24_hours": "24 hours"
-        }
-      },
-      "detergent": {
-        "name": "Detergent",
-        "state": {
-          "auto": "Auto",
-          "less": "Less",
-          "standard": "Standard",
-          "more": "More"
-        }
-      },
-      "dry_level": {
-        "name": "Drying level",
-        "state": {
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "dry_time": {
-        "name": "Dry time",
-        "state": {
-          "wardrobe": "Wardrobe",
-          "pre-ironing": "Pre-ironing",
-          "extra_dry": "Extra dry",
-          "30_min": "30 min",
-          "60_min": "60 min",
-          "90_min": "90 min",
-          "120_min": "120 min",
-          "180_min": "180 min",
-          "240_min": "240 min",
-          "iron": "Iron",
-          "cupboard": "Cupboard",
-          "none": "None",
-          "5_min": "5 min",
-          "10_min": "10 min",
-          "15_min": "15 min"
-        }
-      },
-      "drymodel": {
-        "name": "Dry model",
-        "state": {
-          "wash": "Wash",
-          "wash_and_dry": "Wash and dry",
-          "dry_only": "Dry only"
-        }
-      },
-      "extrarinsenum": {
-        "name": "Extra rinse",
-        "state": {
-          "none": "None"
-        }
-      },
-      "language_status": {
-        "name": "Language",
-        "state": {
-          "english": "English",
-          "simplified_chinese": "Simplified chinese"
-        }
-      },
-      "motorlevel": {
-        "name": "Motor level"
-      },
-      "oven_temperature_unit": {
-        "name": "Oven temperature unit",
-        "state": {
-          "celsius": "Celsius",
-          "fahrenheit": "Fahrenheit"
-        }
-      },
-      "sand_timer_1_status_cmd": {
-        "name": "Sand timer 1 control",
-        "state": {
-          "start": "Start",
-          "stop": "Stop",
-          "pause": "Pause",
-          "cancel": "Cancel"
-        }
-      },
-      "sand_timer_2_status_cmd": {
-        "name": "Sand timer 2 control",
-        "state": {
-          "start": "Start",
-          "stop": "Stop",
-          "pause": "Pause",
-          "cancel": "Cancel"
-        }
-      },
-      "sand_timer_3_status_cmd": {
-        "name": "Sand timer 3 control",
-        "state": {
-          "start": "Start",
-          "stop": "Stop",
-          "pause": "Pause",
-          "cancel": "Cancel"
-        }
-      },
-      "selected_program_id": {
-        "name": "Selected program",
-        "state": {
-          "auto": "Auto",
-          "anti_allergy": "Anti allergy",
-          "refresh": "Refresh",
-          "sports": "Sports",
-          "towels": "Towels",
-          "time": "Time",
-          "cotton": "Cotton",
-          "baby": "Baby",
-          "synthetic": "Synthetics",
-          "wool": "Wool",
-          "delicates": "Delicates",
-          "fast30": "Quick 30",
-          "shirts": "Shirts",
-          "bed_linen": "Bed linen",
-          "down": "Down",
-          "cotton_dry": "Cotton dry",
-          "synthetic_dry": "Synthetic dry",
-          "drum_cleaning": "Drum cleaning",
-          "eco_40_60": "Eco 40 60",
-          "fast15": "Fast15",
-          "spin-dry": "Spin-dry",
-          "rinse_spin": "Rinse spin",
-          "clean_dry_60": "Clean dry 60",
-          "power49": "Power49",
-          "allergy_care": "Allergy care",
-          "wash_and_dry_49": "Wash and dry 49",
-          "bedding": "Bedding",
-          "power_30": "Power 30",
-          "pets": "Pets",
-          "full_load_49": "Full load 49",
-          "mix": "Mix",
-          "jeans": "Jeans",
-          "sportswear": "Sportswear",
-          "hand_wash": "Hand wash",
-          "eco": "Eco",
-          "ion_refresh": "Ion refresh",
-          "duvet": "Duvet",
-          "time_dry": "Time dry",
-          "baby_care": "Baby care",
-          "synthetics": "Synthetics",
-          "quick_30": "Quick 30",
-          "rack_dry": "Rack dry",
-          "drum_clean": "Drum clean",
-          "quick_15": "Quick 15",
-          "spin": "Spin",
-          "silk_delicate": "Silk delicate",
-          "power_49": "Power 49"
-        }
-      },
-      "softener": {
-        "name": "Softener",
-        "state": {
-          "auto": "Auto",
-          "less": "Less",
-          "standard": "Standard",
-          "more": "More"
-        }
-      },
-      "spin_speed_rpm": {
-        "name": "Spin speed",
-        "state": {
-          "none": "None"
-        }
-      },
-      "stain_removal": {
-        "name": "Stain removal",
-        "state": {
-          "wine": "Wine",
-          "grass": "Grass",
-          "soil": "Soil",
-          "coffee": "Coffee",
-          "milk": "Milk",
-          "juice": "Juice",
-          "sweat": "Sweat",
-          "blood": "Blood",
-          "oil": "Oil"
-        }
-      },
-      "steam_123": {
-        "name": "Steam 123",
-        "state": {
-          "steam123_0": "Steam123 0",
-          "steam123_1": "Steam123 1",
-          "steam123_2": "Steam123 2",
-          "steam123_3": "Steam123 3"
-        }
-      },
-      "step_1_bake_mode": {
-        "name": "Step 1 bake mode",
-        "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Recipe",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake",
-          "extrabake_fastpreheat": "ExtraBake - Fast preheat",
-          "extrabake_warming": "ExtraBake - Warming",
-          "extrabake_cleaning": "ExtraBake - Cleaning",
-          "meatprobebake": "MeatProbeBake"
-        }
-      },
-      "step_1_set_microwave_wattage": {
-        "name": "Step 1 set microwave wattage",
-        "state": {
-          "none": "None"
-        }
-      },
-      "step_1_time_unit": {
-        "name": "Step 1 time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_2_bake_mode": {
-        "name": "Step 2 bake mode",
-        "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Recipe",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
-        }
-      },
-      "step_2_set_microwave_wattage": {
-        "name": "Step 2 set microwave wattage",
-        "state": {
-          "none": "None"
-        }
-      },
-      "step_2_time_unit": {
-        "name": "Step 2 time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_3_bake_mode": {
-        "name": "Step 3 bake mode",
-        "state": {
-          "undefined": "Undefined",
-          "probake": "ProBake",
-          "stepbake": "StepBake",
-          "extrabake": "ExtraBake",
-          "autobake": "AutoBake",
-          "recipe": "Recipe",
-          "steambake": "SteamBake",
-          "steamcombibake": "SteamCombiBake"
-        }
-      },
-      "step_3_set_microwave_wattage": {
-        "name": "Step 3 set microwave wattage",
-        "state": {
-          "none": "None"
-        }
-      },
-      "step_3_status": {
-        "name": "Step 3 status",
-        "state": {
-          "not_active": "Not active",
-          "active": "Active",
-          "available": "Available"
-        }
-      },
-      "step_3_time_unit": {
-        "name": "Step 3 time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_after_bake_mode": {
-        "name": "Step after bake mode",
-        "state": {
-          "gratine": "Gratine"
-        }
-      },
-      "step_after_bake_time_unit": {
-        "name": "Step after bake time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "step_pre_bake_mode": {
-        "name": "Step pre bake mode",
-        "state": {
-          "not_active": "Not active",
-          "preheat": "Preheat",
-          "delay_start_waiting": "Delay start waiting"
-        }
-      },
-      "step_pre_bake_time_unit": {
-        "name": "Step pre bake time unit",
-        "state": {
-          "seconds": "Seconds",
-          "minutes": "Minutes",
-          "hours": "Hours"
-        }
-      },
-      "t_fan_speed": {
-        "name": "Fan speed",
-        "state": {
-          "auto": "Auto",
-          "low": "Low",
-          "high": "High"
-        }
-      },
-      "t_sleep": {
-        "name": "Sleep Mode",
-        "state": {
-          "off": "Off",
-          "general": "General",
-          "for_old": "For old",
-          "for_young": "For young",
-          "for_kid": "For kid"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Swing angle",
-        "state": {
-          "swing": "Swing",
-          "auto": "Auto",
-          "angle_1": "Angle 1",
-          "angle_2": "Angle 2",
-          "angle_3": "Angle 3",
-          "angle_4": "Angle 4",
-          "angle_5": "Angle 5",
-          "angle_6": "Angle 6"
-        }
-      },
-      "t_swing_follow": {
-        "name": "AI ventilation",
-        "state": {
-          "off": "Off",
-          "follow": "Follow",
-          "not_follow": "Not Follow"
-        }
-      },
-      "temperature": {
-        "name": "Temperature",
-        "state": {
-          "cold": "Cold"
-        }
-      },
-      "temperature_unit": {
-        "name": "Temperature unit",
-        "state": {
-          "celsius": "Celsius",
-          "fahrenheit": "Fahrenheit"
-        }
-      },
-      "time_format": {
-        "name": "Time format",
-        "state": {
-          "12h": "12h",
-          "24h": "24h"
-        }
-      },
-      "volume": {
-        "name": "Volume"
-      },
-      "warming_drawer_power_level": {
-        "name": "Warming drawer power level",
-        "state": {
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "water_hardness": {
-        "name": "Water hardness"
-      }
-    },
     "water_heater": {
       "connectlife": {
         "state": {
           "auto": "Auto"
         }
       }
+    }
+  },
+  "issues": {
+    "unavailable_device": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "Ignored \"{device_name} no longer available\". The device and all its entities will still be listed in the regiestry."
+        },
+        "step": {
+          "init": {
+            "description": "The device \"{device_name}\" is now longer available in your ConnectLife account. If you no longer have this device, you can delete it from Home Assistant.",
+            "menu_options": {
+              "ignore": "Ignore",
+              "remove": "Remove"
+            },
+            "title": "{device_name} no longer available"
+          },
+          "remove": {
+            "description": "The device \"{device_name}\" and all its entities will be removed from Home Assistant.",
+            "title": "Remove {device_name}"
+          }
+        }
+      },
+      "title": "{device_name} no longer available"
     },
-    "number": {
-      "delayendtime_hour": {
-        "name": "Delayendtime hour"
+    "unsupported_beep": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "Ignored \"Disable beep not supported by {device_name}\"."
+        },
+        "step": {
+          "init": {
+            "description": "The device \"{device_name}\" does not support the disable beep option.",
+            "menu_options": {
+              "confirm": "Update configuration",
+              "ignore": "Ignore"
+            },
+            "title": "Disable beep not supported by {device_name}"
+          }
+        }
       },
-      "freeze_max_temperature": {
-        "name": "Freezeer max temperature"
+      "title": "Disable beep not supported by {device_name}"
+    }
+  },
+  "options": {
+    "error": {
+      "test_server_invalid": "Invalid test server URL",
+      "test_server_required": "Development mode requires test server URL"
+    },
+    "step": {
+      "configure_device": {
+        "data": {
+          "disable_beep": "Disable beep"
+        },
+        "description": "Configure a device."
       },
-      "freeze_min_temperature": {
-        "name": "Freezeer min temperature"
+      "development": {
+        "data": {
+          "development_mode": "Development mode",
+          "test_server_url": "Test server URL"
+        },
+        "description": "Enable development mode to connect to test server instead of the ConnectLife API."
       },
-      "freeze_temperature": {
-        "name": "Freezeer temperature"
+      "init": {
+        "menu_options": {
+          "development": "Configure development mode",
+          "select_device": "Configure a device"
+        }
       },
-      "gratin_from_below_functionset_time_in_seconds": {
-        "name": "Gratin from below function set time"
-      },
-      "gratin_function_set_time_in_seconds": {
-        "name": "Gratin function set time"
-      },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
-      "refrigerator_max_temperature": {
-        "name": "Refrigerator max temperature"
-      },
-      "refrigerator_min_temperature": {
-        "name": "Refrigerator min temperature"
-      },
-      "refrigerator_temperature": {
-        "name": "Refrigerator temperature"
-      },
-      "variation_max_temperature": {
-        "name": "Variation max temperature"
-      },
-      "variation_min_temperature": {
-        "name": "Variation min temperature"
-      },
-      "variation_temperature": {
-        "name": "Variation temperature"
+      "select_device": {
+        "data": {
+          "device": "Select device"
+        },
+        "description": "Configure a device."
       }
+    }
+  },
+  "selector": {
+    "actions": {
+      "options": {
+        "1": "Stop",
+        "2": "Start",
+        "3": "Pause",
+        "4": "Open door"
+      }
+    }
+  },
+  "services": {
+    "set_action": {
+      "description": "Sets action for device. Use with care.",
+      "fields": {
+        "action": {
+          "description": "Action to set.",
+          "name": "Action"
+        }
+      },
+      "name": "Set action"
+    },
+    "set_value": {
+      "description": "Sets a value for the status. Use with care. Does not apply multiplier when setting.",
+      "fields": {
+        "value": {
+          "description": "Value to set.",
+          "name": "Value"
+        }
+      },
+      "name": "Set value"
+    },
+    "update": {
+      "description": "Updates all properties defined in the data field.",
+      "fields": {
+        "data": {
+          "description": "Properties that should be updated",
+          "name": "Data"
+        }
+      },
+      "name": "Update device"
     }
   }
 }

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -1,1745 +1,1744 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "El dispositivo ya está configurado"
-        },
-        "error": {
-            "cannot_connect": "Fallo al establecer la conexión",
-            "invalid_auth": "Autentificación Fallida",
-            "unknown": "Error desconocido"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "password": "Contraseña",
-                    "username": "Nombre de usuario"
-                }
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "El dispositivo ya est\u00e1 configurado"
     },
-    "issues": {
-        "unavailable_device": {
-            "title": "{device_name} no está disponible",
-            "fix_flow": {
-                "abort": {
-                    "issue_ignored": "El dispositivo ignorado \"{device_name} no está disponible\". El dispositivo y todas sus entidades permanecerán listadas en el registro."
-                },
-                "step": {
-                    "init": {
-                        "title": "{device_name} no está disponible",
-                        "description": "El dispositivo \"{device_name}\" está disponible en tu cuenta de ConnectLife. Si ya no dispones de este dispositivo, puedes eliminarlo de Home Assistant.",
-                        "menu_options": {
-                            "ignore": "Ignorar",
-                            "remove": "Eliminar"
-                        }
-                    },
-                    "remove": {
-                        "title": "Eliminar {device_name}",
-                        "description": "El dispositivo \"{device_name}\" y todas sus entidades serán eliminadas de Home Assistant."
-                    }
-                }
-            }
-        }
+    "error": {
+      "cannot_connect": "Fallo al establecer la conexi\u00f3n",
+      "invalid_auth": "Autentificaci\u00f3n Fallida",
+      "unknown": "Error desconocido"
     },
-    "options": {
-        "step": {
-            "init": {
-                "menu_options": {
-                    "select_device": "Configurar un dispositivo",
-                    "development": "Configurar modo desarrollo"
-                }
-            },
-            "select_device": {
-                "data": {
-                    "device": "Seleccionar dispositivo"
-                },
-                "description": "Configurar un dispositivo."
-            },
-            "configure_device": {
-                "data": {
-                    "disable_beep": "Deshabilitar beep"
-                },
-                "description": "Configurar un dispositivo."
-            },
-            "development": {
-                "data": {
-                    "development_mode": "Modo desarrollo",
-                    "test_server_url": "Test server URL"
-                },
-                "description": "Habilitar modo desarrollo para conectar al test server en vez de a ConnectLife API."
-            }
-        },
-        "error": {
-            "test_server_invalid": "Test server URL invalida",
-            "test_server_required": "El modo desarrollo requiere una URL del Test Server"
+    "step": {
+      "user": {
+        "data": {
+          "password": "Contrase\u00f1a",
+          "username": "Nombre de usuario"
         }
-    },
-    "services": {
-        "set_value": {
-            "name": "Asignar valor",
-            "description": "Asignar valor al estado. Usar con cuidado.",
-            "fields": {
-                "value": {
-                    "name": "Valor",
-                    "description": "Valor a asignar."
-                }
-            }
-        }
-    },
-    "entity": {
-        "binary_sensor": {
-            "alarm_1": {
-                "name": "Alarma 1"
-            },
-            "alarm_10": {
-                "name": "Alarma 10"
-            },
-            "alarm_11": {
-                "name": "Alarma 11"
-            },
-            "alarm_12": {
-                "name": "Alarm 12"
-            },
-            "alarm_2": {
-                "name": "Alarma 2"
-            },
-            "alarm_3": {
-                "name": "Alarma 3"
-            },
-            "alarm_4": {
-                "name": "Alarma 4"
-            },
-            "alarm_5": {
-                "name": "Alarma 5"
-            },
-            "alarm_6": {
-                "name": "Alarma 6"
-            },
-            "alarm_7": {
-                "name": "Alarma 7"
-            },
-            "alarm_8": {
-                "name": "Alarma 8"
-            },
-            "alarm_9": {
-                "name": "Alarma 9"
-            },
-            "alarm_alarm_time_reached": {
-                "name": "Tiempo de alarma finalizado."
-            },
-            "alarm_auto_dose_refill": {
-                "name": "Alarma en el auto relleno del dosificador"
-            },
-            "alarm_auto_program_notification": {
-                "name": "Auto program notification"
-            },
-            "alarm_autodose_level10": {
-                "name": "Autodosificador nivel 10"
-            },
-            "alarm_autodose_level20": {
-                "name": "Autodosificador nivel 20"
-            },
-            "alarm_automatic_switch_off_zone": {
-                "name": "Interruptor de zona automatico"
-            },
-            "alarm_baking_finished": {
-                "name": "Alarma de horneado finalizada"
-            },
-            "alarm_clean_the_filters": {
-                "name": "Limpiar filtros"
-            },
-            "alarm_descale_now": {
-                "name": "Alarma, descalcifique ahora"
-            },
-            "alarm_door_closed": {
-                "name": "Puerta cerrada"
-            },
-            "alarm_door_opened": {
-                "name": "Puerta abierta"
-            },
-            "alarm_external_autodose_level15": {
-                "name": "Autodosificador externo nivel 15"
-            },
-            "alarm_external_autodose_level30": {
-                "name": "Autodosificador externo nivel 30"
-            },
-            "alarm_hob_hood_started": {
-                "name": "Campana encendida"
-            },
-            "alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina NTC"
-            },
-            "alarm_ntc_power": {
-                "name": "NTC power"
-            },
-            "alarm_ntc_tc": {
-                "name": "NTC TC"
-            },
-            "alarm_preheat_reached": {
-                "name": "Alarma, precalentamiento alcanzado"
-            },
-            "alarm_preheating_ready": {
-                "name": "Precalentado"
-            },
-            "alarm_program_done": {
-                "name": "Programa terminado"
-            },
-            "alarm_program_pause": {
-                "name": "Programa pausado"
-            },
-            "alarm_remote_start_canceled": {
-                "name": "Inicio remoto cancelado"
-            },
-            "alarm_rinse_aid_refill": {
-                "name": "Recargar abrillantador"
-            },
-            "alarm_rinse_aid_refill_external": {
-                "name": "Recargar abrillantador externo"
-            },
-            "alarm_run_selfcleaning": {
-                "name": "Ejecutar autolimpieza"
-            },
-            "alarm_salt_refill": {
-                "name": "Recargar sal"
-            },
-            "alarm_sani_program_finished": {
-                "name": "Programa Sani terminado"
-            },
-            "alarm_steam_empty": {
-                "name": "Vapor vacío"
-            },
-            "alarm_temperature_reached": {
-                "name": "Temperatura alcanzada"
-            },
-            "alarm_timer_ended": {
-                "name": "Tiempo finalizado"
-            },
-            "alarm_turn_food": {
-                "name": "Girar comida"
-            },
-            "alarm_voltage": {
-                "name": "Voltage"
-            },
-            "alarm_warning_fastpreheat": {
-                "name": "Atención, precalentamiento rápido"
-            },
-            "alarm_warning_microwave": {
-                "name": "Atención microondas"
-            },
-            "alarm_warning_steam": {
-                "name": "Atención vapor caliente"
-            },
-            "alarm_water_tank_empty": {
-                "name": "Tanque de agua vacio"
-            },
-            "alarm_water_tank_missing": {
-                "name": "Tanque de agua no encontrado"
-            },
-            "alarm_zone_turned_off": {
-                "name": "Zona apagada"
-            },
-            "charcoal_filter_expiration_alarm": {
-                "name": "Alarma de caducidad del filtro de carbón"
-            },
-            "child_lock": {
-                "name": "Bloqueo niños"
-            },
-            "child_lock_status": {
-                "name": "Bloqueo niños"
-            },
-            "clean_filter": {
-                "name": "Limpiar filtro"
-            },
-            "delay_start_status": {
-                "name": "Estado de inicio retrasado"
-            },
-            "delaystart_delayend_mode": {
-                "name": "Inicio retrasado"
-            },
-            "demo_mode": {
-                "name": "Modo demostración"
-            },
-            "door": {
-                "name": "Puerta"
-            },
-            "eco_mode": {
-                "name": "Modo ECO"
-            },
-            "error_0": {
-                "name": "Error 0"
-            },
-            "error_1": {
-                "name": "Error 1"
-            },
-            "error_10": {
-                "name": "Error 10"
-            },
-            "error_11": {
-                "name": "Error 11"
-            },
-            "error_12": {
-                "name": "Error 12"
-            },
-            "error_13": {
-                "name": "Error 13"
-            },
-            "error_14": {
-                "name": "Error 14"
-            },
-            "error_15": {
-                "name": "Error 15"
-            },
-            "error_16": {
-                "name": "Error 16"
-            },
-            "error_2": {
-                "name": "Error 2"
-            },
-            "error_3": {
-                "name": "Error 3"
-            },
-            "error_4": {
-                "name": "Error 4"
-            },
-            "error_5": {
-                "name": "Error 5"
-            },
-            "error_6": {
-                "name": "Error 6"
-            },
-            "error_7": {
-                "name": "Error 7"
-            },
-            "error_8": {
-                "name": "Error 8"
-            },
-            "error_9": {
-                "name": "Error 9"
-            },
-            "f_e_filterclean": {
-                "name": "Limpiar filtro"
-            },
-            "f_e_pump": {
-                "name": "Bomba"
-            },
-            "f_e_push": {
-                "name": "Empujar"
-            },
-            "f_e_temp": {
-                "name": "Temperatura"
-            },
-            "f_e_tubetemp": {
-                "name": "Temperatura tubo"
-            },
-            "f_e_waterfull": {
-                "name": "Agua llena"
-            },
-            "f_e_wetsensor": {
-                "name": "Sensor humedo"
-            },
-            "fill_salt": {
-                "name": "Recargar sal"
-            },
-            "float_switch": {
-                "name": "Interruptor de flotador"
-            },
-            "free_defrosting_failure": {
-                "name": "Fallo en descongelación del congelador"
-            },
-            "free_evap_temp_sens_head_failure": {
-                "name": "Falla en el cabezal sensor de temperatura del evaporador del congelador"
-            },
-            "free_fan_failure": {
-                "name": "Fallo del ventilador del congelador"
-            },
-            "free_room_over_temp_alarm_failure": {
-                "name": "Fallo de alarma de exceso de temperatura en la sala del congelador"
-            },
-            "free_temp_sens_head_failure": {
-                "name": "Falla en el cabezal sensor de temperatura del congelador"
-            },
-            "frost_state": {
-                "name": "Estado de escarcha"
-            },
-            "hard_pairing_status": {
-                "name": "Estado de emparejamiento difícil"
-            },
-            "humidity_sensor": {
-                "name": "Sensor humedad"
-            },
-            "humidity_sensor_failure": {
-                "name": "Fallo en el sensor de humedad"
-            },
-            "ice_making_machine_failure": {
-                "name": "Fallo en maquina de hielo"
-            },
-            "light": {
-                "name": "Luz"
-            },
-            "low_wine_area_c_evaporator_fault": {
-                "name": "Fallo del evaporador del área baja c de vino"
-            },
-            "low_wine_area_c_fan_fault": {
-                "name": "Fallo del ventilador del área baja c de vino"
-            },
-            "low_wine_area_c_humdy_fault": {
-                "name": "Fallo en la humedad del área baja c de vino"
-            },
-            "low_wine_area_c_temp_fault": {
-                "name": "Fallo en la temperatura del área baja c de vino"
-            },
-            "mid_wine_area_b_evaporator_fault": {
-                "name": "Fallo del evaporador del área media b de vino"
-            },
-            "mid_wine_area_b_fan_fault": {
-                "name": "Fallo del ventilador del área media b de vino"
-            },
-            "mid_wine_area_b_humdy_fault": {
-                "name": "Fallo en la humedad del área media b de vino"
-            },
-            "mid_wine_area_b_temp_fault": {
-                "name": "Fallo en la temperatura del área media b de vino"
-            },
-            "open_freeze_door_alarm": {
-                "name": "Alarma, puerta abierta del frigorífico"
-            },
-            "open_refrigerator_door_alarm": {
-                "name": "Alarma, puerta abierta del frigorífico"
-            },
-            "open_the_door_alarm": {
-                "name": "Alarma, puerta abierta"
-            },
-            "open_variation_door_alarm": {
-                "name": "Alarma, puerta abierta"
-            },
-            "preheat": {
-                "name": "Precalentar"
-            },
-            "quiet_mode_status": {
-                "name": "Modo silencioso"
-            },
-            "reed_switch": {
-                "name": "Interruptor caña"
-            },
-            "refr_defrosting_failure": {
-                "name": "Fallo en el descongelamiento del refrigerador"
-            },
-            "refr_dry_wet_room_sens_failure": {
-                "name": "Fallo en sensor de compartimento seco-húmedo del refrigerador"
-            },
-            "refr_evap_temp_sens_head_failure": {
-                "name": "Fallo en el cabezal del sensor de temperatura"
-            },
-            "refr_fan_failure": {
-                "name": "Fallo en el ventilador del refrigerador"
-            },
-            "refr_room_open": {
-                "name": "Puerta abierta refrigerador"
-            },
-            "refr_room_over_temp_alarm": {
-                "name": "Alarma de temperatura en el refigerador"
-            },
-            "refr_temp_sens_head_failure": {
-                "name": "Fallo en el cabezal del sensor de temperatura"
-            },
-            "refr_var_room_sens_failure": {
-                "name": "Refrigerator var room sens failure"
-            },
-            "remote_control_mode_monitoring": {
-                "name": "Monitoreo del modo de control remoto"
-            },
-            "rx_failure": {
-                "name": "Fallo RX"
-            },
-            "sabbath_mode_status": {
-                "name": "Estado Sabbath mode"
-            },
-            "sabbath_mode_switch_status": {
-                "name": "Estado interruptor Sabbath mode"
-            },
-            "save_mode": {
-                "name": "Modo ahorro"
-            },
-            "selected_program_anticrease_status": {
-                "name": "Antiarrgas "
-            },
-            "selected_program_extradry_status": {
-                "name": "Secado extra"
-            },
-            "selected_program_steamfinish": {
-                "name": "Vaporización terminada"
-            },
-            "session_pairing_active": {
-                "name": "Emparejamiento de sesiones activo"
-            },
-            "sl1_alarm_auto_program_notification": {
-                "name": "Notificación de programa automático de zona 1"
-            },
-            "sl1_alarm_automatic_switch_off_zone": {
-                "name": "La zona 1 se apaga automáticamente"
-            },
-            "sl1_alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina de la zona 1"
-            },
-            "sl1_alarm_timer_ended": {
-                "name": "El temporizador de la zona 1 finalizó"
-            },
-            "sl1_alarm_zone_turned_off": {
-                "name": "Zona 1 apagada"
-            },
-            "sl1_bridge_function_active": {
-                "name": "Zone 1 puente activo"
-            },
-            "sl1_pot_detected": {
-                "name": "Zone 1 olla detectada"
-            },
-            "sl1_status": {
-                "name": "Estado Zone 1"
-            },
-            "sl2_alarm_auto_program_notification": {
-                "name": "Notificación de programa automático de zona 2"
-            },
-            "sl2_alarm_automatic_switch_off_zone": {
-                "name": "La zona 2 se apaga automáticamente"
-            },
-            "sl2_alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina de la zona 2"
-            },
-            "sl2_alarm_timer_ended": {
-                "name": "El temporizador de la zona 2 finalizó"
-            },
-            "sl2_alarm_zone_turned_off": {
-                "name": "Zona 2 apagada"
-            },
-            "sl2_bridge_function_active": {
-                "name": "Zone 2 puente activo"
-            },
-            "sl2_pot_detected": {
-                "name": "Zone 2 olla detectada"
-            },
-            "sl2_status": {
-                "name": "Estado Zone 2"
-            },
-            "sl3_alarm_auto_program_notification": {
-                "name": "Notificación de programa automático de zona 3"
-            },
-            "sl3_alarm_automatic_switch_off_zone": {
-                "name": "La zona 3 se apaga automáticamente"
-            },
-            "sl3_alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina de la zona 3"
-            },
-            "sl3_alarm_timer_ended": {
-                "name": "El temporizador de la zona 3 finalizó"
-            },
-            "sl3_alarm_zone_turned_off": {
-                "name": "Zona 3 apagada"
-            },
-            "sl3_bridge_function_active": {
-                "name": "Zone 3 puente activo"
-            },
-            "sl3_pot_detected": {
-                "name": "Zone 3 olla detectada"
-            },
-            "sl3_status": {
-                "name": "Estado Zone 3"
-            },
-            "sl4_alarm_auto_program_notification": {
-                "name": "Notificación de programa automático de zona 4"
-            },
-            "sl4_alarm_automatic_switch_off_zone": {
-                "name": "La zona 4 se apaga automáticamente"
-            },
-            "sl42_alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina de la zona 4"
-            },
-            "sl4_alarm_timer_ended": {
-                "name": "El temporizador de la zona 4 finalizó"
-            },
-            "sl4_alarm_zone_turned_off": {
-                "name": "Zona 4 apagada"
-            },
-            "sl4_bridge_function_active": {
-                "name": "Zone 4 puente activo"
-            },
-            "sl4_pot_detected": {
-                "name": "Zone 4 olla detectada"
-            },
-            "sl4_status": {
-                "name": "Estado Zone 4"
-            },
-            "sl5_alarm_auto_program_notification": {
-                "name": "Notificación de programa automático de zona 5"
-            },
-            "sl5_alarm_automatic_switch_off_zone": {
-                "name": "La zona 5 se apaga automáticamente"
-            },
-            "sl5_alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina de la zona 5"
-            },
-            "sl5_alarm_timer_ended": {
-                "name": "El temporizador de la zona 5 finalizó"
-            },
-            "sl5_alarm_zone_turned_off": {
-                "name": "Zona 5 apagada"
-            },
-            "sl5_bridge_function_active": {
-                "name": "Zone 5 puente activo"
-            },
-            "sl5_pot_detected": {
-                "name": "Zone 5 olla detectada"
-            },
-            "sl5_status": {
-                "name": "Estado Zone 5"
-            },
-            "sl6_alarm_auto_program_notification": {
-                "name": "Notificación de programa automático de zona 6"
-            },
-            "sl6_alarm_automatic_switch_off_zone": {
-                "name": "La zona 6 se apaga automáticamente"
-            },
-            "sl6_alarm_ntc_coil_overheating": {
-                "name": "Sobrecalentamiento de la bobina de la zona 6"
-            },
-            "sl6_alarm_timer_ended": {
-                "name": "El temporizador de la zona 6 finalizó"
-            },
-            "sl6_alarm_zone_turned_off": {
-                "name": "Zona 6 apagada"
-            },
-            "sl6_bridge_function_active": {
-                "name": "Zone 6 puente activo"
-            },
-            "sl6_pot_detected": {
-                "name": "Zone 6 olla detectada"
-            },
-            "sl6_status": {
-                "name": "Estado Zone 6"
-            },
-            "step1_status": {
-                "name": "Estado paso 1"
-            },
-            "step6_status": {
-                "name": "Estado paso 2"
-            },
-            "step3_status": {
-                "name": "Estado paso 3"
-            },
-            "tx_failure": {
-                "name": "Fallo TX"
-            },
-            "vacuum_on_off_status": {
-                "name": "Estado aspiradora"
-            },
-            "vari_evap_temp_sens_head_failure": {
-                "name": "Fallo del cabezal sensor de temperatura de evaporación variable"
-            },
-            "vari_temp_sens_head_failure": {
-                "name": "Fallo del cabezal sensor de temperatura variable"
-            },
-            "vibration_alarm": {
-                "name": "Alarma de vibración"
-            },
-            "vibration_sensor_fault": {
-                "name": "Fallo en sensor de vibración"
-            },
-            "water_level_switch": {
-                "name": "Interruptor nivel de agua"
-            },
-            "waterbox_full": {
-                "name": "Compartimento de agua lleno"
-            }
-        },
-        "climate": {
-            "connectlife": {
-                "state_attributes": {
-                    "fan_mode": {
-                        "state": {
-                            "middle_low": "Medio bajo",
-                            "middle_high": "Medio alto"
-                        }
-                    },
-                    "preset_mode": {
-                        "state": {
-                            "ai": "AI",
-                            "off": "Apagado",
-                            "mute": "Silencioso",
-                            "eco_mute": "Silencioso Eco",
-                            "super": "Super",
-                            "sleep_1": "Sueño 1",
-                            "sleep_2": "Sueño 2",
-                            "sleep_3": "Sueño 3",
-                            "sleep_4": "Sueño 4",
-                            "eco_sleep_1": "Sueño Eco 1",
-                            "eco_sleep_2": "Sueño Eco 2",
-                            "eco_sleep_3": "Sueño Eco 3",
-                            "eco_sleep_4": "Sueño Eco 4"
-                        }
-                    },
-                    "swing_mode": {
-                        "state": {
-                            "both_sides": "Ambos lados",
-                            "forward": "Avanzar",
-                            "left": "Izquierda",
-                            "right": "Derecha",
-                            "swing": "Balanceo"
-                        }
-                    }
-                }
-            }
-        },
-        "humidifier": {
-            "connectlife": {
-                "state_attributes": {
-                    "mode": {
-                        "state": {
-                            "auto": "Auto",
-                            "continuous": "Continuo",
-                            "manual": "Manual",
-                            "clothes_dry": "Ropa seca"
-                        }
-                    }
-                }
-            }
-        },
-        "sensor": {
-            "ado_allowed": {
-                "name": "ADO permitido"
-            },
-            "alarm_door_closed": {
-                "name": "Puerta cerrada"
-            },
-            "alarm_door_opened": {
-                "name": "Puerta abierta"
-            },
-            "anticrease_setting": {
-                "name": "Duración anti arrugas"
-            },
-            "appliance_status": {
-                "state": {
-                    "idle": "Inactivo",
-                    "running": "En funcionamiento"
-                }
-            },
-            "auto_dose_duration": {
-                "name": "Duración de la dosis automática"
-            },
-            "auto_dose_quantity_setting_status": {
-                "name": "Configuración automática de la cantidad de dosificador"
-            },
-            "auto_dose_refill": {
-                "name": "Recargar autodosificador"
-            },
-            "auto_dose_setting_status": {
-                "name": "Configuracion autodosificador"
-            },
-            "bundling_humidity": {
-                "name": "Humedad acumulado"
-            },
-            "bundling_temperature": {
-                "name": "Temperatura acumulado"
-            },
-            "child_lock_setting_status": {
-                "name": "Configuracion bloqueo niños"
-            },
-            "curent_program_duration": {
-                "name": "Duracion del programa actual"
-            },
-            "curent_program_remaining_time": {
-                "name": "Tiempo restante programa actual"
-            },
-            "current_baking_step": {
-                "name": "Fase de horneado",
-                "state": {
-                    "preheat": "Precalentar",
-                    "step_1": "Paso 1",
-                    "step_2": "Paso 2",
-                    "step_3": "Paso 3",
-                    "after_bake_finished": "Horneado terminado"
-                }
-            },
-            "current_program_phase": {
-                "state": {
-                    "not_available": "No disponible",
-                    "program_not_selected": "Programa no seleccionado",
-                    "program_selected": "Programa selecionado",
-                    "delay_start_waiting": "Esperando inicio pospuesto",
-                    "preheat": "Precantamiento",
-                    "preheat_finished": "Precantamiento terminado",
-                    "prewash": "Prelavando",
-                    "main_wash": "Lavado principal",
-                    "wash": "Lavando",
-                    "drying": "Secando",
-                    "program_finished": "Programa Terminado",
-                    "ventilating": "Ventilación",
-                    "idle": "Pausado",
-                    "running": "En marcha",
-                    "anti_crease": "Anti arrugas",
-                    "delay": "Pospuesto",
-                    "finished": "Terminado",
-                    "weigh": "Pesando",
-                    "rinse": "Aclarando",
-                    "spin-dry": "Centrifugando"
-                }
-            },
-            "current_programphase": {
-                "state": {
-                    "running": "En marcha"
-                }
-            },
-            "daily_energy_kwh": {
-                "name": "Consumo energia diario"
-            },
-            "daily_energy_consumption": {
-                "name": "Consumo energia diario"
-            },
-            "delay_duration_inminutes": {
-                "name": "Duración retraso"
-            },
-            "delaystart_delayend_duration_inminutes": {
-                "name": "Duracción inicio retrasado"
-            },
-            "delaystart_delayend_remaining_timein_minutes": {
-                "name": "Tiempo restrante inicio retrasado"
-            },
-            "detergent_display": {
-                "name": "Display Detergente",
-                "state": {
-                    "off": "off",
-                    "on": "on"
-                }
-            },
-            "device_status": {
-                "state": {
-                    "demo_mode": "Modo demostración",
-                    "failure": "Fallo",
-                    "idle": "Suspendido",
-                    "iq": "IQ",
-                    "locked": "Cerrado",
-                    "not_available": "No disponible",
-                    "pause": "Pausado",
-                    "pause_mode": "Pausado",
-                    "production": "Producción",
-                    "running": "En marcha",
-                    "service": "Servicio",
-                    "stand_by": "Suspendido",
-                    "paused": "Pausado",
-                    "delay_time_waiting": "Esperando tiempo de retraso",
-                    "error": "Error",
-                    "after_bake_finished": "Horneado terminado"
-                }
-            },
-            "display_brightness_setting_status": {
-                "name": "Configuracion brillo display"
-            },
-            "door_status": {
-                "name": "Puerta",
-                "state": {
-                    "not_available": "No disponible",
-                    "closed": "Cerrada",
-                    "open": "Abierta"
-                }
-            },
-            "dry_time": {
-                "name": "Tipo Secado",
-                "state": {
-                    "iron": "Seco plancha",
-                    "closet": "Seco armario",
-                    "extra_dry": "Extra seco",
-                    "30": "30 min",
-                    "60": "60 min",
-                    "90": "90 min",
-                    "120": "120 min",
-                    "150": "150 min",
-                    "180": "180 min"
-                }
-            },
-            "energy_consumption_in_running_program": {
-                "name": "Energia consumida programa en curso"
-            },
-            "electricit_consumption_int": {
-                "name": "Energia consumida"
-            },
-            "energy_estimate": {
-                "name": "Energia estimada"
-            },
-            "environment_humidity": {
-                "name": "Humedad ambiental"
-            },
-            "error_code": {
-                "name": "Código error"
-            },
-            "extradry_setting": {
-                "name": "Configuración extra-seco"
-            },
-            "f_cool_qvalue": {
-                "name": "Enfriando"
-            },
-            "f_heat_qvalue": {
-                "name": "Calentando"
-            },
-            "f_votage": {
-                "name": "Voltaje"
-            },
-            "feedback_volumen_setting_status": {
-                "state": {
-					"mute": "Silenciar",
-                    "low": "Bajo",
-                    "mid": "Medio",
-                    "high": "Alto"
-                }
-            },
-            "freeze_real_temperature": {
-                "name": "Temperatura real congelador"
-            },
-            "freeze_sensor_real_temperature": {
-                "name": "Temperatura real sensor congelador"
-            },
-            "fruit_vegetables_temperature": {
-                "name": "Temperatura compartimento frutas y vegetales"
-            },
-            "high_humidity": {
-                "name": "Humedad alta"
-            },
-            "high_temperature": {
-                "name": "Temperatura alta"
-            },
-            "last_run_program_id": {
-                "name": "Último programa"
-            },
-            "low_humidity": {
-                "name": "Humedad baja"
-            },
-            "low_temperature": {
-                "name": "Temperatura baja"
-            },
-            "machine_status": {
-                "name": "Estado Maquina",
-                "state": {
-                    "off": "Apagada",
-                    "standby": "Suspendida",
-                    "running": "En Marcha"
-                }
-            },
-            "measured_vibrations": {
-                "name": "Vivbraciones"
-            },
-            "meat_probe_measured_temperature": {
-                "name": "Temperatura sonda de carne"
-            },
-            "meat_probe_set_temperature": {
-                "name": "Temperatura sonda de carne"
-            },
-            "medium_humidity": {
-                "name": "Humedad media"
-            },
-            "medium_temperature": {
-                "name": "Temperatura media"
-            },
-            "oven_temperature": {
-                "name": "Temperatura horno"
-            },
-            "real_humidity": {
-                "name": "Humedad real"
-            },
-            "real_humidity_b": {
-                "name": "Humedad real b"
-            },
-            "real_humidity_c": {
-                "name": "Humedad real c"
-            },
-            "refrigerator_real_temperature": {
-                "name": "Temperatura real refrigerador"
-            },
-            "refrigerator_sensor_real_temperature": {
-                "name": "Temperatura real sensor refrigerador"
-            },
-            "rinsenum": {
-                "name": "Aclarados extra"
-            },
-            "sand_timer1_duration_in_seconds": {
-                "name": "Duraciñon temporizador 1"
-            },
-            "sand_timer1_status": {
-                "name": "Temporizador 1",
-                "state": {
-                    "started": "Inciado",
-                    "paused": "Pausado",
-                    "stopped": "Parado"
-                }
-            },
-            "sand_timer2_duration_in_seconds": {
-                "name": "Duraciñon temporizador 12"
-            },
-            "sand_timer2_status": {
-                "name": "Temporizador 2",
-                "state": {
-                    "started": "Inciado",
-                    "paused": "Pausado",
-                    "stopped": "Parado"
-                }
-            },
-            "sand_timer3_duration_in_seconds": {
-                "name": "Duraciñon temporizador 3"
-            },
-            "sand_timer3_status": {
-                "name": "Temporizador 3",
-                "state": {
-                    "started": "Inciado",
-                    "paused": "Pausado",
-                    "stopped": "Parado"
-                }
-            },
-            "selected_program_id": {
-                "name": "Programa seleccionado",
-                "state": {
-                    "cotton_storage": "Algodón",
-                    "standard": "Estándar",
-                    "iron": "Plancha",
-                    "mix": "Mix",
-                    "synthetic": "Sinténticos",
-                    "wool": "Lana",
-                    "bed_linen": "Ropa de cama",
-                    "time": "Tiempo",
-                    "baby": "Ropa bebé",
-                    "sensitive": "Delicados",
-                    "shirts": "Camisas",
-                    "sports": "Ropa deporte",
-                    "fast89": "Fast 89",
-                    "extra_hygiene": "Extra higiene",
-                    "remote": "Remoto",
-                    "none": "Nada",
-                    "auto": "Auto",
-                    "anti_allergy": "Antialergias",
-                    "refresh": "Refrescar",
-                    "towels": "Toallas",
-                    "cotton": "Algodón",
-                    "delicates": "Delicados",
-                    "fast30": "Rápido 30´",
-                    "fast15": "Rápido 15´",
-                    "down": "Bajar",
-                    "cotton_dry": "Secado Algodón",
-                    "synthetic_dry": "Secado Sintéticos",
-                    "drum_cleaning": "Limpieza Tambor",
-                    "eco_40_60": "Eco 40-60",
-                    "spin-dry": "Centrifugar",
-                    "rinse_dpin": "Aclarado y Centrifugado",
-                    "clean_dry_60": "Lavado Secado 60´",
-                    "power49": "Power 49"
-                }
-            },
-            "selected_program_remaining_time_in_minutes": {
-                "name": "Tiempo restante programa seleccionado"
-            },
-            "selected_programduration_inminutes": {
-                "name": "Duración programa seleccionado"
-            },
-            "selected_programremaining_time_inminutes": {
-                "name": "Tiempo restante programa seleccionado"
-            },
-            "selected_program_total_time_in_minutes": {
-                "name": "Tiempo total programa seleccionado"
-            },
-            "selected_program_total_running_time_in_minutes": {
-                "name": "Tiempo total programa seleccionado en curso"
-            },
-            "set_progress_type": {
-                "name": "Tipo progreso",
-                "state": {
-                    "oven_set": "Oven set",
-                    "mw_set": "Mw set",
-                    "mwc_set": "Mwc set",
-                    "st_set": "St set",
-                    "stc_set": "Stc set",
-                    "fast_set": "Fast set",
-                    "stage_set": "Stage set",
-                    "culi_set": "Culi set",
-                    "warming": "Calentando",
-                    "defrost": "Descongelar",
-                    "cleaning": "Limpieza",
-                    "pyrolysis": "Pirolysis",
-                    "none": "Nada"
-                }
-            },
-            "sl1_active_timer": {
-                "name": "Zona 1 temporizador activo",
-                "state": {
-                    "inactive": "Inactivo",
-                    "stopwatch": "Parado",
-                    "timer": "Tiempo"
-                }
-            },
-            "sl1_functions": {
-                "name": "Zona 1 funciones",
-                "state": {
-                    "none": "Nada",
-                    "boil": "Hervir",
-                    "simmer": "Hervir a fuego lento",
-                    "keep_warm": "Mantener caliente",
-                    "wok": "Wok",
-                    "roast": "Asar",
-                    "grill": "Parrilla"
-                }
-            },
-            "sl1_ntc_sensor": {
-                "name": "Zona 1 sensor NTC"
-            },
-            "sl1_power_level": {
-                "name": "Zona 1 nivel potencia"
-            },
-            "sl1_power_level_max": {
-                "name": "Zona 1 maximo nivel potencia"
-            },
-            "sl1_zone_shape": {
-                "name": "Zona 1 forma",
-                "state": {
-                    "round": "Redonda",
-                    "square": "Cuadrada",
-                    "rectangle_vertical": "Rectángulo vertical",
-                    "rectangle_horizontal": "Rectángulo horizontal",
-                    "no_shape": "Sin forma"
-                }
-            },
-            "sl2_active_timer": {
-                "name": "Zona 2 temporizador activo",
-                "state": {
-                    "inactive": "Inactivo",
-                    "stopwatch": "Parado",
-                    "timer": "Tiempo"
-                }
-            },
-            "sl2_functions": {
-                "name": "Zona 2 funciones",
-                "state": {
-                    "none": "Nada",
-                    "boil": "Hervir",
-                    "simmer": "Hervir a fuego lento",
-                    "keep_warm": "Mantener caliente",
-                    "wok": "Wok",
-                    "roast": "Asar",
-                    "grill": "Parrilla"
-                }
-            },
-            "sl2_ntc_sensor": {
-                "name": "Zona 2 sensor NTC"
-            },
-            "sl2_power_level": {
-                "name": "Zona 2 nivel potencia"
-            },
-            "sl2_power_level_max": {
-                "name": "Zona 2 máximo nivel potencia"
-            },
-            "sl2_zone_shape": {
-                "name": "Zona 2 forma",
-                "state": {
-                    "round": "Redonda",
-                    "square": "Cuadrada",
-                    "rectangle_vertical": "Rectángulo vertical",
-                    "rectangle_horizontal": "Rectángulo horizontal",
-                    "no_shape": "Sin forma"
-                }
-            },
-            "sl3_active_timer": {
-                "name": "Zona 3 temporizador activo",
-                "state": {
-                    "inactive": "Inactivo",
-                    "stopwatch": "Parado",
-                    "timer": "Tiempo"
-                }
-            },
-            "sl3_functions": {
-                "name": "Zona 3 funciones",
-                "state": {
-                    "none": "Nada",
-                    "boil": "Hervir",
-                    "simmer": "Hervir a fuego lento",
-                    "keep_warm": "Mantener caliente",
-                    "wok": "Wok",
-                    "roast": "Asar",
-                    "grill": "Parrilla"
-                }
-            },
-            "sl3_ntc_sensor": {
-                "name": "Zona 3 sensor NTC"
-            },
-            "sl3_power_level": {
-                "name": "Zona 3 nivel potencia"
-            },
-            "sl3_power_level_max": {
-                "name": "Zona 3 máximo nivel potencia"
-            },
-            "sl3_zone_shape": {
-                "name": "Zona 3 forma",
-                "state": {
-                    "round": "Redonda",
-                    "square": "Cuadrada",
-                    "rectangle_vertical": "Rectángulo vertical",
-                    "rectangle_horizontal": "Rectángulo horizontal",
-                    "no_shape": "Sin forma"
-                }
-            },
-            "sl4_active_timer": {
-                "name": "Zona 4 temporizador activo",
-                "state": {
-                    "inactive": "Inactivo",
-                    "stopwatch": "Parado",
-                    "timer": "Tiempo"
-                }
-            },
-            "sl4_functions": {
-                "name": "Zona 4 funciones",
-                "state": {
-                    "none": "Nada",
-                    "boil": "Hervir",
-                    "simmer": "Hervir a fuego lento",
-                    "keep_warm": "Mantener caliente",
-                    "wok": "Wok",
-                    "roast": "Asar",
-                    "grill": "Parrilla"
-                }
-            },
-            "sl4_ntc_sensor": {
-                "name": "Zona 4 sensor NTC"
-            },
-            "sl4_power_level": {
-                "name": "Zona 4 nivel potencia"
-            },
-            "sl4_power_level_max": {
-                "name": "Zona 4 máximo nivel potencia"
-            },
-            "sl4_zone_shape": {
-                "name": "Zona 4 forma",
-                "state": {
-                    "round": "Redonda",
-                    "square": "Cuadrada",
-                    "rectangle_vertical": "Rectángulo vertical",
-                    "rectangle_horizontal": "Rectángulo horizontal",
-                    "no_shape": "Sin forma"
-                }
-            },
-            "sl5_active_timer": {
-                "name": "Zona 5 temporizador activo",
-                "state": {
-                    "inactive": "Inactivo",
-                    "stopwatch": "Parado",
-                    "timer": "Tiempo"
-                }
-            },
-            "sl5_functions": {
-                "name": "Zona 5 funciones",
-                "state": {
-                    "none": "Nada",
-                    "boil": "Hervir",
-                    "simmer": "Hervir a fuego lento",
-                    "keep_warm": "Mantener caliente",
-                    "wok": "Wok",
-                    "roast": "Asar",
-                    "grill": "Parrilla"
-                }
-            },
-            "sl5_ntc_sensor": {
-                "name": "Zona 5 sensor NTC"
-            },
-            "sl5_power_level": {
-                "name": "Zona 5 nivel potencia"
-            },
-            "sl5_power_level_max": {
-                "name": "Zona 5 máximo nivel potencia"
-            },
-            "sl5_zone_shape": {
-                "name": "Zona 5 forma",
-                "state": {
-                    "round": "Redonda",
-                    "square": "Cuadrada",
-                    "rectangle_vertical": "Rectángulo vertical",
-                    "rectangle_horizontal": "Rectángulo horizontal",
-                    "no_shape": "Sin forma"
-                }
-            },
-            "sl6_active_timer": {
-                "name": "Zona 6 temporizador activo",
-                "state": {
-                    "inactive": "Inactivo",
-                    "stopwatch": "Parado",
-                    "timer": "Tiempo"
-                }
-            },
-            "sl6_functions": {
-                "name": "Zona 6 funciones",
-                "state": {
-                    "none": "Nada",
-                    "boil": "Hervir",
-                    "simmer": "Hervir a fuego lento",
-                    "keep_warm": "Mantener caliente",
-                    "wok": "Wok",
-                    "roast": "Asar",
-                    "grill": "Parrilla"
-                }
-            },
-            "sl6_ntc_sensor": {
-                "name": "Zona 6 sensor NTC"
-            },
-            "sl6_power_level": {
-                "name": "Zona 6 nivel potencia"
-            },
-            "sl6_power_level_max": {
-                "name": "Zona 6 maximo nivel potencia"
-            },
-            "sl6_zone_shape": {
-                "name": "Zona 6 forma",
-                "state": {
-                    "round": "Redonda",
-                    "square": "Cuadrada",
-                    "rectangle_vertical": "Rectángulo vertical",
-                    "rectangle_horizontal": "Rectángulo horizontal",
-                    "no_shape": "Sin forma"
-                }
-            },
-            "selected_program_id_status": {
-                "name": "Programa seleccionado",
-                "state": {
-					"auto": "Auto",
-                    "eco": "Eco",
-                    "one_hour": "1 hora",
-                    "intensive": "Intensivo",
-                    "glass": "Cristal",
-                    "hygiene": "Higiene",
-                    "night": "Noche",
-                    "clean": "Limpieza"
-                }
-            },
-            "selected_program_mode": {
-                "name": "Modo programa",
-                "state": {
-					"normal": "Normal",
-                    "fast": "Rápido"
-                }
-            },
-            "spintime_index": {
-                "name": "Duración centrifugado"
-            },
-            "step1_duration": {
-                "name": "Fase 1 duración"
-            },
-            "step1_heater_system": {
-                "name": "Fase 1 sistema calentado",
-                "state": {
-                    "hot_air": "Aire Caliente",
-                    "eco_hot_air": "Aire Caliente ECO",
-                    "top_bottom": "Arriba y Abajo",
-                    "hot_air_bottom": "Calor Arriba y Abajo",
-                    "bottom_fan": "Ventilador abajo",
-                    "bottom": "Abajo",
-                    "top": "Arriba",
-                    "small_grill": "Parrilla pequeña",
-                    "large_grill": "Parrilla grande",
-                    "large_grill_fan": "Ventilador parrilla grande",
-                    "pro_roasting": "Pro tostado",
-                    "hotairmicro": "Micro aire caliente",
-                    "grillfanmicro": "Grill fa nmicro",
-                    "micro": "Micro",
-                    "hot_air_steam_1": "Vapor nivel 1",
-                    "hot_air_steam_2": "Vapor nivel 2",
-                    "hot_air_steam_3": "Vapor nivel 3",
-                    "fast_preheat": "Precalentado rápido",
-                    "pyro": "Pyro",
-                    "defrost": "Descongelado",
-                    "keep_warm": "Mantener caliente",
-                    "plates": "Platos",
-                    "aqua_clean": "Limpieza agua",
-                    "steam_clean": "Limpieza vapor",
-                    "regenerate": "Regeneración",
-                    "descale": "Desincrustar",
-                    "microwave_defrost": "Microondas descongelar",
-                    "sous_vide": "Al vacio",
-                    "low_temp_steam": "Vapor baja temperatura",
-                    "steam": "Vapor",
-                    "quick": "Rápido",
-                    "clean_air": "Limpieza aire",
-                    "defrost_auto": "Descongelado automatico",
-                    "sabbath": "Sabbath",
-                    "programs": "Programas",
-                    "warming": "Calentamiento",
-                    "microwave_clean": "Microondas limpieza",
-                    "hot_air_micro": "Microondas aire caliente",
-                    "grill_fan_micro": "Microondas ventilador parrilla"
-                }
-            },
-            "step1_remaining_time": {
-                "name": "Fase 1 tiempo restante"
-            },
-            "step1_set_temperature": {
-                "name": "Fase 1 temperatura"
-            },
-            "step2_duration": {
-                "name": "Fase 2 duración"
-            },
-            "step2_heater_system": {
-                "name": "Fase 2 sistema calentado",
-                "state": {
-                    "hot_air": "Aire Caliente",
-                    "eco_hot_air": "Aire Caliente ECO",
-                    "top_bottom": "Arriba y Abajo",
-                    "hot_air_bottom": "Calor Arriba y Abajo",
-                    "bottom_fan": "Ventilador abajo",
-                    "bottom": "Abajo",
-                    "top": "Arriba",
-                    "small_grill": "Parrilla pequeña",
-                    "large_grill": "Parrilla grande",
-                    "large_grill_fan": "Ventilador parrilla grande",
-                    "pro_roasting": "Pro tostado",
-                    "hotairmicro": "Micro aire caliente",
-                    "grillfanmicro": "Grill fa nmicro",
-                    "micro": "Micro",
-                    "hot_air_steam_1": "Vapor nivel 1",
-                    "hot_air_steam_2": "Vapor nivel 2",
-                    "hot_air_steam_3": "Vapor nivel 3",
-                    "fast_preheat": "Precalentado rápido",
-                    "pyro": "Pyro",
-                    "defrost": "Descongelado",
-                    "keep_warm": "Mantener caliente",
-                    "plates": "Platos",
-                    "aqua_clean": "Limpieza agua",
-                    "steam_clean": "Limpieza vapor",
-                    "regenerate": "Regeneración",
-                    "descale": "Desincrustar",
-                    "microwave_defrost": "Microondas descongelar",
-                    "sous_vide": "Al vacio",
-                    "low_temp_steam": "Vapor baja temperatura",
-                    "steam": "Vapor",
-                    "quick": "Rápido",
-                    "clean_air": "Limpieza aire",
-                    "defrost_auto": "Descongelado automatico",
-                    "sabbath": "Sabbath",
-                    "programs": "Programas",
-                    "warming": "Calentamiento",
-                    "microwave_clean": "Microondas limpieza",
-                    "hot_air_micro": "Microondas aire caliente",
-                    "grill_fan_micro": "Microondas ventilador parrilla"
-                }
-            },
-            "step2_remaining_time": {
-                "name": "Fase 1 tiempo restante"
-            },
-            "step2_set_temperature": {
-                "name": "Fase 2 temperatura"
-            },
-            "step3_duration": {
-                "name": "Fase 1 duración"
-            },
-            "step3_heater_system": {
-                "name": "Fase 3 sistema calentado",
-                "state": {
-                    "hot_air": "Aire Caliente",
-                    "eco_hot_air": "Aire Caliente ECO",
-                    "top_bottom": "Arriba y Abajo",
-                    "hot_air_bottom": "Calor Arriba y Abajo",
-                    "bottom_fan": "Ventilador abajo",
-                    "bottom": "Abajo",
-                    "top": "Arriba",
-                    "small_grill": "Parrilla pequeña",
-                    "large_grill": "Parrilla grande",
-                    "large_grill_fan": "Ventilador parrilla grande",
-                    "pro_roasting": "Pro tostado",
-                    "hotairmicro": "Micro aire caliente",
-                    "grillfanmicro": "Grill fa nmicro",
-                    "micro": "Micro",
-                    "hot_air_steam_1": "Vapor nivel 1",
-                    "hot_air_steam_2": "Vapor nivel 2",
-                    "hot_air_steam_3": "Vapor nivel 3",
-                    "fast_preheat": "Precalentado rápido",
-                    "pyro": "Pyro",
-                    "defrost": "Descongelado",
-                    "keep_warm": "Mantener caliente",
-                    "plates": "Platos",
-                    "aqua_clean": "Limpieza agua",
-                    "steam_clean": "Limpieza vapor",
-                    "regenerate": "Regeneración",
-                    "descale": "Desincrustar",
-                    "microwave_defrost": "Microondas descongelar",
-                    "sous_vide": "Al vacio",
-                    "low_temp_steam": "Vapor baja temperatura",
-                    "steam": "Vapor",
-                    "quick": "Rápido",
-                    "clean_air": "Limpieza aire",
-                    "defrost_auto": "Descongelado automatico",
-                    "sabbath": "Sabbath",
-                    "programs": "Programas",
-                    "warming": "Calentamiento",
-                    "microwave_clean": "Microondas limpieza",
-                    "hot_air_micro": "Microondas aire caliente",
-                    "grill_fan_micro": "Microondas ventilador parrilla"
-                }
-            },
-            "step3_remaining_time": {
-                "name": "Fase 1 tiempo restante"
-            },
-            "step3_set_temperature": {
-                "name": "Fase 3 temperatura"
-            },
-            "softer_display": {
-                "name": "Display Suavizante",
-                "state": {
-                    "off": "off",
-                    "on": "on"
-                }
-            },
-            "t_sleep": {
-                "name": "Suspendido"
-            },
-            "temperature_room_judge": {
-                "name": "Temperature room judge"
-            },
-            "total_energy_consumption": {
-                "name": "Total consumo de energia"
-            },
-            "total_number_of_cycles": {
-                "name": "Número total de ciclos"
-            },
-            "total_passed_time": {
-                "name": "Tiempo transcurrido"
-            },
-            "total_remaining_time": {
-                "name": "Tiempo restante"
-            },
-            "total_run_time": {
-                "name": "Tiempo total"
-            },
-            "total_time_of_cooking_in_hours": {
-                "name": "Tiempo total cocinado"
-            },
-            "total_water_consumption": {
-                "name": "Total agua consumida"
-            },
-            "utc_datetime_bdc_delaystart_delayend_timestamp": {
-                "name": "BDC DelayStart DelayEnd"
-            },
-            "variation_real_temperature": {
-                "name": "Variacion real de temperatura"
-            },
-            "variation_sensor_real_temperature": {
-                "name": "Sensor variación real de temperatura"
-            },
-            "water_consumption_int": {
-                "name": "Agua consumida"
-            },
-            "water_consumption_in_running_program": {
-                "name": "Agua consumida en programa actual"
-            },
-            "zone_number": {
-                "name": "Número de zonas"
-            }
-        },
-        "switch": {
-            "anticrease": {
-                "name": "Antiarrugas"
-            },
-            "automatic_ice_making": {
-                "name": "Fabricación automática de hielo"
-            },
-            "child_lock": {
-                "name": "Bloqueo para niños"
-            },
-            "drum_light": {
-                "name": "Luz tambor"
-            },
-            "holiday_mode": {
-                "name": "Modo vacaciones"
-            },
-            "mute": {
-                "name": "Silenciar"
-            },
-            "t_air": {
-                "name": "Aire"
-            },
-            "t_beep": {
-                "name": "Beep"
-            },
-            "t_eco": {
-                "name": "Eco"
-            },
-            "t_fan_mute": {
-                "name": "Silenciar ventilador"
-            },
-            "t_power": {
-                "name": "Encendido"
-            },
-            "t_purify": {
-                "name": "Purificador"
-            },
-            "t_sleep": {
-                "name": "Suspender"
-            },
-            "t_sterilization": {
-                "name": "Esterilización"
-            },
-            "t_super": {
-                "name": "Super"
-            },
-            "t_tms": {
-                "name": "AI"
-            },
-            "steam": {
-                "name": "Vapor"
-            },
-            "prewash": {
-                "name": "Prelavado"
-            }
-        },
-        "select": {
-            "dry_level": {
-                "name": "Nivel Secado",
-                "state": {
-                    "1": "1",
-                    "2": "2",
-                    "3": "3"
-                }
-            },
-            "t_fan_speed": {
-                "name": "Velocidad ventilador",
-                "state": {
-                    "auto": "Auto",
-                    "low": "Bajo",
-                    "high": "Alto"
-                }
-            },
-            "t_sleep": {
-                "name": "Modo suspensión",
-                "state": {
-                    "off": "Apagado",
-                    "general": "General",
-                    "for_old": "Para mayores",
-                    "for_young": "Para jovenes",
-                    "for_kid": "Para niños"
-                }
-            },
-            "t_swing_angle": {
-                "name": "Modo balanceo",
-                "state": {
-                    "swing": "balanceo",
-                    "auto": "Auto",
-                    "angle_1": "Anglulo 1",
-                    "angle_2": "Anglulo 2",
-                    "angle_3": "Anglulo 3",
-                    "angle_4": "Anglulo 4",
-                    "angle_5": "Anglulo 5",
-                    "angle_6": "Anglulo 6"
-                }
-            },
-            "t_swing_follow": {
-                "name": "AI ventilacion",
-                "state": {
-                    "off": "Apagado",
-                    "follow": "Seguir",
-                    "not_follow": "No seguir"
-                }
-            },
-            "selected_program_id": {
-                "name": "Programa seleccionado",
-                "state": {
-                    "auto": "Auto",
-                    "remote": "Control remoto",
-                    "anti_allergy": "Antialergias",
-                    "refresh": "Refrescar",
-                    "sports": "Ropa deporte",
-                    "towels": "Toalas",
-                    "time": "Secado por tiempo",
-                    "cotton": "Algodon",
-                    "baby": "Ropa bebé",
-                    "synthetic": "Sinteticos",
-                    "wool": "Lana",
-                    "delicates": "Delicados",
-                    "fast30": "Rapido 30´",
-                    "fast15": "Rapido 15´",
-                    "shirts": "Camisas",
-                    "bed_linen": "Ropa de cama",
-                    "down": "Bajar",
-                    "cotton_dry": "Secado Agodón",
-                    "synthetic_dry": "Secado Sinteticos",
-                    "drum_cleaning": "Limpieza Tambor",
-                    "eco_40_60": "Eco 40-60",
-                    "spin-dry": "Centrifugar",
-                    "rinse_spin": "Aclarado y Centrifugado",
-                    "clean_dry_60": "Lavado Secado 60´",
-                    "power49": "Power 49"
-                }
-            },
-            "dry_time": {
-                "name": "Secado",
-                "state": {
-                    "wardrobe": "Armario",
-                    "pre-ironing": "Plancha",
-                    "extra_dry": "Exstra seco"
-                }
-            },
-            "temperature": {
-                "name": "Temperatura",
-                "state": {
-                    "cold" : "Frio",
-                    "20": "20",
-                    "30": "30",
-                    "40": "40",
-                    "60": "60",
-                    "90": "90"
-                }
-            },
-            "spin_speed_rpm": {
-                "name": "Centrifugado",
-                "state": {
-                    "1400" : "1400",
-                    "1200": "1200",
-                    "1000": "30",
-                    "800": "40",
-                    "600": "60",
-                    "none": "No centrifugar"
-                }
-            },
-            "ExtraRinseNum": {
-                "name": "Aclarado extra",
-                "state": {
-                    "0" : "0",
-                    "1" : "1",
-                    "2": "2",
-                    "3": "3"
-                    
-                }
-            }
-        },
-        "water_heater": {
-            "connectlife": {
-                "state": {
-                    "auto": "Auto"
-                }
-            }
-        },
-        "number": {
-            "freeze_max_temperature": {
-                "name": "Congelador temperatura máxima"
-            },
-            "freeze_min_temperature": {
-                "name": "Congelador temperatura mínima"
-            },
-            "freeze_temperature": {
-                "name": "Temperatura Congelador"
-            },
-            "refrigerator_max_temperature": {
-                "name": "Frigorifico temperatura máxima"
-            },
-            "refrigerator_min_temperature": {
-                "name": "Frigorifico temperatura mínima"
-            },
-            "refrigerator_temperature": {
-                "name": "Temperatura frigorífico"
-            },
-            "variation_max_temperature": {
-                "name": "Variación temperatura máxima"
-            },
-            "variation_min_temperature": {
-                "name": "Variación temperatura mínima"
-            },
-            "variation_temperature": {
-                "name": "Temperatura variación"
-            }
-        }
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "alarm_1": {
+        "name": "Alarma 1"
+      },
+      "alarm_10": {
+        "name": "Alarma 10"
+      },
+      "alarm_11": {
+        "name": "Alarma 11"
+      },
+      "alarm_12": {
+        "name": "Alarm 12"
+      },
+      "alarm_2": {
+        "name": "Alarma 2"
+      },
+      "alarm_3": {
+        "name": "Alarma 3"
+      },
+      "alarm_4": {
+        "name": "Alarma 4"
+      },
+      "alarm_5": {
+        "name": "Alarma 5"
+      },
+      "alarm_6": {
+        "name": "Alarma 6"
+      },
+      "alarm_7": {
+        "name": "Alarma 7"
+      },
+      "alarm_8": {
+        "name": "Alarma 8"
+      },
+      "alarm_9": {
+        "name": "Alarma 9"
+      },
+      "alarm_alarm_time_reached": {
+        "name": "Tiempo de alarma finalizado."
+      },
+      "alarm_auto_dose_refill": {
+        "name": "Alarma en el auto relleno del dosificador"
+      },
+      "alarm_auto_program_notification": {
+        "name": "Auto program notification"
+      },
+      "alarm_autodose_level10": {
+        "name": "Autodosificador nivel 10"
+      },
+      "alarm_autodose_level20": {
+        "name": "Autodosificador nivel 20"
+      },
+      "alarm_automatic_switch_off_zone": {
+        "name": "Interruptor de zona automatico"
+      },
+      "alarm_baking_finished": {
+        "name": "Alarma de horneado finalizada"
+      },
+      "alarm_clean_the_filters": {
+        "name": "Limpiar filtros"
+      },
+      "alarm_descale_now": {
+        "name": "Alarma, descalcifique ahora"
+      },
+      "alarm_door_closed": {
+        "name": "Puerta cerrada"
+      },
+      "alarm_door_opened": {
+        "name": "Puerta abierta"
+      },
+      "alarm_external_autodose_level15": {
+        "name": "Autodosificador externo nivel 15"
+      },
+      "alarm_external_autodose_level30": {
+        "name": "Autodosificador externo nivel 30"
+      },
+      "alarm_hob_hood_started": {
+        "name": "Campana encendida"
+      },
+      "alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina NTC"
+      },
+      "alarm_ntc_power": {
+        "name": "NTC power"
+      },
+      "alarm_ntc_tc": {
+        "name": "NTC TC"
+      },
+      "alarm_preheat_reached": {
+        "name": "Alarma, precalentamiento alcanzado"
+      },
+      "alarm_preheating_ready": {
+        "name": "Precalentado"
+      },
+      "alarm_program_done": {
+        "name": "Programa terminado"
+      },
+      "alarm_program_pause": {
+        "name": "Programa pausado"
+      },
+      "alarm_remote_start_canceled": {
+        "name": "Inicio remoto cancelado"
+      },
+      "alarm_rinse_aid_refill": {
+        "name": "Recargar abrillantador"
+      },
+      "alarm_rinse_aid_refill_external": {
+        "name": "Recargar abrillantador externo"
+      },
+      "alarm_run_selfcleaning": {
+        "name": "Ejecutar autolimpieza"
+      },
+      "alarm_salt_refill": {
+        "name": "Recargar sal"
+      },
+      "alarm_sani_program_finished": {
+        "name": "Programa Sani terminado"
+      },
+      "alarm_steam_empty": {
+        "name": "Vapor vac\u00edo"
+      },
+      "alarm_temperature_reached": {
+        "name": "Temperatura alcanzada"
+      },
+      "alarm_timer_ended": {
+        "name": "Tiempo finalizado"
+      },
+      "alarm_turn_food": {
+        "name": "Girar comida"
+      },
+      "alarm_voltage": {
+        "name": "Voltage"
+      },
+      "alarm_warning_fastpreheat": {
+        "name": "Atenci\u00f3n, precalentamiento r\u00e1pido"
+      },
+      "alarm_warning_microwave": {
+        "name": "Atenci\u00f3n microondas"
+      },
+      "alarm_warning_steam": {
+        "name": "Atenci\u00f3n vapor caliente"
+      },
+      "alarm_water_tank_empty": {
+        "name": "Tanque de agua vacio"
+      },
+      "alarm_water_tank_missing": {
+        "name": "Tanque de agua no encontrado"
+      },
+      "alarm_zone_turned_off": {
+        "name": "Zona apagada"
+      },
+      "charcoal_filter_expiration_alarm": {
+        "name": "Alarma de caducidad del filtro de carb\u00f3n"
+      },
+      "child_lock": {
+        "name": "Bloqueo ni\u00f1os"
+      },
+      "child_lock_status": {
+        "name": "Bloqueo ni\u00f1os"
+      },
+      "clean_filter": {
+        "name": "Limpiar filtro"
+      },
+      "delay_start_status": {
+        "name": "Estado de inicio retrasado"
+      },
+      "delaystart_delayend_mode": {
+        "name": "Inicio retrasado"
+      },
+      "demo_mode": {
+        "name": "Modo demostraci\u00f3n"
+      },
+      "door": {
+        "name": "Puerta"
+      },
+      "eco_mode": {
+        "name": "Modo ECO"
+      },
+      "error_0": {
+        "name": "Error 0"
+      },
+      "error_1": {
+        "name": "Error 1"
+      },
+      "error_10": {
+        "name": "Error 10"
+      },
+      "error_11": {
+        "name": "Error 11"
+      },
+      "error_12": {
+        "name": "Error 12"
+      },
+      "error_13": {
+        "name": "Error 13"
+      },
+      "error_14": {
+        "name": "Error 14"
+      },
+      "error_15": {
+        "name": "Error 15"
+      },
+      "error_16": {
+        "name": "Error 16"
+      },
+      "error_2": {
+        "name": "Error 2"
+      },
+      "error_3": {
+        "name": "Error 3"
+      },
+      "error_4": {
+        "name": "Error 4"
+      },
+      "error_5": {
+        "name": "Error 5"
+      },
+      "error_6": {
+        "name": "Error 6"
+      },
+      "error_7": {
+        "name": "Error 7"
+      },
+      "error_8": {
+        "name": "Error 8"
+      },
+      "error_9": {
+        "name": "Error 9"
+      },
+      "f_e_filterclean": {
+        "name": "Limpiar filtro"
+      },
+      "f_e_pump": {
+        "name": "Bomba"
+      },
+      "f_e_push": {
+        "name": "Empujar"
+      },
+      "f_e_temp": {
+        "name": "Temperatura"
+      },
+      "f_e_tubetemp": {
+        "name": "Temperatura tubo"
+      },
+      "f_e_waterfull": {
+        "name": "Agua llena"
+      },
+      "f_e_wetsensor": {
+        "name": "Sensor humedo"
+      },
+      "fill_salt": {
+        "name": "Recargar sal"
+      },
+      "float_switch": {
+        "name": "Interruptor de flotador"
+      },
+      "free_defrosting_failure": {
+        "name": "Fallo en descongelaci\u00f3n del congelador"
+      },
+      "free_evap_temp_sens_head_failure": {
+        "name": "Falla en el cabezal sensor de temperatura del evaporador del congelador"
+      },
+      "free_fan_failure": {
+        "name": "Fallo del ventilador del congelador"
+      },
+      "free_room_over_temp_alarm_failure": {
+        "name": "Fallo de alarma de exceso de temperatura en la sala del congelador"
+      },
+      "free_temp_sens_head_failure": {
+        "name": "Falla en el cabezal sensor de temperatura del congelador"
+      },
+      "frost_state": {
+        "name": "Estado de escarcha"
+      },
+      "hard_pairing_status": {
+        "name": "Estado de emparejamiento dif\u00edcil"
+      },
+      "humidity_sensor": {
+        "name": "Sensor humedad"
+      },
+      "humidity_sensor_failure": {
+        "name": "Fallo en el sensor de humedad"
+      },
+      "ice_making_machine_failure": {
+        "name": "Fallo en maquina de hielo"
+      },
+      "light": {
+        "name": "Luz"
+      },
+      "low_wine_area_c_evaporator_fault": {
+        "name": "Fallo del evaporador del \u00e1rea baja c de vino"
+      },
+      "low_wine_area_c_fan_fault": {
+        "name": "Fallo del ventilador del \u00e1rea baja c de vino"
+      },
+      "low_wine_area_c_humdy_fault": {
+        "name": "Fallo en la humedad del \u00e1rea baja c de vino"
+      },
+      "low_wine_area_c_temp_fault": {
+        "name": "Fallo en la temperatura del \u00e1rea baja c de vino"
+      },
+      "mid_wine_area_b_evaporator_fault": {
+        "name": "Fallo del evaporador del \u00e1rea media b de vino"
+      },
+      "mid_wine_area_b_fan_fault": {
+        "name": "Fallo del ventilador del \u00e1rea media b de vino"
+      },
+      "mid_wine_area_b_humdy_fault": {
+        "name": "Fallo en la humedad del \u00e1rea media b de vino"
+      },
+      "mid_wine_area_b_temp_fault": {
+        "name": "Fallo en la temperatura del \u00e1rea media b de vino"
+      },
+      "open_freeze_door_alarm": {
+        "name": "Alarma, puerta abierta del frigor\u00edfico"
+      },
+      "open_refrigerator_door_alarm": {
+        "name": "Alarma, puerta abierta del frigor\u00edfico"
+      },
+      "open_the_door_alarm": {
+        "name": "Alarma, puerta abierta"
+      },
+      "open_variation_door_alarm": {
+        "name": "Alarma, puerta abierta"
+      },
+      "preheat": {
+        "name": "Precalentar"
+      },
+      "quiet_mode_status": {
+        "name": "Modo silencioso"
+      },
+      "reed_switch": {
+        "name": "Interruptor ca\u00f1a"
+      },
+      "refr_defrosting_failure": {
+        "name": "Fallo en el descongelamiento del refrigerador"
+      },
+      "refr_dry_wet_room_sens_failure": {
+        "name": "Fallo en sensor de compartimento seco-h\u00famedo del refrigerador"
+      },
+      "refr_evap_temp_sens_head_failure": {
+        "name": "Fallo en el cabezal del sensor de temperatura"
+      },
+      "refr_fan_failure": {
+        "name": "Fallo en el ventilador del refrigerador"
+      },
+      "refr_room_open": {
+        "name": "Puerta abierta refrigerador"
+      },
+      "refr_room_over_temp_alarm": {
+        "name": "Alarma de temperatura en el refigerador"
+      },
+      "refr_temp_sens_head_failure": {
+        "name": "Fallo en el cabezal del sensor de temperatura"
+      },
+      "refr_var_room_sens_failure": {
+        "name": "Refrigerator var room sens failure"
+      },
+      "remote_control_mode_monitoring": {
+        "name": "Monitoreo del modo de control remoto"
+      },
+      "rx_failure": {
+        "name": "Fallo RX"
+      },
+      "sabbath_mode_status": {
+        "name": "Estado Sabbath mode"
+      },
+      "sabbath_mode_switch_status": {
+        "name": "Estado interruptor Sabbath mode"
+      },
+      "save_mode": {
+        "name": "Modo ahorro"
+      },
+      "selected_program_anticrease_status": {
+        "name": "Antiarrgas "
+      },
+      "selected_program_extradry_status": {
+        "name": "Secado extra"
+      },
+      "selected_program_steamfinish": {
+        "name": "Vaporizaci\u00f3n terminada"
+      },
+      "session_pairing_active": {
+        "name": "Emparejamiento de sesiones activo"
+      },
+      "sl1_alarm_auto_program_notification": {
+        "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 1"
+      },
+      "sl1_alarm_automatic_switch_off_zone": {
+        "name": "La zona 1 se apaga autom\u00e1ticamente"
+      },
+      "sl1_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 1"
+      },
+      "sl1_alarm_timer_ended": {
+        "name": "El temporizador de la zona 1 finaliz\u00f3"
+      },
+      "sl1_alarm_zone_turned_off": {
+        "name": "Zona 1 apagada"
+      },
+      "sl1_bridge_function_active": {
+        "name": "Zone 1 puente activo"
+      },
+      "sl1_pot_detected": {
+        "name": "Zone 1 olla detectada"
+      },
+      "sl1_status": {
+        "name": "Estado Zone 1"
+      },
+      "sl2_alarm_auto_program_notification": {
+        "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 2"
+      },
+      "sl2_alarm_automatic_switch_off_zone": {
+        "name": "La zona 2 se apaga autom\u00e1ticamente"
+      },
+      "sl2_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 2"
+      },
+      "sl2_alarm_timer_ended": {
+        "name": "El temporizador de la zona 2 finaliz\u00f3"
+      },
+      "sl2_alarm_zone_turned_off": {
+        "name": "Zona 2 apagada"
+      },
+      "sl2_bridge_function_active": {
+        "name": "Zone 2 puente activo"
+      },
+      "sl2_pot_detected": {
+        "name": "Zone 2 olla detectada"
+      },
+      "sl2_status": {
+        "name": "Estado Zone 2"
+      },
+      "sl3_alarm_auto_program_notification": {
+        "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 3"
+      },
+      "sl3_alarm_automatic_switch_off_zone": {
+        "name": "La zona 3 se apaga autom\u00e1ticamente"
+      },
+      "sl3_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 3"
+      },
+      "sl3_alarm_timer_ended": {
+        "name": "El temporizador de la zona 3 finaliz\u00f3"
+      },
+      "sl3_alarm_zone_turned_off": {
+        "name": "Zona 3 apagada"
+      },
+      "sl3_bridge_function_active": {
+        "name": "Zone 3 puente activo"
+      },
+      "sl3_pot_detected": {
+        "name": "Zone 3 olla detectada"
+      },
+      "sl3_status": {
+        "name": "Estado Zone 3"
+      },
+      "sl42_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 4"
+      },
+      "sl4_alarm_auto_program_notification": {
+        "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 4"
+      },
+      "sl4_alarm_automatic_switch_off_zone": {
+        "name": "La zona 4 se apaga autom\u00e1ticamente"
+      },
+      "sl4_alarm_timer_ended": {
+        "name": "El temporizador de la zona 4 finaliz\u00f3"
+      },
+      "sl4_alarm_zone_turned_off": {
+        "name": "Zona 4 apagada"
+      },
+      "sl4_bridge_function_active": {
+        "name": "Zone 4 puente activo"
+      },
+      "sl4_pot_detected": {
+        "name": "Zone 4 olla detectada"
+      },
+      "sl4_status": {
+        "name": "Estado Zone 4"
+      },
+      "sl5_alarm_auto_program_notification": {
+        "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 5"
+      },
+      "sl5_alarm_automatic_switch_off_zone": {
+        "name": "La zona 5 se apaga autom\u00e1ticamente"
+      },
+      "sl5_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 5"
+      },
+      "sl5_alarm_timer_ended": {
+        "name": "El temporizador de la zona 5 finaliz\u00f3"
+      },
+      "sl5_alarm_zone_turned_off": {
+        "name": "Zona 5 apagada"
+      },
+      "sl5_bridge_function_active": {
+        "name": "Zone 5 puente activo"
+      },
+      "sl5_pot_detected": {
+        "name": "Zone 5 olla detectada"
+      },
+      "sl5_status": {
+        "name": "Estado Zone 5"
+      },
+      "sl6_alarm_auto_program_notification": {
+        "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 6"
+      },
+      "sl6_alarm_automatic_switch_off_zone": {
+        "name": "La zona 6 se apaga autom\u00e1ticamente"
+      },
+      "sl6_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 6"
+      },
+      "sl6_alarm_timer_ended": {
+        "name": "El temporizador de la zona 6 finaliz\u00f3"
+      },
+      "sl6_alarm_zone_turned_off": {
+        "name": "Zona 6 apagada"
+      },
+      "sl6_bridge_function_active": {
+        "name": "Zone 6 puente activo"
+      },
+      "sl6_pot_detected": {
+        "name": "Zone 6 olla detectada"
+      },
+      "sl6_status": {
+        "name": "Estado Zone 6"
+      },
+      "step1_status": {
+        "name": "Estado paso 1"
+      },
+      "step3_status": {
+        "name": "Estado paso 3"
+      },
+      "step6_status": {
+        "name": "Estado paso 2"
+      },
+      "tx_failure": {
+        "name": "Fallo TX"
+      },
+      "vacuum_on_off_status": {
+        "name": "Estado aspiradora"
+      },
+      "vari_evap_temp_sens_head_failure": {
+        "name": "Fallo del cabezal sensor de temperatura de evaporaci\u00f3n variable"
+      },
+      "vari_temp_sens_head_failure": {
+        "name": "Fallo del cabezal sensor de temperatura variable"
+      },
+      "vibration_alarm": {
+        "name": "Alarma de vibraci\u00f3n"
+      },
+      "vibration_sensor_fault": {
+        "name": "Fallo en sensor de vibraci\u00f3n"
+      },
+      "water_level_switch": {
+        "name": "Interruptor nivel de agua"
+      },
+      "waterbox_full": {
+        "name": "Compartimento de agua lleno"
+      }
+    },
+    "climate": {
+      "connectlife": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "middle_high": "Medio alto",
+              "middle_low": "Medio bajo"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "ai": "AI",
+              "eco_mute": "Silencioso Eco",
+              "eco_sleep_1": "Sue\u00f1o Eco 1",
+              "eco_sleep_2": "Sue\u00f1o Eco 2",
+              "eco_sleep_3": "Sue\u00f1o Eco 3",
+              "eco_sleep_4": "Sue\u00f1o Eco 4",
+              "mute": "Silencioso",
+              "off": "Apagado",
+              "sleep_1": "Sue\u00f1o 1",
+              "sleep_2": "Sue\u00f1o 2",
+              "sleep_3": "Sue\u00f1o 3",
+              "sleep_4": "Sue\u00f1o 4",
+              "super": "Super"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "both_sides": "Ambos lados",
+              "forward": "Avanzar",
+              "left": "Izquierda",
+              "right": "Derecha",
+              "swing": "Balanceo"
+            }
+          }
+        }
+      }
+    },
+    "humidifier": {
+      "connectlife": {
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "auto": "Auto",
+              "clothes_dry": "Ropa seca",
+              "continuous": "Continuo",
+              "manual": "Manual"
+            }
+          }
+        }
+      }
+    },
+    "number": {
+      "freeze_max_temperature": {
+        "name": "Congelador temperatura m\u00e1xima"
+      },
+      "freeze_min_temperature": {
+        "name": "Congelador temperatura m\u00ednima"
+      },
+      "freeze_temperature": {
+        "name": "Temperatura Congelador"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Frigorifico temperatura m\u00e1xima"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Frigorifico temperatura m\u00ednima"
+      },
+      "refrigerator_temperature": {
+        "name": "Temperatura frigor\u00edfico"
+      },
+      "variation_max_temperature": {
+        "name": "Variaci\u00f3n temperatura m\u00e1xima"
+      },
+      "variation_min_temperature": {
+        "name": "Variaci\u00f3n temperatura m\u00ednima"
+      },
+      "variation_temperature": {
+        "name": "Temperatura variaci\u00f3n"
+      }
+    },
+    "select": {
+      "ExtraRinseNum": {
+        "name": "Aclarado extra",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
+        }
+      },
+      "dry_level": {
+        "name": "Nivel Secado",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3"
+        }
+      },
+      "dry_time": {
+        "name": "Secado",
+        "state": {
+          "extra_dry": "Exstra seco",
+          "pre-ironing": "Plancha",
+          "wardrobe": "Armario"
+        }
+      },
+      "selected_program_id": {
+        "name": "Programa seleccionado",
+        "state": {
+          "anti_allergy": "Antialergias",
+          "auto": "Auto",
+          "baby": "Ropa beb\u00e9",
+          "bed_linen": "Ropa de cama",
+          "clean_dry_60": "Lavado Secado 60\u00b4",
+          "cotton": "Algodon",
+          "cotton_dry": "Secado Agod\u00f3n",
+          "delicates": "Delicados",
+          "down": "Bajar",
+          "drum_cleaning": "Limpieza Tambor",
+          "eco_40_60": "Eco 40-60",
+          "fast15": "Rapido 15\u00b4",
+          "fast30": "Rapido 30\u00b4",
+          "power49": "Power 49",
+          "refresh": "Refrescar",
+          "remote": "Control remoto",
+          "rinse_spin": "Aclarado y Centrifugado",
+          "shirts": "Camisas",
+          "spin-dry": "Centrifugar",
+          "sports": "Ropa deporte",
+          "synthetic": "Sinteticos",
+          "synthetic_dry": "Secado Sinteticos",
+          "time": "Secado por tiempo",
+          "towels": "Toalas",
+          "wool": "Lana"
+        }
+      },
+      "spin_speed_rpm": {
+        "name": "Centrifugado",
+        "state": {
+          "1000": "30",
+          "1200": "1200",
+          "1400": "1400",
+          "600": "60",
+          "800": "40",
+          "none": "No centrifugar"
+        }
+      },
+      "t_fan_speed": {
+        "name": "Velocidad ventilador",
+        "state": {
+          "auto": "Auto",
+          "high": "Alto",
+          "low": "Bajo"
+        }
+      },
+      "t_sleep": {
+        "name": "Modo suspensi\u00f3n",
+        "state": {
+          "for_kid": "Para ni\u00f1os",
+          "for_old": "Para mayores",
+          "for_young": "Para jovenes",
+          "general": "General",
+          "off": "Apagado"
+        }
+      },
+      "t_swing_angle": {
+        "name": "Modo balanceo",
+        "state": {
+          "angle_1": "Anglulo 1",
+          "angle_2": "Anglulo 2",
+          "angle_3": "Anglulo 3",
+          "angle_4": "Anglulo 4",
+          "angle_5": "Anglulo 5",
+          "angle_6": "Anglulo 6",
+          "auto": "Auto",
+          "swing": "balanceo"
+        }
+      },
+      "t_swing_follow": {
+        "name": "AI ventilacion",
+        "state": {
+          "follow": "Seguir",
+          "not_follow": "No seguir",
+          "off": "Apagado"
+        }
+      },
+      "temperature": {
+        "name": "Temperatura",
+        "state": {
+          "20": "20",
+          "30": "30",
+          "40": "40",
+          "60": "60",
+          "90": "90",
+          "cold": "Frio"
+        }
+      }
+    },
+    "sensor": {
+      "ado_allowed": {
+        "name": "ADO permitido"
+      },
+      "alarm_door_closed": {
+        "name": "Puerta cerrada"
+      },
+      "alarm_door_opened": {
+        "name": "Puerta abierta"
+      },
+      "anticrease_setting": {
+        "name": "Duraci\u00f3n anti arrugas"
+      },
+      "appliance_status": {
+        "state": {
+          "idle": "Inactivo",
+          "running": "En funcionamiento"
+        }
+      },
+      "auto_dose_duration": {
+        "name": "Duraci\u00f3n de la dosis autom\u00e1tica"
+      },
+      "auto_dose_quantity_setting_status": {
+        "name": "Configuraci\u00f3n autom\u00e1tica de la cantidad de dosificador"
+      },
+      "auto_dose_refill": {
+        "name": "Recargar autodosificador"
+      },
+      "auto_dose_setting_status": {
+        "name": "Configuracion autodosificador"
+      },
+      "bundling_humidity": {
+        "name": "Humedad acumulado"
+      },
+      "bundling_temperature": {
+        "name": "Temperatura acumulado"
+      },
+      "child_lock_setting_status": {
+        "name": "Configuracion bloqueo ni\u00f1os"
+      },
+      "curent_program_duration": {
+        "name": "Duracion del programa actual"
+      },
+      "curent_program_remaining_time": {
+        "name": "Tiempo restante programa actual"
+      },
+      "current_baking_step": {
+        "name": "Fase de horneado",
+        "state": {
+          "after_bake_finished": "Horneado terminado",
+          "preheat": "Precalentar",
+          "step_1": "Paso 1",
+          "step_2": "Paso 2",
+          "step_3": "Paso 3"
+        }
+      },
+      "current_program_phase": {
+        "state": {
+          "anti_crease": "Anti arrugas",
+          "delay": "Pospuesto",
+          "delay_start_waiting": "Esperando inicio pospuesto",
+          "drying": "Secando",
+          "finished": "Terminado",
+          "idle": "Pausado",
+          "main_wash": "Lavado principal",
+          "not_available": "No disponible",
+          "preheat": "Precantamiento",
+          "preheat_finished": "Precantamiento terminado",
+          "prewash": "Prelavando",
+          "program_finished": "Programa Terminado",
+          "program_not_selected": "Programa no seleccionado",
+          "program_selected": "Programa selecionado",
+          "rinse": "Aclarando",
+          "running": "En marcha",
+          "spin-dry": "Centrifugando",
+          "ventilating": "Ventilaci\u00f3n",
+          "wash": "Lavando",
+          "weigh": "Pesando"
+        }
+      },
+      "current_programphase": {
+        "state": {
+          "running": "En marcha"
+        }
+      },
+      "daily_energy_consumption": {
+        "name": "Consumo energia diario"
+      },
+      "daily_energy_kwh": {
+        "name": "Consumo energia diario"
+      },
+      "delay_duration_inminutes": {
+        "name": "Duraci\u00f3n retraso"
+      },
+      "delaystart_delayend_duration_inminutes": {
+        "name": "Duracci\u00f3n inicio retrasado"
+      },
+      "delaystart_delayend_remaining_timein_minutes": {
+        "name": "Tiempo restrante inicio retrasado"
+      },
+      "detergent_display": {
+        "name": "Display Detergente",
+        "state": {
+          "off": "off",
+          "on": "on"
+        }
+      },
+      "device_status": {
+        "state": {
+          "after_bake_finished": "Horneado terminado",
+          "delay_time_waiting": "Esperando tiempo de retraso",
+          "demo_mode": "Modo demostraci\u00f3n",
+          "error": "Error",
+          "failure": "Fallo",
+          "idle": "Suspendido",
+          "iq": "IQ",
+          "locked": "Cerrado",
+          "not_available": "No disponible",
+          "pause": "Pausado",
+          "pause_mode": "Pausado",
+          "paused": "Pausado",
+          "production": "Producci\u00f3n",
+          "running": "En marcha",
+          "service": "Servicio",
+          "stand_by": "Suspendido"
+        }
+      },
+      "display_brightness_setting_status": {
+        "name": "Configuracion brillo display"
+      },
+      "door_status": {
+        "name": "Puerta",
+        "state": {
+          "closed": "Cerrada",
+          "not_available": "No disponible",
+          "open": "Abierta"
+        }
+      },
+      "dry_time": {
+        "name": "Tipo Secado",
+        "state": {
+          "120": "120 min",
+          "150": "150 min",
+          "180": "180 min",
+          "30": "30 min",
+          "60": "60 min",
+          "90": "90 min",
+          "closet": "Seco armario",
+          "extra_dry": "Extra seco",
+          "iron": "Seco plancha"
+        }
+      },
+      "electricit_consumption_int": {
+        "name": "Energia consumida"
+      },
+      "energy_consumption_in_running_program": {
+        "name": "Energia consumida programa en curso"
+      },
+      "energy_estimate": {
+        "name": "Energia estimada"
+      },
+      "environment_humidity": {
+        "name": "Humedad ambiental"
+      },
+      "error_code": {
+        "name": "C\u00f3digo error"
+      },
+      "extradry_setting": {
+        "name": "Configuraci\u00f3n extra-seco"
+      },
+      "f_cool_qvalue": {
+        "name": "Enfriando"
+      },
+      "f_heat_qvalue": {
+        "name": "Calentando"
+      },
+      "f_votage": {
+        "name": "Voltaje"
+      },
+      "feedback_volumen_setting_status": {
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "mid": "Medio",
+          "mute": "Silenciar"
+        }
+      },
+      "freeze_real_temperature": {
+        "name": "Temperatura real congelador"
+      },
+      "freeze_sensor_real_temperature": {
+        "name": "Temperatura real sensor congelador"
+      },
+      "fruit_vegetables_temperature": {
+        "name": "Temperatura compartimento frutas y vegetales"
+      },
+      "high_humidity": {
+        "name": "Humedad alta"
+      },
+      "high_temperature": {
+        "name": "Temperatura alta"
+      },
+      "last_run_program_id": {
+        "name": "\u00daltimo programa"
+      },
+      "low_humidity": {
+        "name": "Humedad baja"
+      },
+      "low_temperature": {
+        "name": "Temperatura baja"
+      },
+      "machine_status": {
+        "name": "Estado Maquina",
+        "state": {
+          "off": "Apagada",
+          "running": "En Marcha",
+          "standby": "Suspendida"
+        }
+      },
+      "measured_vibrations": {
+        "name": "Vivbraciones"
+      },
+      "meat_probe_measured_temperature": {
+        "name": "Temperatura sonda de carne"
+      },
+      "meat_probe_set_temperature": {
+        "name": "Temperatura sonda de carne"
+      },
+      "medium_humidity": {
+        "name": "Humedad media"
+      },
+      "medium_temperature": {
+        "name": "Temperatura media"
+      },
+      "oven_temperature": {
+        "name": "Temperatura horno"
+      },
+      "real_humidity": {
+        "name": "Humedad real"
+      },
+      "real_humidity_b": {
+        "name": "Humedad real b"
+      },
+      "real_humidity_c": {
+        "name": "Humedad real c"
+      },
+      "refrigerator_real_temperature": {
+        "name": "Temperatura real refrigerador"
+      },
+      "refrigerator_sensor_real_temperature": {
+        "name": "Temperatura real sensor refrigerador"
+      },
+      "rinsenum": {
+        "name": "Aclarados extra"
+      },
+      "sand_timer1_duration_in_seconds": {
+        "name": "Duraci\u00f1on temporizador 1"
+      },
+      "sand_timer1_status": {
+        "name": "Temporizador 1",
+        "state": {
+          "paused": "Pausado",
+          "started": "Inciado",
+          "stopped": "Parado"
+        }
+      },
+      "sand_timer2_duration_in_seconds": {
+        "name": "Duraci\u00f1on temporizador 12"
+      },
+      "sand_timer2_status": {
+        "name": "Temporizador 2",
+        "state": {
+          "paused": "Pausado",
+          "started": "Inciado",
+          "stopped": "Parado"
+        }
+      },
+      "sand_timer3_duration_in_seconds": {
+        "name": "Duraci\u00f1on temporizador 3"
+      },
+      "sand_timer3_status": {
+        "name": "Temporizador 3",
+        "state": {
+          "paused": "Pausado",
+          "started": "Inciado",
+          "stopped": "Parado"
+        }
+      },
+      "selected_program_id": {
+        "name": "Programa seleccionado",
+        "state": {
+          "anti_allergy": "Antialergias",
+          "auto": "Auto",
+          "baby": "Ropa beb\u00e9",
+          "bed_linen": "Ropa de cama",
+          "clean_dry_60": "Lavado Secado 60\u00b4",
+          "cotton": "Algod\u00f3n",
+          "cotton_dry": "Secado Algod\u00f3n",
+          "cotton_storage": "Algod\u00f3n",
+          "delicates": "Delicados",
+          "down": "Bajar",
+          "drum_cleaning": "Limpieza Tambor",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Extra higiene",
+          "fast15": "R\u00e1pido 15\u00b4",
+          "fast30": "R\u00e1pido 30\u00b4",
+          "fast89": "Fast 89",
+          "iron": "Plancha",
+          "mix": "Mix",
+          "none": "Nada",
+          "power49": "Power 49",
+          "refresh": "Refrescar",
+          "remote": "Remoto",
+          "rinse_dpin": "Aclarado y Centrifugado",
+          "sensitive": "Delicados",
+          "shirts": "Camisas",
+          "spin-dry": "Centrifugar",
+          "sports": "Ropa deporte",
+          "standard": "Est\u00e1ndar",
+          "synthetic": "Sint\u00e9nticos",
+          "synthetic_dry": "Secado Sint\u00e9ticos",
+          "time": "Tiempo",
+          "towels": "Toallas",
+          "wool": "Lana"
+        }
+      },
+      "selected_program_id_status": {
+        "name": "Programa seleccionado",
+        "state": {
+          "auto": "Auto",
+          "clean": "Limpieza",
+          "eco": "Eco",
+          "glass": "Cristal",
+          "hygiene": "Higiene",
+          "intensive": "Intensivo",
+          "night": "Noche",
+          "one_hour": "1 hora"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Modo programa",
+        "state": {
+          "fast": "R\u00e1pido",
+          "normal": "Normal"
+        }
+      },
+      "selected_program_remaining_time_in_minutes": {
+        "name": "Tiempo restante programa seleccionado"
+      },
+      "selected_program_total_running_time_in_minutes": {
+        "name": "Tiempo total programa seleccionado en curso"
+      },
+      "selected_program_total_time_in_minutes": {
+        "name": "Tiempo total programa seleccionado"
+      },
+      "selected_programduration_inminutes": {
+        "name": "Duraci\u00f3n programa seleccionado"
+      },
+      "selected_programremaining_time_inminutes": {
+        "name": "Tiempo restante programa seleccionado"
+      },
+      "set_progress_type": {
+        "name": "Tipo progreso",
+        "state": {
+          "cleaning": "Limpieza",
+          "culi_set": "Culi set",
+          "defrost": "Descongelar",
+          "fast_set": "Fast set",
+          "mw_set": "Mw set",
+          "mwc_set": "Mwc set",
+          "none": "Nada",
+          "oven_set": "Oven set",
+          "pyrolysis": "Pirolysis",
+          "st_set": "St set",
+          "stage_set": "Stage set",
+          "stc_set": "Stc set",
+          "warming": "Calentando"
+        }
+      },
+      "sl1_active_timer": {
+        "name": "Zona 1 temporizador activo",
+        "state": {
+          "inactive": "Inactivo",
+          "stopwatch": "Parado",
+          "timer": "Tiempo"
+        }
+      },
+      "sl1_functions": {
+        "name": "Zona 1 funciones",
+        "state": {
+          "boil": "Hervir",
+          "grill": "Parrilla",
+          "keep_warm": "Mantener caliente",
+          "none": "Nada",
+          "roast": "Asar",
+          "simmer": "Hervir a fuego lento",
+          "wok": "Wok"
+        }
+      },
+      "sl1_ntc_sensor": {
+        "name": "Zona 1 sensor NTC"
+      },
+      "sl1_power_level": {
+        "name": "Zona 1 nivel potencia"
+      },
+      "sl1_power_level_max": {
+        "name": "Zona 1 maximo nivel potencia"
+      },
+      "sl1_zone_shape": {
+        "name": "Zona 1 forma",
+        "state": {
+          "no_shape": "Sin forma",
+          "rectangle_horizontal": "Rect\u00e1ngulo horizontal",
+          "rectangle_vertical": "Rect\u00e1ngulo vertical",
+          "round": "Redonda",
+          "square": "Cuadrada"
+        }
+      },
+      "sl2_active_timer": {
+        "name": "Zona 2 temporizador activo",
+        "state": {
+          "inactive": "Inactivo",
+          "stopwatch": "Parado",
+          "timer": "Tiempo"
+        }
+      },
+      "sl2_functions": {
+        "name": "Zona 2 funciones",
+        "state": {
+          "boil": "Hervir",
+          "grill": "Parrilla",
+          "keep_warm": "Mantener caliente",
+          "none": "Nada",
+          "roast": "Asar",
+          "simmer": "Hervir a fuego lento",
+          "wok": "Wok"
+        }
+      },
+      "sl2_ntc_sensor": {
+        "name": "Zona 2 sensor NTC"
+      },
+      "sl2_power_level": {
+        "name": "Zona 2 nivel potencia"
+      },
+      "sl2_power_level_max": {
+        "name": "Zona 2 m\u00e1ximo nivel potencia"
+      },
+      "sl2_zone_shape": {
+        "name": "Zona 2 forma",
+        "state": {
+          "no_shape": "Sin forma",
+          "rectangle_horizontal": "Rect\u00e1ngulo horizontal",
+          "rectangle_vertical": "Rect\u00e1ngulo vertical",
+          "round": "Redonda",
+          "square": "Cuadrada"
+        }
+      },
+      "sl3_active_timer": {
+        "name": "Zona 3 temporizador activo",
+        "state": {
+          "inactive": "Inactivo",
+          "stopwatch": "Parado",
+          "timer": "Tiempo"
+        }
+      },
+      "sl3_functions": {
+        "name": "Zona 3 funciones",
+        "state": {
+          "boil": "Hervir",
+          "grill": "Parrilla",
+          "keep_warm": "Mantener caliente",
+          "none": "Nada",
+          "roast": "Asar",
+          "simmer": "Hervir a fuego lento",
+          "wok": "Wok"
+        }
+      },
+      "sl3_ntc_sensor": {
+        "name": "Zona 3 sensor NTC"
+      },
+      "sl3_power_level": {
+        "name": "Zona 3 nivel potencia"
+      },
+      "sl3_power_level_max": {
+        "name": "Zona 3 m\u00e1ximo nivel potencia"
+      },
+      "sl3_zone_shape": {
+        "name": "Zona 3 forma",
+        "state": {
+          "no_shape": "Sin forma",
+          "rectangle_horizontal": "Rect\u00e1ngulo horizontal",
+          "rectangle_vertical": "Rect\u00e1ngulo vertical",
+          "round": "Redonda",
+          "square": "Cuadrada"
+        }
+      },
+      "sl4_active_timer": {
+        "name": "Zona 4 temporizador activo",
+        "state": {
+          "inactive": "Inactivo",
+          "stopwatch": "Parado",
+          "timer": "Tiempo"
+        }
+      },
+      "sl4_functions": {
+        "name": "Zona 4 funciones",
+        "state": {
+          "boil": "Hervir",
+          "grill": "Parrilla",
+          "keep_warm": "Mantener caliente",
+          "none": "Nada",
+          "roast": "Asar",
+          "simmer": "Hervir a fuego lento",
+          "wok": "Wok"
+        }
+      },
+      "sl4_ntc_sensor": {
+        "name": "Zona 4 sensor NTC"
+      },
+      "sl4_power_level": {
+        "name": "Zona 4 nivel potencia"
+      },
+      "sl4_power_level_max": {
+        "name": "Zona 4 m\u00e1ximo nivel potencia"
+      },
+      "sl4_zone_shape": {
+        "name": "Zona 4 forma",
+        "state": {
+          "no_shape": "Sin forma",
+          "rectangle_horizontal": "Rect\u00e1ngulo horizontal",
+          "rectangle_vertical": "Rect\u00e1ngulo vertical",
+          "round": "Redonda",
+          "square": "Cuadrada"
+        }
+      },
+      "sl5_active_timer": {
+        "name": "Zona 5 temporizador activo",
+        "state": {
+          "inactive": "Inactivo",
+          "stopwatch": "Parado",
+          "timer": "Tiempo"
+        }
+      },
+      "sl5_functions": {
+        "name": "Zona 5 funciones",
+        "state": {
+          "boil": "Hervir",
+          "grill": "Parrilla",
+          "keep_warm": "Mantener caliente",
+          "none": "Nada",
+          "roast": "Asar",
+          "simmer": "Hervir a fuego lento",
+          "wok": "Wok"
+        }
+      },
+      "sl5_ntc_sensor": {
+        "name": "Zona 5 sensor NTC"
+      },
+      "sl5_power_level": {
+        "name": "Zona 5 nivel potencia"
+      },
+      "sl5_power_level_max": {
+        "name": "Zona 5 m\u00e1ximo nivel potencia"
+      },
+      "sl5_zone_shape": {
+        "name": "Zona 5 forma",
+        "state": {
+          "no_shape": "Sin forma",
+          "rectangle_horizontal": "Rect\u00e1ngulo horizontal",
+          "rectangle_vertical": "Rect\u00e1ngulo vertical",
+          "round": "Redonda",
+          "square": "Cuadrada"
+        }
+      },
+      "sl6_active_timer": {
+        "name": "Zona 6 temporizador activo",
+        "state": {
+          "inactive": "Inactivo",
+          "stopwatch": "Parado",
+          "timer": "Tiempo"
+        }
+      },
+      "sl6_functions": {
+        "name": "Zona 6 funciones",
+        "state": {
+          "boil": "Hervir",
+          "grill": "Parrilla",
+          "keep_warm": "Mantener caliente",
+          "none": "Nada",
+          "roast": "Asar",
+          "simmer": "Hervir a fuego lento",
+          "wok": "Wok"
+        }
+      },
+      "sl6_ntc_sensor": {
+        "name": "Zona 6 sensor NTC"
+      },
+      "sl6_power_level": {
+        "name": "Zona 6 nivel potencia"
+      },
+      "sl6_power_level_max": {
+        "name": "Zona 6 maximo nivel potencia"
+      },
+      "sl6_zone_shape": {
+        "name": "Zona 6 forma",
+        "state": {
+          "no_shape": "Sin forma",
+          "rectangle_horizontal": "Rect\u00e1ngulo horizontal",
+          "rectangle_vertical": "Rect\u00e1ngulo vertical",
+          "round": "Redonda",
+          "square": "Cuadrada"
+        }
+      },
+      "softer_display": {
+        "name": "Display Suavizante",
+        "state": {
+          "off": "off",
+          "on": "on"
+        }
+      },
+      "spintime_index": {
+        "name": "Duraci\u00f3n centrifugado"
+      },
+      "step1_duration": {
+        "name": "Fase 1 duraci\u00f3n"
+      },
+      "step1_heater_system": {
+        "name": "Fase 1 sistema calentado",
+        "state": {
+          "aqua_clean": "Limpieza agua",
+          "bottom": "Abajo",
+          "bottom_fan": "Ventilador abajo",
+          "clean_air": "Limpieza aire",
+          "defrost": "Descongelado",
+          "defrost_auto": "Descongelado automatico",
+          "descale": "Desincrustar",
+          "eco_hot_air": "Aire Caliente ECO",
+          "fast_preheat": "Precalentado r\u00e1pido",
+          "grill_fan_micro": "Microondas ventilador parrilla",
+          "grillfanmicro": "Grill fa nmicro",
+          "hot_air": "Aire Caliente",
+          "hot_air_bottom": "Calor Arriba y Abajo",
+          "hot_air_micro": "Microondas aire caliente",
+          "hot_air_steam_1": "Vapor nivel 1",
+          "hot_air_steam_2": "Vapor nivel 2",
+          "hot_air_steam_3": "Vapor nivel 3",
+          "hotairmicro": "Micro aire caliente",
+          "keep_warm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_fan": "Ventilador parrilla grande",
+          "low_temp_steam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "microwave_clean": "Microondas limpieza",
+          "microwave_defrost": "Microondas descongelar",
+          "plates": "Platos",
+          "pro_roasting": "Pro tostado",
+          "programs": "Programas",
+          "pyro": "Pyro",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "small_grill": "Parrilla peque\u00f1a",
+          "sous_vide": "Al vacio",
+          "steam": "Vapor",
+          "steam_clean": "Limpieza vapor",
+          "top": "Arriba",
+          "top_bottom": "Arriba y Abajo",
+          "warming": "Calentamiento"
+        }
+      },
+      "step1_remaining_time": {
+        "name": "Fase 1 tiempo restante"
+      },
+      "step1_set_temperature": {
+        "name": "Fase 1 temperatura"
+      },
+      "step2_duration": {
+        "name": "Fase 2 duraci\u00f3n"
+      },
+      "step2_heater_system": {
+        "name": "Fase 2 sistema calentado",
+        "state": {
+          "aqua_clean": "Limpieza agua",
+          "bottom": "Abajo",
+          "bottom_fan": "Ventilador abajo",
+          "clean_air": "Limpieza aire",
+          "defrost": "Descongelado",
+          "defrost_auto": "Descongelado automatico",
+          "descale": "Desincrustar",
+          "eco_hot_air": "Aire Caliente ECO",
+          "fast_preheat": "Precalentado r\u00e1pido",
+          "grill_fan_micro": "Microondas ventilador parrilla",
+          "grillfanmicro": "Grill fa nmicro",
+          "hot_air": "Aire Caliente",
+          "hot_air_bottom": "Calor Arriba y Abajo",
+          "hot_air_micro": "Microondas aire caliente",
+          "hot_air_steam_1": "Vapor nivel 1",
+          "hot_air_steam_2": "Vapor nivel 2",
+          "hot_air_steam_3": "Vapor nivel 3",
+          "hotairmicro": "Micro aire caliente",
+          "keep_warm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_fan": "Ventilador parrilla grande",
+          "low_temp_steam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "microwave_clean": "Microondas limpieza",
+          "microwave_defrost": "Microondas descongelar",
+          "plates": "Platos",
+          "pro_roasting": "Pro tostado",
+          "programs": "Programas",
+          "pyro": "Pyro",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "small_grill": "Parrilla peque\u00f1a",
+          "sous_vide": "Al vacio",
+          "steam": "Vapor",
+          "steam_clean": "Limpieza vapor",
+          "top": "Arriba",
+          "top_bottom": "Arriba y Abajo",
+          "warming": "Calentamiento"
+        }
+      },
+      "step2_remaining_time": {
+        "name": "Fase 1 tiempo restante"
+      },
+      "step2_set_temperature": {
+        "name": "Fase 2 temperatura"
+      },
+      "step3_duration": {
+        "name": "Fase 1 duraci\u00f3n"
+      },
+      "step3_heater_system": {
+        "name": "Fase 3 sistema calentado",
+        "state": {
+          "aqua_clean": "Limpieza agua",
+          "bottom": "Abajo",
+          "bottom_fan": "Ventilador abajo",
+          "clean_air": "Limpieza aire",
+          "defrost": "Descongelado",
+          "defrost_auto": "Descongelado automatico",
+          "descale": "Desincrustar",
+          "eco_hot_air": "Aire Caliente ECO",
+          "fast_preheat": "Precalentado r\u00e1pido",
+          "grill_fan_micro": "Microondas ventilador parrilla",
+          "grillfanmicro": "Grill fa nmicro",
+          "hot_air": "Aire Caliente",
+          "hot_air_bottom": "Calor Arriba y Abajo",
+          "hot_air_micro": "Microondas aire caliente",
+          "hot_air_steam_1": "Vapor nivel 1",
+          "hot_air_steam_2": "Vapor nivel 2",
+          "hot_air_steam_3": "Vapor nivel 3",
+          "hotairmicro": "Micro aire caliente",
+          "keep_warm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_fan": "Ventilador parrilla grande",
+          "low_temp_steam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "microwave_clean": "Microondas limpieza",
+          "microwave_defrost": "Microondas descongelar",
+          "plates": "Platos",
+          "pro_roasting": "Pro tostado",
+          "programs": "Programas",
+          "pyro": "Pyro",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "small_grill": "Parrilla peque\u00f1a",
+          "sous_vide": "Al vacio",
+          "steam": "Vapor",
+          "steam_clean": "Limpieza vapor",
+          "top": "Arriba",
+          "top_bottom": "Arriba y Abajo",
+          "warming": "Calentamiento"
+        }
+      },
+      "step3_remaining_time": {
+        "name": "Fase 1 tiempo restante"
+      },
+      "step3_set_temperature": {
+        "name": "Fase 3 temperatura"
+      },
+      "t_sleep": {
+        "name": "Suspendido"
+      },
+      "temperature_room_judge": {
+        "name": "Temperature room judge"
+      },
+      "total_energy_consumption": {
+        "name": "Total consumo de energia"
+      },
+      "total_number_of_cycles": {
+        "name": "N\u00famero total de ciclos"
+      },
+      "total_passed_time": {
+        "name": "Tiempo transcurrido"
+      },
+      "total_remaining_time": {
+        "name": "Tiempo restante"
+      },
+      "total_run_time": {
+        "name": "Tiempo total"
+      },
+      "total_time_of_cooking_in_hours": {
+        "name": "Tiempo total cocinado"
+      },
+      "total_water_consumption": {
+        "name": "Total agua consumida"
+      },
+      "utc_datetime_bdc_delaystart_delayend_timestamp": {
+        "name": "BDC DelayStart DelayEnd"
+      },
+      "variation_real_temperature": {
+        "name": "Variacion real de temperatura"
+      },
+      "variation_sensor_real_temperature": {
+        "name": "Sensor variaci\u00f3n real de temperatura"
+      },
+      "water_consumption_in_running_program": {
+        "name": "Agua consumida en programa actual"
+      },
+      "water_consumption_int": {
+        "name": "Agua consumida"
+      },
+      "zone_number": {
+        "name": "N\u00famero de zonas"
+      }
+    },
+    "switch": {
+      "anticrease": {
+        "name": "Antiarrugas"
+      },
+      "automatic_ice_making": {
+        "name": "Fabricaci\u00f3n autom\u00e1tica de hielo"
+      },
+      "child_lock": {
+        "name": "Bloqueo para ni\u00f1os"
+      },
+      "drum_light": {
+        "name": "Luz tambor"
+      },
+      "holiday_mode": {
+        "name": "Modo vacaciones"
+      },
+      "mute": {
+        "name": "Silenciar"
+      },
+      "prewash": {
+        "name": "Prelavado"
+      },
+      "steam": {
+        "name": "Vapor"
+      },
+      "t_air": {
+        "name": "Aire"
+      },
+      "t_beep": {
+        "name": "Beep"
+      },
+      "t_eco": {
+        "name": "Eco"
+      },
+      "t_fan_mute": {
+        "name": "Silenciar ventilador"
+      },
+      "t_power": {
+        "name": "Encendido"
+      },
+      "t_purify": {
+        "name": "Purificador"
+      },
+      "t_sleep": {
+        "name": "Suspender"
+      },
+      "t_sterilization": {
+        "name": "Esterilizaci\u00f3n"
+      },
+      "t_super": {
+        "name": "Super"
+      },
+      "t_tms": {
+        "name": "AI"
+      }
+    },
+    "water_heater": {
+      "connectlife": {
+        "state": {
+          "auto": "Auto"
+        }
+      }
+    }
+  },
+  "issues": {
+    "unavailable_device": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "El dispositivo ignorado \"{device_name} no est\u00e1 disponible\". El dispositivo y todas sus entidades permanecer\u00e1n listadas en el registro."
+        },
+        "step": {
+          "init": {
+            "description": "El dispositivo \"{device_name}\" est\u00e1 disponible en tu cuenta de ConnectLife. Si ya no dispones de este dispositivo, puedes eliminarlo de Home Assistant.",
+            "menu_options": {
+              "ignore": "Ignorar",
+              "remove": "Eliminar"
+            },
+            "title": "{device_name} no est\u00e1 disponible"
+          },
+          "remove": {
+            "description": "El dispositivo \"{device_name}\" y todas sus entidades ser\u00e1n eliminadas de Home Assistant.",
+            "title": "Eliminar {device_name}"
+          }
+        }
+      },
+      "title": "{device_name} no est\u00e1 disponible"
+    }
+  },
+  "options": {
+    "error": {
+      "test_server_invalid": "Test server URL invalida",
+      "test_server_required": "El modo desarrollo requiere una URL del Test Server"
+    },
+    "step": {
+      "configure_device": {
+        "data": {
+          "disable_beep": "Deshabilitar beep"
+        },
+        "description": "Configurar un dispositivo."
+      },
+      "development": {
+        "data": {
+          "development_mode": "Modo desarrollo",
+          "test_server_url": "Test server URL"
+        },
+        "description": "Habilitar modo desarrollo para conectar al test server en vez de a ConnectLife API."
+      },
+      "init": {
+        "menu_options": {
+          "development": "Configurar modo desarrollo",
+          "select_device": "Configurar un dispositivo"
+        }
+      },
+      "select_device": {
+        "data": {
+          "device": "Seleccionar dispositivo"
+        },
+        "description": "Configurar un dispositivo."
+      }
+    }
+  },
+  "services": {
+    "set_value": {
+      "description": "Asignar valor al estado. Usar con cuidado.",
+      "fields": {
+        "value": {
+          "description": "Valor a asignar.",
+          "name": "Valor"
+        }
+      },
+      "name": "Asignar valor"
+    }
+  }
 }

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -1,707 +1,707 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Il dispositivo è già configurato"
-        },
-        "error": {
-            "cannot_connect": "Impossibile connettersi",
-            "invalid_auth": "Autenticazione non valida",
-            "unknown": "Errore imprevisto"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "password": "Password",
-                    "username": "Username"
-                }
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "Il dispositivo \u00e8 gi\u00e0 configurato"
     },
-    "options": {
-        "step": {
-            "init": {
-                "menu_options": {
-                    "select_device": "Configura un dispositivo",
-                    "development": "Configura la modalità di sviluppo"
-                }
-            },
-            "select_device": {
-                "data": {
-                    "device": "Seleziona dispositivo"
-                },
-                "description": "Configura un dispositivo."
-            },
-            "configure_device": {
-                "data": {
-                    "disable_beep": "Disattiva beep"
-                },
-                "description": "Configura un dispositivo."
-            },
-            "development": {
-                "data": {
-                    "development_mode": "Modalità di sviluppo",
-                    "test_server_url": "Test server URL"
-                },
-                "description": "Abilita la modalità di sviluppo per connettersi al server di test anziché all'API ConnectLife."
-            }
-        },
-        "error": {
-            "test_server_invalid": "Invalid test server URL",
-            "test_server_required": "La modalità di sviluppo richiede l'URL del server di prova"
-        }
+    "error": {
+      "cannot_connect": "Impossibile connettersi",
+      "invalid_auth": "Autenticazione non valida",
+      "unknown": "Errore imprevisto"
     },
-    "services": {
-        "set_value": {
-            "name": "Imposta valore",
-            "description": "Imposta un valore per lo stato. Utilizzare con cura.",
-            "fields": {
-                "value": {
-                    "name": "Value",
-                    "description": "Valore da impostare."
-                }
-            }
+    "step": {
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Username"
         }
-    },
-    "entity": {
-        "binary_sensor": {
-            "child_lock_status": {
-                "name": "Blocco bambini"
-            },
-            "delaystart_delayend_mode": {
-                "name": "Partenza ritardata"
-            },
-            "selected_program_anticrease_status": {
-                "name": "Antipiega"
-            },
-            "selected_program_extradry_status": {
-                "name": "Extra secco"
-            },
-            "selected_program_steamfinish": {
-                "name": "Finitura a vapore"
-            },
-            "sl1_alarm_auto_program_notification": {
-                "name": "Notifica del programma automatico della zona 1"
-            },
-            "sl1_alarm_automatic_switch_off_zone": {
-                "name": "La zona 1 si spegne automaticamente"
-            },
-            "sl1_alarm_ntc_coil_overheating": {
-                "name": "Surriscaldamento della bobina della zona 1"
-            },
-            "sl1_alarm_timer_ended": {
-                "name": "Il timer della zona 1 è terminato"
-            },
-            "sl1_alarm_zone_turned_off": {
-                "name": "Zona 1 spenta"
-            },
-            "sl1_bridge_function_active": {
-                "name": "Ponte della zona 1 attivo"
-            },
-            "sl1_pot_detected": {
-                "name": "Rilevata pentola zona 1"
-            },
-            "sl1_status": {
-                "name": "Stato della zona 1"
-            },
-            "sl2_alarm_auto_program_notification": {
-                "name": "Notifica del programma automatico della zona 2"
-            },
-            "sl2_alarm_automatic_switch_off_zone": {
-                "name": "La zona 2 si spegne automaticamente"
-            },
-            "sl2_alarm_ntc_coil_overheating": {
-                "name": "Surriscaldamento della bobina della zona 2"
-            },
-            "sl2_alarm_timer_ended": {
-                "name": "Il timer della zona 2 è terminato"
-            },
-            "sl2_alarm_zone_turned_off": {
-                "name": "Zona 2 spenta"
-            },
-            "sl2_bridge_function_active": {
-                "name": "Ponte della zona 2 attivo"
-            },
-            "sl2_pot_detected": {
-                "name": "Rilevata pentola zona 2"
-            },
-            "sl2_status": {
-                "name": "Stato della zona 2"
-            },
-            "sl3_alarm_auto_program_notification": {
-                "name": "Notifica del programma automatico della zona 3"
-            },
-            "sl3_alarm_automatic_switch_off_zone": {
-                "name": "La zona 3 si spegne automaticamente"
-            },
-            "sl3_alarm_ntc_coil_overheating": {
-                "name": "Surriscaldamento della bobina della zona 3"
-            },
-            "sl3_alarm_timer_ended": {
-                "name": "Il timer della zona 3 è terminato"
-            },
-            "sl3_alarm_zone_turned_off": {
-                "name": "Zona 3 spenta"
-            },
-            "sl3_bridge_function_active": {
-                "name": "Ponte della zona 3 attivo"
-            },
-            "sl3_pot_detected": {
-                "name": "Rilevata pentola zona 3"
-            },
-            "sl3_status": {
-                "name": "Stato della zona 3"
-            },
-            "sl4_alarm_auto_program_notification": {
-                "name": "Notifica del programma automatico della zona 4"
-            },
-            "sl4_alarm_automatic_switch_off_zone": {
-                "name": "La zona 4 si spegne automaticamente"
-            },
-            "sl4_alarm_ntc_coil_overheating": {
-                "name": "Surriscaldamento della bobina della zona 4"
-            },
-            "sl4_alarm_timer_ended": {
-                "name": "Il timer della zona 4 è terminato"
-            },
-            "sl4_alarm_zone_turned_off": {
-                "name": "Zona 4 spenta"
-            },
-            "sl4_bridge_function_active": {
-                "name": "Ponte della zona 4 attivo"
-            },
-            "sl4_pot_detected": {
-                "name": "Rilevata pentola zona 4"
-            },
-            "sl4_status": {
-                "name": "Stato della zona 4"
-            },
-            "sl5_alarm_auto_program_notification": {
-                "name": "Notifica del programma automatico della zona 5"
-            },
-            "sl5_alarm_automatic_switch_off_zone": {
-                "name": "La zona 5 si spegne automaticamente"
-            },
-            "sl5_alarm_ntc_coil_overheating": {
-                "name": "Surriscaldamento della bobina della zona 5"
-            },
-            "sl5_alarm_timer_ended": {
-                "name": "Il timer della zona 5 è terminato"
-            },
-            "sl5_alarm_zone_turned_off": {
-                "name": "Zona 5 spenta"
-            },
-            "sl5_bridge_function_active": {
-                "name": "Ponte della zona 5 attivo"
-            },
-            "sl5_pot_detected": {
-                "name": "Rilevata pentola zona 5"
-            },
-            "sl5_status": {
-                "name": "Stato della zona 5"
-            },
-            "sl6_alarm_auto_program_notification": {
-                "name": "Notifica del programma automatico della zona 6"
-            },
-            "sl6_alarm_automatic_switch_off_zone": {
-                "name": "La zona 6 si spegne automaticamente"
-            },
-            "sl6_alarm_ntc_coil_overheating": {
-                "name": "Surriscaldamento della bobina della zona 6"
-            },
-            "sl6_alarm_timer_ended": {
-                "name": "Il timer della zona 6 è terminato"
-            },
-            "sl6_alarm_zone_turned_off": {
-                "name": "Zona 6 spenta"
-            },
-            "sl6_bridge_function_active": {
-                "name": "Ponte della zona 6 attivo"
-            },
-            "sl6_pot_detected": {
-                "name": "Rilevata pentola zona 6"
-            },
-            "sl6_status": {
-                "name": "Stato della zona 6"
-            }
-        },
-        "climate": {
-            "connectlife": {
-                "state_attributes": {
-                    "fan_mode": {
-                        "state": {
-                            "middle_low": "Medio bassa",
-                            "middle_high": "Medio alta"
-                        }
-                    },
-                    "preset_mode": {
-                        "state": {
-                            "ai": "AI",
-                            "off": "Off",
-                            "mute": "Mute",
-                            "eco_mute": "Eco mute",
-                            "super": "Super",
-                            "sleep_1": "Sleep 1",
-                            "sleep_2": "Sleep 2",
-                            "sleep_3": "Sleep 3",
-                            "sleep_4": "Sleep 4",
-                            "eco_sleep_1": "Eco sleep 1",
-                            "eco_sleep_2": "Eco sleep 2",
-                            "eco_sleep_3": "Eco sleep 3",
-                            "eco_sleep_4": "Eco sleep 4"
-                        }
-                    },
-                    "swing_mode": {
-                        "state": {
-                            "both_sides": "Solo lati",
-                            "forward": "Dritto",
-                            "left": "Sinistra",
-                            "right": "Destra",
-                            "swing": "Oscillazione"
-                        }
-                    }
-                }
-            }
-        },
-        "humidifier": {
-            "connectlife": {
-                "state_attributes": {
-                    "mode": {
-                        "state": {
-                            "auto": "Auto",
-                            "continuous": "Continuo",
-                            "manual": "Manuale",
-                            "clothes_dry": "Vestiti asciutti"
-                        }
-                    }
-                }
-            }
-        },
-        "sensor": {
-            "alarm_door_closed": {
-                "name": "Porta chiusa"
-            },
-            "alarm_door_opened": {
-                "name": "Porta aperta"
-            },
-            "anticrease_setting": {
-                "name": "Durata antipiega"
-            },
-            "appliance_status": {
-                "state": {
-                    "idle": "Idle",
-                    "running": "In esecuzione"
-                }
-            },
-            "bundling_humidity": {
-                "name": "Accumulo di umidità"
-            },
-            "bundling_temperature": {
-                "name": "Temperatura di fasciatura"
-            },
-            "current_program_phase": {
-                "state": {
-                    "not_available": "Non disponibile",
-                    "program_not_selected": "Programma non selezionato",
-                    "program_selected": "Programma selezionato",
-                    "delay_start_waiting": "Attesa avvio ritardato",
-                    "preheat": "Preriscaldamento",
-                    "preheat_finished": "Preriscaldamento terminato",
-                    "prewash": "Prelavaggio",
-                    "main_wash": "Lavaggio principale",
-                    "drying": "Asciugatura",
-                    "program_finished": "Terminato",
-                    "ventilating": "Ventilazione"
-                }
-            },
-            "current_programphase": {
-                "state": {
-                    "running": "In esecuzione"
-                }
-            },
-            "daily_energy_kwh": {
-                "name": "Consumo energetico giornaliero"
-            },
-            "delaystart_delayend_duration_inminutes": {
-                "name": "Durata avvio ritardato"
-            },
-            "delaystart_delayend_remaining_timein_minutes": {
-                "name": "Tempo rimanente avvio ritardato"
-            },
-            "delay_duration_inminutes": {
-                "name": "Durata ritardo"
-            },
-            "device_status": {
-                "demo_mode": "Modalità demo",
-                "failure": "Guasto",
-                "idle": "Inattivo",
-                "iq": "IQ",
-                "locked": "Bloccato",
-                "not_available": "Non disponibile",
-                "pause": "In pausa",
-                "pause_mode": "In pausa",
-                "production": "Produzione",
-                "running": "In esecuzione",
-                "service": "Servizio",
-                "stand_by": "In attesa"
-            },
-            "door_status": {
-                "name": "Porta",
-                "state": {
-                    "not_available": "Non disponibile",
-                    "closed": "Chiusa",
-                    "open": "Apera"
-                }
-            },
-            "selected_program_id": {
-                "name": "Seleziona programma",
-                "state": {
-                    "cotton_storage": "Conservazione cotone",
-                    "standard": "Standard",
-                    "iron": "Stiratura",
-                    "mix": "Misto",
-                    "synthetic": "Sintetico",
-                    "wool": "Lana",
-                    "bed_linen": "Lenzuola",
-                    "time": "Tempo",
-                    "baby": "Bambino",
-                    "sensitive": "Delicati",
-                    "shirts": "Camice",
-                    "sports": "Sport",
-                    "fast89": "Veloce 89",
-                    "extra_hygiene": "Igiene extra",
-                    "remote": "Remoto",
-                    "none": "Nessuno"
-                }
-            },
-            "selected_programduration_inminutes": {
-                "name": "Durata del programma selezionato"
-            },
-            "selected_programremaining_time_inminutes": {
-                "name": "Tempo rimanente del programma selezionato"
-            },
-            "sl1_active_timer": {
-                "name": "Timer attivo zona 1",
-                "state": {
-                    "inactive": "Inattivo",
-                    "stopwatch": "Cronometro",
-                    "timer": "Timer"
-                }
-            },
-            "sl1_functions": {
-                "name": "Funzione Zona 1",
-                "state": {
-                    "none": "Nessuno",
-                    "boil": "Bollire",
-                    "simmer": "Sobbollire",
-                    "keep_warm": "Mantieni caldo",
-                    "wok": "Wok",
-                    "roast": "Arrostire",
-                    "grill": "Grigliare"
-                }
-            },
-            "sl1_ntc_sensor": {
-                "name": "Sensore NTC Zona 1"
-            },
-            "sl1_power_level": {
-                "name": "Livello di potenza Zona 1"
-            },
-            "sl1_power_level_max": {
-                "name": "Livello di potenza massimo Zona 1"
-            },
-            "sl1_zone_shape": {
-                "name": "Forma Zona 1",
-                "state": {
-                    "round": "Rotonda",
-                    "square": "Quadrata",
-                    "rectangle_vertical": "Rettangolare verticale",
-                    "rectangle_horizontal": "Rettangolare orizzontale",
-                    "no_shape": "Senza forma"
-                }
-            },
-            "sl2_active_timer": {
-                "name": "Timer attivo Zona 2",
-                "state": {
-                    "inactive": "Inattivo",
-                    "stopwatch": "Cronometro",
-                    "timer": "Timer"
-                }
-            },
-            "sl2_functions": {
-                "name": "Funzione Zona 2",
-                "state": {
-                    "none": "Nessuno",
-                    "boil": "Bollire",
-                    "simmer": "Sobbollire",
-                    "keep_warm": "Mantieni caldo",
-                    "wok": "Wok",
-                    "roast": "Arrostire",
-                    "grill": "Grigliare"
-                }
-            },
-            "sl2_ntc_sensor": {
-                "name": "Sensore NTC Zona 2"
-            },
-            "sl2_power_level": {
-                "name": "Livello di potenza Zona 2"
-            },
-            "sl2_power_level_max": {
-                "name": "Livello di potenza massimo Zona 2"
-            },
-            "sl2_zone_shape": {
-                "name": "Forma Zona 2",
-                "state": {
-                    "round": "Rotonda",
-                    "square": "Quadrata",
-                    "rectangle_vertical": "Rettangolare verticale",
-                    "rectangle_horizontal": "Rettangolare orizzontale",
-                    "no_shape": "Senza forma"
-                }
-            },
-            "sl3_active_timer": {
-                "name": "Timer attivo Zona 3",
-                "state": {
-                    "inactive": "Inattivo",
-                    "stopwatch": "Cronometro",
-                    "timer": "Timer"
-                }
-            },
-            "sl3_functions": {
-                "name": "Funzione Zona 3",
-                "state": {
-                    "none": "Nessuno",
-                    "boil": "Bollire",
-                    "simmer": "Sobbollire",
-                    "keep_warm": "Mantieni caldo",
-                    "wok": "Wok",
-                    "roast": "Arrostire",
-                    "grill": "Grigliare"
-                }
-            },
-            "sl3_ntc_sensor": {
-                "name": "Sensore NTC Zona 3"
-            },
-            "sl3_power_level": {
-                "name": "Livello di potenza Zona 3"
-            },
-            "sl3_power_level_max": {
-                "name": "Livello di potenza massimo Zona 3"
-            },
-            "sl3_zone_shape": {
-                "name": "Forma Zona 3",
-                "state": {
-                    "round": "Rotonda",
-                    "square": "Quadrata",
-                    "rectangle_vertical": "Rettangolare verticale",
-                    "rectangle_horizontal": "Rettangolare orizzontale",
-                    "no_shape": "Senza forma"
-                }
-            },
-            "sl4_active_timer": {
-                "name": "Timer attivo Zona 4",
-                "state": {
-                    "inactive": "Inattivo",
-                    "stopwatch": "Cronometro",
-                    "timer": "Timer"
-                }
-            },
-            "sl4_functions": {
-                "name": "Funzione Zona 4",
-                "state": {
-                    "none": "Nessuno",
-                    "boil": "Bollire",
-                    "simmer": "Sobbollire",
-                    "keep_warm": "Mantieni caldo",
-                    "wok": "Wok",
-                    "roast": "Arrostire",
-                    "grill": "Grigliare"
-                }
-            },
-            "sl4_ntc_sensor": {
-                "name": "Sensore NTC Zona 4"
-            },
-            "sl4_power_level": {
-                "name": "Livello di potenza Zona 4"
-            },
-            "sl4_power_level_max": {
-                "name": "Livello di potenza massimo Zona 4"
-            },
-            "sl4_zone_shape": {
-                "name": "Forma Zona 4",
-                "state": {
-                    "round": "Rotonda",
-                    "square": "Quadrata",
-                    "rectangle_vertical": "Rettangolare verticale",
-                    "rectangle_horizontal": "Rettangolare orizzontale",
-                    "no_shape": "Senza forma"
-                }
-            },
-            "sl5_active_timer": {
-                "name": "Timer attivo Zona 5",
-                "state": {
-                    "inactive": "Inattivo",
-                    "stopwatch": "Cronometro",
-                    "timer": "Timer"
-                }
-            },
-            "sl5_functions": {
-                "name": "Funzione Zona 5",
-                "state": {
-                    "none": "Nessuno",
-                    "boil": "Bollire",
-                    "simmer": "Sobbollire",
-                    "keep_warm": "Mantieni caldo",
-                    "wok": "Wok",
-                    "roast": "Arrostire",
-                    "grill": "Grigliare"
-                }
-            },
-            "sl5_ntc_sensor": {
-                "name": "Sensore NTC Zona 5"
-            },
-            "sl5_power_level": {
-                "name": "Livello di potenza Zona 5"
-            },
-            "sl5_power_level_max": {
-                "name": "Livello di potenza massimo Zona 5"
-            },
-            "sl5_zone_shape": {
-                "name": "Forma Zona 5",
-                "state": {
-                    "round": "Rotonda",
-                    "square": "Quadrata",
-                    "rectangle_vertical": "Rettangolare verticale",
-                    "rectangle_horizontal": "Rettangolare orizzontale",
-                    "no_shape": "Senza forma"
-                }
-            },
-            "sl6_active_timer": {
-                "name": "Timer attivo Zona 6",
-                "state": {
-                    "inactive": "Inattivo",
-                    "stopwatch": "Cronometro",
-                    "timer": "Timer"
-                }
-            },
-            "sl6_functions": {
-                "name": "Funzione Zona 6",
-                "state": {
-                    "none": "Nessuno",
-                    "boil": "Bollire",
-                    "simmer": "Sobbollire",
-                    "keep_warm": "Mantieni caldo",
-                    "wok": "Wok",
-                    "roast": "Arrostire",
-                    "grill": "Grigliare"
-                }
-            },
-            "sl6_ntc_sensor": {
-                "name": "Sensore NTC Zona 6"
-            },
-            "sl6_power_level": {
-                "name": "Livello di potenza Zona 6"
-            },
-            "sl6_power_level_max": {
-                "name": "Livello di potenza massimo Zona 6"
-            },
-            "sl6_zone_shape": {
-                "name": "Forma Zona 6",
-                "state": {
-                    "round": "Rotonda",
-                    "square": "Quadrata",
-                    "rectangle_vertical": "Rettangolare verticale",
-                    "rectangle_horizontal": "Rettangolare orizzontale",
-                    "no_shape": "Senza forma"
-                }
-            },
-            "total_time_of_cooking_in_hours": {
-                "name": "Tempo totale di cottura"
-            },
-            "t_sleep": {
-                "name": "Riposo"
-            },
-            "zone_number": {
-                "name": "Number of zones"
-            }
-        },
-        "switch": {
-            "t_eco": {
-                "name": "Eco"
-            },
-            "t_purify": {
-                "name": "Purificatore dell'aria"
-            },
-            "t_air": {
-                "name": "Air"
-            },
-            "t_beep": {
-                "name": "Beep"
-            },
-            "t_fan_mute": {
-                "name": "Silenzioso"
-            },
-            "t_power": {
-                "name": "Power"
-            },
-            "t_sleep": {
-                "name": "Sleep"
-            },
-            "t_super": {
-                "name": "Super"
-            },
-            "t_sterilization": {
-                "name": "Sterilizzazione"
-            },
-            "t_tms": {
-                "name": "AI"
-            }
-        },
-        "select": {
-            "t_fan_speed": {
-                "name": "Fan speed",
-                "state": {
-                    "auto": "Auto",
-                    "low": "Low",
-                    "high": "High"
-                }
-            },
-            "t_swing_follow": {
-                "name": "AI ventilazione",
-                "state": {
-                    "off": "Spento",
-                    "follow": "Diretta",
-                    "not_follow": "Indiretta"
-                }
-            },
-            "t_swing_angle": {
-                "name": "Flusso d'aria",
-                "state": {
-                    "swing": "Oscillazione",
-                    "auto": "Auto",
-                    "angle_1": "Posizione 1",
-                    "angle_2": "Posizione 2",
-                    "angle_3": "Posizione 3",
-                    "angle_4": "Posizione 4",
-                    "angle_5": "Posizione 5",
-                    "angle_6": "Posizione 6"
-                }
-            },
-            "t_sleep": {
-                "name": "Riposo",
-                "state": {
-                    "off": "Spento",
-                    "general": "Generale",
-                    "for_old": "Per anziani",
-                    "for_young": "Per Giovani",
-                    "for_kid": "Per Bambini"
-                }
-            }
-        },
-        "water_heater": {
-            "connectlife": {
-                "state": {
-                    "auto": "Auto"
-                }
-            }
-        }
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "child_lock_status": {
+        "name": "Blocco bambini"
+      },
+      "delaystart_delayend_mode": {
+        "name": "Partenza ritardata"
+      },
+      "selected_program_anticrease_status": {
+        "name": "Antipiega"
+      },
+      "selected_program_extradry_status": {
+        "name": "Extra secco"
+      },
+      "selected_program_steamfinish": {
+        "name": "Finitura a vapore"
+      },
+      "sl1_alarm_auto_program_notification": {
+        "name": "Notifica del programma automatico della zona 1"
+      },
+      "sl1_alarm_automatic_switch_off_zone": {
+        "name": "La zona 1 si spegne automaticamente"
+      },
+      "sl1_alarm_ntc_coil_overheating": {
+        "name": "Surriscaldamento della bobina della zona 1"
+      },
+      "sl1_alarm_timer_ended": {
+        "name": "Il timer della zona 1 \u00e8 terminato"
+      },
+      "sl1_alarm_zone_turned_off": {
+        "name": "Zona 1 spenta"
+      },
+      "sl1_bridge_function_active": {
+        "name": "Ponte della zona 1 attivo"
+      },
+      "sl1_pot_detected": {
+        "name": "Rilevata pentola zona 1"
+      },
+      "sl1_status": {
+        "name": "Stato della zona 1"
+      },
+      "sl2_alarm_auto_program_notification": {
+        "name": "Notifica del programma automatico della zona 2"
+      },
+      "sl2_alarm_automatic_switch_off_zone": {
+        "name": "La zona 2 si spegne automaticamente"
+      },
+      "sl2_alarm_ntc_coil_overheating": {
+        "name": "Surriscaldamento della bobina della zona 2"
+      },
+      "sl2_alarm_timer_ended": {
+        "name": "Il timer della zona 2 \u00e8 terminato"
+      },
+      "sl2_alarm_zone_turned_off": {
+        "name": "Zona 2 spenta"
+      },
+      "sl2_bridge_function_active": {
+        "name": "Ponte della zona 2 attivo"
+      },
+      "sl2_pot_detected": {
+        "name": "Rilevata pentola zona 2"
+      },
+      "sl2_status": {
+        "name": "Stato della zona 2"
+      },
+      "sl3_alarm_auto_program_notification": {
+        "name": "Notifica del programma automatico della zona 3"
+      },
+      "sl3_alarm_automatic_switch_off_zone": {
+        "name": "La zona 3 si spegne automaticamente"
+      },
+      "sl3_alarm_ntc_coil_overheating": {
+        "name": "Surriscaldamento della bobina della zona 3"
+      },
+      "sl3_alarm_timer_ended": {
+        "name": "Il timer della zona 3 \u00e8 terminato"
+      },
+      "sl3_alarm_zone_turned_off": {
+        "name": "Zona 3 spenta"
+      },
+      "sl3_bridge_function_active": {
+        "name": "Ponte della zona 3 attivo"
+      },
+      "sl3_pot_detected": {
+        "name": "Rilevata pentola zona 3"
+      },
+      "sl3_status": {
+        "name": "Stato della zona 3"
+      },
+      "sl4_alarm_auto_program_notification": {
+        "name": "Notifica del programma automatico della zona 4"
+      },
+      "sl4_alarm_automatic_switch_off_zone": {
+        "name": "La zona 4 si spegne automaticamente"
+      },
+      "sl4_alarm_ntc_coil_overheating": {
+        "name": "Surriscaldamento della bobina della zona 4"
+      },
+      "sl4_alarm_timer_ended": {
+        "name": "Il timer della zona 4 \u00e8 terminato"
+      },
+      "sl4_alarm_zone_turned_off": {
+        "name": "Zona 4 spenta"
+      },
+      "sl4_bridge_function_active": {
+        "name": "Ponte della zona 4 attivo"
+      },
+      "sl4_pot_detected": {
+        "name": "Rilevata pentola zona 4"
+      },
+      "sl4_status": {
+        "name": "Stato della zona 4"
+      },
+      "sl5_alarm_auto_program_notification": {
+        "name": "Notifica del programma automatico della zona 5"
+      },
+      "sl5_alarm_automatic_switch_off_zone": {
+        "name": "La zona 5 si spegne automaticamente"
+      },
+      "sl5_alarm_ntc_coil_overheating": {
+        "name": "Surriscaldamento della bobina della zona 5"
+      },
+      "sl5_alarm_timer_ended": {
+        "name": "Il timer della zona 5 \u00e8 terminato"
+      },
+      "sl5_alarm_zone_turned_off": {
+        "name": "Zona 5 spenta"
+      },
+      "sl5_bridge_function_active": {
+        "name": "Ponte della zona 5 attivo"
+      },
+      "sl5_pot_detected": {
+        "name": "Rilevata pentola zona 5"
+      },
+      "sl5_status": {
+        "name": "Stato della zona 5"
+      },
+      "sl6_alarm_auto_program_notification": {
+        "name": "Notifica del programma automatico della zona 6"
+      },
+      "sl6_alarm_automatic_switch_off_zone": {
+        "name": "La zona 6 si spegne automaticamente"
+      },
+      "sl6_alarm_ntc_coil_overheating": {
+        "name": "Surriscaldamento della bobina della zona 6"
+      },
+      "sl6_alarm_timer_ended": {
+        "name": "Il timer della zona 6 \u00e8 terminato"
+      },
+      "sl6_alarm_zone_turned_off": {
+        "name": "Zona 6 spenta"
+      },
+      "sl6_bridge_function_active": {
+        "name": "Ponte della zona 6 attivo"
+      },
+      "sl6_pot_detected": {
+        "name": "Rilevata pentola zona 6"
+      },
+      "sl6_status": {
+        "name": "Stato della zona 6"
+      }
+    },
+    "climate": {
+      "connectlife": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "middle_high": "Medio alta",
+              "middle_low": "Medio bassa"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "ai": "AI",
+              "eco_mute": "Eco mute",
+              "eco_sleep_1": "Eco sleep 1",
+              "eco_sleep_2": "Eco sleep 2",
+              "eco_sleep_3": "Eco sleep 3",
+              "eco_sleep_4": "Eco sleep 4",
+              "mute": "Mute",
+              "off": "Off",
+              "sleep_1": "Sleep 1",
+              "sleep_2": "Sleep 2",
+              "sleep_3": "Sleep 3",
+              "sleep_4": "Sleep 4",
+              "super": "Super"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "both_sides": "Solo lati",
+              "forward": "Dritto",
+              "left": "Sinistra",
+              "right": "Destra",
+              "swing": "Oscillazione"
+            }
+          }
+        }
+      }
+    },
+    "humidifier": {
+      "connectlife": {
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "auto": "Auto",
+              "clothes_dry": "Vestiti asciutti",
+              "continuous": "Continuo",
+              "manual": "Manuale"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "t_fan_speed": {
+        "name": "Fan speed",
+        "state": {
+          "auto": "Auto",
+          "high": "High",
+          "low": "Low"
+        }
+      },
+      "t_sleep": {
+        "name": "Riposo",
+        "state": {
+          "for_kid": "Per Bambini",
+          "for_old": "Per anziani",
+          "for_young": "Per Giovani",
+          "general": "Generale",
+          "off": "Spento"
+        }
+      },
+      "t_swing_angle": {
+        "name": "Flusso d'aria",
+        "state": {
+          "angle_1": "Posizione 1",
+          "angle_2": "Posizione 2",
+          "angle_3": "Posizione 3",
+          "angle_4": "Posizione 4",
+          "angle_5": "Posizione 5",
+          "angle_6": "Posizione 6",
+          "auto": "Auto",
+          "swing": "Oscillazione"
+        }
+      },
+      "t_swing_follow": {
+        "name": "AI ventilazione",
+        "state": {
+          "follow": "Diretta",
+          "not_follow": "Indiretta",
+          "off": "Spento"
+        }
+      }
+    },
+    "sensor": {
+      "alarm_door_closed": {
+        "name": "Porta chiusa"
+      },
+      "alarm_door_opened": {
+        "name": "Porta aperta"
+      },
+      "anticrease_setting": {
+        "name": "Durata antipiega"
+      },
+      "appliance_status": {
+        "state": {
+          "idle": "Idle",
+          "running": "In esecuzione"
+        }
+      },
+      "bundling_humidity": {
+        "name": "Accumulo di umidit\u00e0"
+      },
+      "bundling_temperature": {
+        "name": "Temperatura di fasciatura"
+      },
+      "current_program_phase": {
+        "state": {
+          "delay_start_waiting": "Attesa avvio ritardato",
+          "drying": "Asciugatura",
+          "main_wash": "Lavaggio principale",
+          "not_available": "Non disponibile",
+          "preheat": "Preriscaldamento",
+          "preheat_finished": "Preriscaldamento terminato",
+          "prewash": "Prelavaggio",
+          "program_finished": "Terminato",
+          "program_not_selected": "Programma non selezionato",
+          "program_selected": "Programma selezionato",
+          "ventilating": "Ventilazione"
+        }
+      },
+      "current_programphase": {
+        "state": {
+          "running": "In esecuzione"
+        }
+      },
+      "daily_energy_kwh": {
+        "name": "Consumo energetico giornaliero"
+      },
+      "delay_duration_inminutes": {
+        "name": "Durata ritardo"
+      },
+      "delaystart_delayend_duration_inminutes": {
+        "name": "Durata avvio ritardato"
+      },
+      "delaystart_delayend_remaining_timein_minutes": {
+        "name": "Tempo rimanente avvio ritardato"
+      },
+      "device_status": {
+        "demo_mode": "Modalit\u00e0 demo",
+        "failure": "Guasto",
+        "idle": "Inattivo",
+        "iq": "IQ",
+        "locked": "Bloccato",
+        "not_available": "Non disponibile",
+        "pause": "In pausa",
+        "pause_mode": "In pausa",
+        "production": "Produzione",
+        "running": "In esecuzione",
+        "service": "Servizio",
+        "stand_by": "In attesa"
+      },
+      "door_status": {
+        "name": "Porta",
+        "state": {
+          "closed": "Chiusa",
+          "not_available": "Non disponibile",
+          "open": "Apera"
+        }
+      },
+      "selected_program_id": {
+        "name": "Seleziona programma",
+        "state": {
+          "baby": "Bambino",
+          "bed_linen": "Lenzuola",
+          "cotton_storage": "Conservazione cotone",
+          "extra_hygiene": "Igiene extra",
+          "fast89": "Veloce 89",
+          "iron": "Stiratura",
+          "mix": "Misto",
+          "none": "Nessuno",
+          "remote": "Remoto",
+          "sensitive": "Delicati",
+          "shirts": "Camice",
+          "sports": "Sport",
+          "standard": "Standard",
+          "synthetic": "Sintetico",
+          "time": "Tempo",
+          "wool": "Lana"
+        }
+      },
+      "selected_programduration_inminutes": {
+        "name": "Durata del programma selezionato"
+      },
+      "selected_programremaining_time_inminutes": {
+        "name": "Tempo rimanente del programma selezionato"
+      },
+      "sl1_active_timer": {
+        "name": "Timer attivo zona 1",
+        "state": {
+          "inactive": "Inattivo",
+          "stopwatch": "Cronometro",
+          "timer": "Timer"
+        }
+      },
+      "sl1_functions": {
+        "name": "Funzione Zona 1",
+        "state": {
+          "boil": "Bollire",
+          "grill": "Grigliare",
+          "keep_warm": "Mantieni caldo",
+          "none": "Nessuno",
+          "roast": "Arrostire",
+          "simmer": "Sobbollire",
+          "wok": "Wok"
+        }
+      },
+      "sl1_ntc_sensor": {
+        "name": "Sensore NTC Zona 1"
+      },
+      "sl1_power_level": {
+        "name": "Livello di potenza Zona 1"
+      },
+      "sl1_power_level_max": {
+        "name": "Livello di potenza massimo Zona 1"
+      },
+      "sl1_zone_shape": {
+        "name": "Forma Zona 1",
+        "state": {
+          "no_shape": "Senza forma",
+          "rectangle_horizontal": "Rettangolare orizzontale",
+          "rectangle_vertical": "Rettangolare verticale",
+          "round": "Rotonda",
+          "square": "Quadrata"
+        }
+      },
+      "sl2_active_timer": {
+        "name": "Timer attivo Zona 2",
+        "state": {
+          "inactive": "Inattivo",
+          "stopwatch": "Cronometro",
+          "timer": "Timer"
+        }
+      },
+      "sl2_functions": {
+        "name": "Funzione Zona 2",
+        "state": {
+          "boil": "Bollire",
+          "grill": "Grigliare",
+          "keep_warm": "Mantieni caldo",
+          "none": "Nessuno",
+          "roast": "Arrostire",
+          "simmer": "Sobbollire",
+          "wok": "Wok"
+        }
+      },
+      "sl2_ntc_sensor": {
+        "name": "Sensore NTC Zona 2"
+      },
+      "sl2_power_level": {
+        "name": "Livello di potenza Zona 2"
+      },
+      "sl2_power_level_max": {
+        "name": "Livello di potenza massimo Zona 2"
+      },
+      "sl2_zone_shape": {
+        "name": "Forma Zona 2",
+        "state": {
+          "no_shape": "Senza forma",
+          "rectangle_horizontal": "Rettangolare orizzontale",
+          "rectangle_vertical": "Rettangolare verticale",
+          "round": "Rotonda",
+          "square": "Quadrata"
+        }
+      },
+      "sl3_active_timer": {
+        "name": "Timer attivo Zona 3",
+        "state": {
+          "inactive": "Inattivo",
+          "stopwatch": "Cronometro",
+          "timer": "Timer"
+        }
+      },
+      "sl3_functions": {
+        "name": "Funzione Zona 3",
+        "state": {
+          "boil": "Bollire",
+          "grill": "Grigliare",
+          "keep_warm": "Mantieni caldo",
+          "none": "Nessuno",
+          "roast": "Arrostire",
+          "simmer": "Sobbollire",
+          "wok": "Wok"
+        }
+      },
+      "sl3_ntc_sensor": {
+        "name": "Sensore NTC Zona 3"
+      },
+      "sl3_power_level": {
+        "name": "Livello di potenza Zona 3"
+      },
+      "sl3_power_level_max": {
+        "name": "Livello di potenza massimo Zona 3"
+      },
+      "sl3_zone_shape": {
+        "name": "Forma Zona 3",
+        "state": {
+          "no_shape": "Senza forma",
+          "rectangle_horizontal": "Rettangolare orizzontale",
+          "rectangle_vertical": "Rettangolare verticale",
+          "round": "Rotonda",
+          "square": "Quadrata"
+        }
+      },
+      "sl4_active_timer": {
+        "name": "Timer attivo Zona 4",
+        "state": {
+          "inactive": "Inattivo",
+          "stopwatch": "Cronometro",
+          "timer": "Timer"
+        }
+      },
+      "sl4_functions": {
+        "name": "Funzione Zona 4",
+        "state": {
+          "boil": "Bollire",
+          "grill": "Grigliare",
+          "keep_warm": "Mantieni caldo",
+          "none": "Nessuno",
+          "roast": "Arrostire",
+          "simmer": "Sobbollire",
+          "wok": "Wok"
+        }
+      },
+      "sl4_ntc_sensor": {
+        "name": "Sensore NTC Zona 4"
+      },
+      "sl4_power_level": {
+        "name": "Livello di potenza Zona 4"
+      },
+      "sl4_power_level_max": {
+        "name": "Livello di potenza massimo Zona 4"
+      },
+      "sl4_zone_shape": {
+        "name": "Forma Zona 4",
+        "state": {
+          "no_shape": "Senza forma",
+          "rectangle_horizontal": "Rettangolare orizzontale",
+          "rectangle_vertical": "Rettangolare verticale",
+          "round": "Rotonda",
+          "square": "Quadrata"
+        }
+      },
+      "sl5_active_timer": {
+        "name": "Timer attivo Zona 5",
+        "state": {
+          "inactive": "Inattivo",
+          "stopwatch": "Cronometro",
+          "timer": "Timer"
+        }
+      },
+      "sl5_functions": {
+        "name": "Funzione Zona 5",
+        "state": {
+          "boil": "Bollire",
+          "grill": "Grigliare",
+          "keep_warm": "Mantieni caldo",
+          "none": "Nessuno",
+          "roast": "Arrostire",
+          "simmer": "Sobbollire",
+          "wok": "Wok"
+        }
+      },
+      "sl5_ntc_sensor": {
+        "name": "Sensore NTC Zona 5"
+      },
+      "sl5_power_level": {
+        "name": "Livello di potenza Zona 5"
+      },
+      "sl5_power_level_max": {
+        "name": "Livello di potenza massimo Zona 5"
+      },
+      "sl5_zone_shape": {
+        "name": "Forma Zona 5",
+        "state": {
+          "no_shape": "Senza forma",
+          "rectangle_horizontal": "Rettangolare orizzontale",
+          "rectangle_vertical": "Rettangolare verticale",
+          "round": "Rotonda",
+          "square": "Quadrata"
+        }
+      },
+      "sl6_active_timer": {
+        "name": "Timer attivo Zona 6",
+        "state": {
+          "inactive": "Inattivo",
+          "stopwatch": "Cronometro",
+          "timer": "Timer"
+        }
+      },
+      "sl6_functions": {
+        "name": "Funzione Zona 6",
+        "state": {
+          "boil": "Bollire",
+          "grill": "Grigliare",
+          "keep_warm": "Mantieni caldo",
+          "none": "Nessuno",
+          "roast": "Arrostire",
+          "simmer": "Sobbollire",
+          "wok": "Wok"
+        }
+      },
+      "sl6_ntc_sensor": {
+        "name": "Sensore NTC Zona 6"
+      },
+      "sl6_power_level": {
+        "name": "Livello di potenza Zona 6"
+      },
+      "sl6_power_level_max": {
+        "name": "Livello di potenza massimo Zona 6"
+      },
+      "sl6_zone_shape": {
+        "name": "Forma Zona 6",
+        "state": {
+          "no_shape": "Senza forma",
+          "rectangle_horizontal": "Rettangolare orizzontale",
+          "rectangle_vertical": "Rettangolare verticale",
+          "round": "Rotonda",
+          "square": "Quadrata"
+        }
+      },
+      "t_sleep": {
+        "name": "Riposo"
+      },
+      "total_time_of_cooking_in_hours": {
+        "name": "Tempo totale di cottura"
+      },
+      "zone_number": {
+        "name": "Number of zones"
+      }
+    },
+    "switch": {
+      "t_air": {
+        "name": "Air"
+      },
+      "t_beep": {
+        "name": "Beep"
+      },
+      "t_eco": {
+        "name": "Eco"
+      },
+      "t_fan_mute": {
+        "name": "Silenzioso"
+      },
+      "t_power": {
+        "name": "Power"
+      },
+      "t_purify": {
+        "name": "Purificatore dell'aria"
+      },
+      "t_sleep": {
+        "name": "Sleep"
+      },
+      "t_sterilization": {
+        "name": "Sterilizzazione"
+      },
+      "t_super": {
+        "name": "Super"
+      },
+      "t_tms": {
+        "name": "AI"
+      }
+    },
+    "water_heater": {
+      "connectlife": {
+        "state": {
+          "auto": "Auto"
+        }
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "test_server_invalid": "Invalid test server URL",
+      "test_server_required": "La modalit\u00e0 di sviluppo richiede l'URL del server di prova"
+    },
+    "step": {
+      "configure_device": {
+        "data": {
+          "disable_beep": "Disattiva beep"
+        },
+        "description": "Configura un dispositivo."
+      },
+      "development": {
+        "data": {
+          "development_mode": "Modalit\u00e0 di sviluppo",
+          "test_server_url": "Test server URL"
+        },
+        "description": "Abilita la modalit\u00e0 di sviluppo per connettersi al server di test anzich\u00e9 all'API ConnectLife."
+      },
+      "init": {
+        "menu_options": {
+          "development": "Configura la modalit\u00e0 di sviluppo",
+          "select_device": "Configura un dispositivo"
+        }
+      },
+      "select_device": {
+        "data": {
+          "device": "Seleziona dispositivo"
+        },
+        "description": "Configura un dispositivo."
+      }
+    }
+  },
+  "services": {
+    "set_value": {
+      "description": "Imposta un valore per lo stato. Utilizzare con cura.",
+      "fields": {
+        "value": {
+          "description": "Valore da impostare.",
+          "name": "Value"
+        }
+      },
+      "name": "Imposta valore"
+    }
+  }
 }

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1,1742 +1,1742 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Apparaat is al geconfigureerd"
-        },
-        "error": {
-            "cannot_connect": "Verbinding mislukt",
-            "invalid_auth": "Ongeldige authenticatie",
-            "unknown": "Onverwachte fout"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "password": "Wachtwoord",
-                    "username": "Gebruikersnaam"
-                }
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "Apparaat is al geconfigureerd"
     },
-    "issues": {
-        "unavailable_device": {
-            "title": "{device_name} niet langer beschikbaar",
-            "fix_flow": {
-                "abort": {
-                    "issue_ignored": "Genegeerd \"{device_name} niet langer beschikbaar\". Het apparaat en al zijn entiteiten zullen nog steeds in het register worden vermeld."
-                },
-                "step": {
-                    "init": {
-                        "title": "{device_name} niet langer beschikbaar",
-                        "description": "Het apparaat \"{device_name}\" is niet langer beschikbaar in uw ConnectLife-account. Als u dit apparaat niet meer heeft, kunt u het uit Home Assistant verwijderen.",
-                        "menu_options": {
-                            "ignore": "Negeren",
-                            "remove": "Verwijderen"
-                        }
-                    },
-                    "remove": {
-                        "title": "Verwijder {device_name}",
-                        "description": "Het apparaat \"{device_name}\" en al zijn entiteiten zullen worden verwijderd uit Home Assistant."
-                    }
-                }
-            }
-        }
+    "error": {
+      "cannot_connect": "Verbinding mislukt",
+      "invalid_auth": "Ongeldige authenticatie",
+      "unknown": "Onverwachte fout"
     },
-    "options": {
-        "step": {
-            "init": {
-                "menu_options": {
-                    "select_device": "Configureer een apparaat",
-                    "development": "Configureer ontwikkelingsmodus"
-                }
-            },
-            "select_device": {
-                "data": {
-                    "device": "Selecteer apparaat"
-                },
-                "description": "Configureer een apparaat."
-            },
-            "configure_device": {
-                "data": {
-                    "disable_beep": "Schakel piep uit"
-                },
-                "description": "Configureer een apparaat."
-            },
-            "development": {
-                "data": {
-                    "development_mode": "Ontwikkelingsmodus",
-                    "test_server_url": "Test server URL"
-                },
-                "description": "Schakel ontwikkelingsmodus in om verbinding te maken met de testserver in plaats van de ConnectLife API."
-            }
-        },
-        "error": {
-            "test_server_invalid": "Ongeldige test server URL",
-            "test_server_required": "Ontwikkelingsmodus vereist test server URL"
+    "step": {
+      "user": {
+        "data": {
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
         }
-    },
-    "selector": {
-        "actions": {
-            "options": {
-                "1": "Start",
-                "2": "Stop",
-                "3": "Pauze",
-                "4": "Deur openen"
-            }
-        }
-    },
-    "services": {
-        "set_value": {
-            "name": "Waarde instellen",
-            "description": "Stelt een waarde in voor de status. Gebruik voorzichtig.",
-            "fields": {
-                "value": {
-                    "name": "Waarde",
-                    "description": "Waarde om in te stellen."
-                }
-            }
-        },
-        "set_action": {
-            "name": "Actie instellen",
-            "description": "Stelt actie in voor apparaat. Gebruik voorzichtig.",
-            "fields": {
-                "action": {
-                    "name": "Actie",
-                    "description": "Actie om in te stellen."
-                }
-            }
-        }
-    },
-    "entity": {
-        "binary_sensor": {
-            "ado_allowed": {
-                "name": "ADO toegestaan"
-            },
-            "alarm_1": {
-                "name": "Alarm 1"
-            },
-            "alarm_10": {
-                "name": "Alarm 10"
-            },
-            "alarm_11": {
-                "name": "Alarm 11"
-            },
-            "alarm_12": {
-                "name": "Alarm 12"
-            },
-            "alarm_2": {
-                "name": "Alarm 2"
-            },
-            "alarm_3": {
-                "name": "Alarm 3"
-            },
-            "alarm_4": {
-                "name": "Alarm 4"
-            },
-            "alarm_5": {
-                "name": "Alarm 5"
-            },
-            "alarm_6": {
-                "name": "Alarm 6"
-            },
-            "alarm_7": {
-                "name": "Alarm 7"
-            },
-            "alarm_8": {
-                "name": "Alarm 8"
-            },
-            "alarm_9": {
-                "name": "Alarm 9"
-            },
-            "alarm_alarm_time_reached": {
-                "name": "Alarmtijd bereikt"
-            },
-            "alarm_auto_dose_refill": {
-                "name": "Auto doseer bijvullen"
-            },
-            "alarm_auto_program_notification": {
-                "name": "Auto program melding"
-            },
-            "alarm_autodose_level10": {
-                "name": "Autodose niveau 10"
-            },
-            "alarm_autodose_level20": {
-                "name": "Autodose niveau 20"
-            },
-            "alarm_automatic_switch_off_zone": {
-                "name": "Automatische uitschakelzone"
-            },
-            "alarm_baking_finished": {
-                "name": "Bakken voltooid"
-            },
-            "alarm_clean_the_filters": {
-                "name": "Reinig de filters"
-            },
-            "alarm_descale_now": {
-                "name": "Ontkalk nu"
-            },
-            "alarm_door_closed": {
-                "name": "Deur gesloten"
-            },
-            "alarm_door_opened": {
-                "name": "Deur geopend"
-            },
-            "alarm_external_autodose_level15": {
-                "name": "Externe autodose niveau 15"
-            },
-            "alarm_external_autodose_level30": {
-                "name": "Externe autodose niveau 30"
-            },
-            "alarm_hob_hood_started": {
-                "name": "Kookplaatkap gestart"
-            },
-            "alarm_ntc_coil_overheating": {
-                "name": "NTC spoel oververhitting"
-            },
-            "alarm_ntc_power": {
-                "name": "NTC vermogen"
-            },
-            "alarm_ntc_tc": {
-                "name": "NTC TC"
-            },
-            "alarm_preheat_reached": {
-                "name": "Voorverwarming bereikt"
-            },
-            "alarm_preheating_ready": {
-                "name": "Voorverwarming gereed"
-            },
-            "alarm_program_done": {
-                "name": "Programma voltooid"
-            },
-            "alarm_program_pause": {
-                "name": "Programma gepauzeerd"
-            },
-            "alarm_remote_start_canceled": {
-                "name": "Afstandsbediening geannuleerd"
-            },
-            "alarm_rinse_aid_refill": {
-                "name": "Glansspoelmiddel bijvullen"
-            },
-            "alarm_rinse_aid_refill_external": {
-                "name": "Extern glansspoelmiddel bijvullen"
-            },
-            "alarm_run_selfcleaning": {
-                "name": "Zelfreiniging uitvoeren"
-            },
-            "alarm_salt_refill": {
-                "name": "Onthardingszout bijvullen"
-            },
-            "alarm_sani_program_finished": {
-                "name": "Sani-programma voltooid"
-            },
-            "alarm_steam_empty": {
-                "name": "Stoom leeg"
-            },
-            "alarm_temperature_reached": {
-                "name": "Temperatuur bereikt"
-            },
-            "alarm_timer_ended": {
-                "name": "Timer beëindigd"
-            },
-            "alarm_turn_food": {
-                "name": "Draai voedsel"
-            },
-            "alarm_voltage": {
-                "name": "Spanning"
-            },
-            "alarm_warning_fastpreheat": {
-                "name": "Waarschuwing snelle voorverwarming"
-            },
-            "alarm_warning_microwave": {
-                "name": "Waarschuwing magnetron"
-            },
-            "alarm_warning_steam": {
-                "name": "Waarschuwing stoom"
-            },
-            "alarm_water_tank_empty": {
-                "name": "Watertank leeg"
-            },
-            "alarm_water_tank_missing": {
-                "name": "Watertank ontbreekt"
-            },
-            "alarm_zone_turned_off": {
-                "name": "Zone uitgeschakeld"
-            },
-            "charcoal_filter_expiration_alarm": {
-                "name": "Waarschuwing houtskoolfilter verlopen"
-            },
-            "child_lock": {
-                "name": "Kinderbeveiliging"
-            },
-            "child_lock_status": {
-                "name": "Kinderbeveiliging"
-            },
-            "clean_filter": {
-                "name": "Filter reinigen"
-            },
-            "delay_start": {
-                "name": "Uitgestelde start"
-            },
-            "delay_start_status": {
-                "name": "Uitgestelde start"
-            },
-            "delaystart_delayend_mode": {
-                "name": "Uitgestelde start modus"
-            },
-            "demo_mode": {
-                "name": "Demomodus"
-            },
-            "door": {
-                "name": "Deur"
-            },
-            "door_status": {
-                "name": "Deur"
-            },
-            "eco_mode": {
-                "name": "ECO-modus"
-            },
-            "error_0": {
-                "name": "Fout 0"
-            },
-            "error_1": {
-                "name": "Fout 1"
-            },
-            "error_10": {
-                "name": "Fout 10"
-            },
-            "error_11": {
-                "name": "Fout 11"
-            },
-            "error_12": {
-                "name": "Fout 12"
-            },
-            "error_13": {
-                "name": "Fout 13"
-            },
-            "error_14": {
-                "name": "Fout 14"
-            },
-            "error_15": {
-                "name": "Fout 15"
-            },
-            "error_16": {
-                "name": "Fout 16"
-            },
-            "error_2": {
-                "name": "Fout 2"
-            },
-            "error_3": {
-                "name": "Fout 3"
-            },
-            "error_4": {
-                "name": "Fout 4"
-            },
-            "error_5": {
-                "name": "Fout 5"
-            },
-            "error_6": {
-                "name": "Fout 6"
-            },
-            "error_7": {
-                "name": "Fout 7"
-            },
-            "error_8": {
-                "name": "Fout 8"
-            },
-            "error_9": {
-                "name": "Fout 9"
-            },
-            "f_e_filterclean": {
-                "name": "Filter reinigen"
-            },
-            "f_e_pump": {
-                "name": "Pomp"
-            },
-            "f_e_push": {
-                "name": "Duwen"
-            },
-            "f_e_temp": {
-                "name": "Temperatuur"
-            },
-            "f_e_tubetemp": {
-                "name": "Buis temperatuur"
-            },
-            "f_e_waterfull": {
-                "name": "Water vol"
-            },
-            "f_e_wetsensor": {
-                "name": "Natte sensor"
-            },
-            "fill_salt": {
-                "name": "Onthardingszout bijvullen"
-            },
-            "float_switch": {
-                "name": "Vlotterschakelaar"
-            },
-            "free_defrosting_failure": {
-                "name": "Vriezer ontdooien mislukt"
-            },
-            "free_evap_temp_sens_head_failure": {
-                "name": "Vriezer verdamper temp sensor hoofd mislukt"
-            },
-            "free_fan_failure": {
-                "name": "Vriezer ventilator mislukt"
-            },
-            "free_room_over_temp_alarm_failure": {
-                "name": "Vriezer kamer over temp alarm mislukt"
-            },
-            "free_temp_sens_head_failure": {
-                "name": "Vriezer temp sensor hoofd mislukt"
-            },
-            "frost_state": {
-                "name": "Vorst toestand"
-            },
-            "hard_pairing_status": {
-                "name": "Harde koppelingsstatus"
-            },
-            "humidity_sensor": {
-                "name": "Vochtigheidssensor"
-            },
-            "humidity_sensor_failure": {
-                "name": "Vochtigheidssensor mislukt"
-            },
-            "ice_making_machine_failure": {
-                "name": "Ijsmachine mislukt"
-            },
-            "light": {
-                "name": "Licht"
-            },
-            "low_wine_area_c_evaporator_fault": {
-                "name": "Lage wijngebied c verdamper fout"
-            },
-            "low_wine_area_c_fan_fault": {
-                "name": "Lage wijngebied c ventilator fout"
-            },
-            "low_wine_area_c_humdy_fault": {
-                "name": "Lage wijngebied c vochtigheid fout"
-            },
-            "low_wine_area_c_temp_fault": {
-                "name": "Lage wijngebied c temperatuur fout"
-            },
-            "mid_wine_area_b_evaporator_fault": {
-                "name": "Midden wijngebied b verdamper fout"
-            },
-            "mid_wine_area_b_fan_fault": {
-                "name": "Midden wijngebied b ventilator fout"
-            },
-            "mid_wine_area_b_humdy_fault": {
-                "name": "Midden wijngebied b vochtigheid fout"
-            },
-            "mid_wine_area_b_temp_fault": {
-                "name": "Midden wijngebied b temperatuur fout"
-            },
-            "open_freeze_door_alarm": {
-                "name": "Vriezer deur open alarm"
-            },
-            "open_refrigerator_door_alarm": {
-                "name": "Koelkast deur open alarm"
-            },
-            "open_the_door_alarm": {
-                "name": "Deur open alarm"
-            },
-            "open_variation_door_alarm": {
-                "name": "Variatie deur open alarm"
-            },
-            "preheat": {
-                "name": "Voorverwarmen"
-            },
-            "quiet_mode_status": {
-                "name": "Stille modus status"
-            },
-            "reed_switch": {
-                "name": "Reed schakelaar"
-            },
-            "refr_defrosting_failure": {
-                "name": "Koelkast ontdooien mislukt"
-            },
-            "refr_dry_wet_room_sens_failure": {
-                "name": "Koelkast droge natte kamer sensor mislukt"
-            },
-            "refr_evap_temp_sens_head_failure": {
-                "name": "Koelkast verdamper temp sensor hoofd mislukt"
-            },
-            "refr_fan_failure": {
-                "name": "Koelkast ventilator mislukt"
-            },
-            "refr_room_open": {
-                "name": "Koelkast kamer open"
-            },
-            "refr_room_over_temp_alarm": {
-                "name": "Koelkast kamer over temp alarm"
-            },
-            "refr_temp_sens_head_failure": {
-                "name": "Koelkast temp sensor hoofd mislukt"
-            },
-            "refr_var_room_sens_failure": {
-                "name": "Koelkast variabele kamer sensor mislukt"
-            },
-            "remote_control_mode_monitoring": {
-                "name": "Afstandsbediening modus bewaking"
-            },
-            "remote_control_monitoring_set_commands_actions": {
-                "name": "Afstandsbediening"
-            },
-            "rinse_aid_refill": {
-                "name": "Glansspoelmiddel bijvullen"
-            },
-            "rx_failure": {
-                "name": "RX mislukt"
-            },
-            "sabbath_mode_status": {
-                "name": "Sabbatmodus status"
-            },
-            "sabbath_mode_switch_status": {
-                "name": "Sabbatmodus schakelstatus"
-            },
-            "save_mode": {
-                "name": "Spaarstand"
-            },
-            "selected_program_anticrease_status": {
-                "name": "Anti-kreuk"
-            },
-            "selected_program_auto_door_open_function": {
-                "name": "Geselecteerd programma automatische deuropening"
-            },
-            "selected_program_extradry_status": {
-                "name": "Extra droog"
-            },
-            "selected_program_steamfinish": {
-                "name": "Stoomafwerking"
-            },
-            "session_pairing_active": {
-                "name": "Sessie koppelingsactief"
-            },
-            "sl1_alarm_auto_program_notification": {
-                "name": "Zone 1 automatische programmamelding"
-            },
-            "sl1_alarm_automatic_switch_off_zone": {
-                "name": "Zone 1 automatisch uitgeschakeld"
-            },
-            "sl1_alarm_ntc_coil_overheating": {
-                "name": "Zone 1 spoel oververhitting"
-            },
-            "sl1_alarm_timer_ended": {
-                "name": "Zone 1 timer beëindigd"
-            },
-            "sl1_alarm_zone_turned_off": {
-                "name": "Zone 1 uitgeschakeld"
-            },
-            "sl1_bridge_function_active": {
-                "name": "Zone 1 brugfunctie actief"
-            },
-            "sl1_pot_detected": {
-                "name": "Zone 1 pot gedetecteerd"
-            },
-            "sl1_status": {
-                "name": "Zone 1 status"
-            },
-            "sl2_alarm_auto_program_notification": {
-                "name": "Zone 2 automatische programmamelding"
-            },
-            "sl2_alarm_automatic_switch_off_zone": {
-                "name": "Zone 2 automatisch uitgeschakeld"
-            },
-            "sl2_alarm_ntc_coil_overheating": {
-                "name": "Zone 2 spoel oververhitting"
-            },
-            "sl2_alarm_timer_ended": {
-                "name": "Zone 2 timer beëindigd"
-            },
-            "sl2_alarm_zone_turned_off": {
-                "name": "Zone 2 uitgeschakeld"
-            },
-            "sl2_bridge_function_active": {
-                "name": "Zone 2 brugfunctie actief"
-            },
-            "sl2_pot_detected": {
-                "name": "Zone 2 pot gedetecteerd"
-            },
-            "sl2_status": {
-                "name": "Zone 2 status"
-            },
-            "sl3_alarm_auto_program_notification": {
-                "name": "Zone 3 automatische programmamelding"
-            },
-            "sl3_alarm_automatic_switch_off_zone": {
-                "name": "Zone 3 automatisch uitgeschakeld"
-            },
-            "sl3_alarm_ntc_coil_overheating": {
-                "name": "Zone 3 spoel oververhitting"
-            },
-            "sl3_alarm_timer_ended": {
-                "name": "Zone 3 timer beëindigd"
-            },
-            "sl3_alarm_zone_turned_off": {
-                "name": "Zone 3 uitgeschakeld"
-            },
-            "sl3_bridge_function_active": {
-                "name": "Zone 3 brugfunctie actief"
-            },
-            "sl3_pot_detected": {
-                "name": "Zone 3 pot gedetecteerd"
-            },
-            "sl3_status": {
-                "name": "Zone 3 status"
-            },
-            "sl4_alarm_auto_program_notification": {
-                "name": "Zone 4 automatische programmamelding"
-            },
-            "sl4_alarm_automatic_switch_off_zone": {
-                "name": "Zone 4 automatisch uitgeschakeld"
-            },
-            "sl4_alarm_ntc_coil_overheating": {
-                "name": "Zone 4 spoel oververhitting"
-            },
-            "sl4_alarm_timer_ended": {
-                "name": "Zone 4 timer beëindigd"
-            },
-            "sl4_alarm_zone_turned_off": {
-                "name": "Zone 4 uitgeschakeld"
-            },
-            "sl4_bridge_function_active": {
-                "name": "Zone 4 brugfunctie actief"
-            },
-            "sl4_pot_detected": {
-                "name": "Zone 4 pot gedetecteerd"
-            },
-            "sl4_status": {
-                "name": "Zone 4 status"
-            },
-            "sl5_alarm_auto_program_notification": {
-                "name": "Zone 5 automatische programmamelding"
-            },
-            "sl5_alarm_automatic_switch_off_zone": {
-                "name": "Zone 5 automatisch uitgeschakeld"
-            },
-            "sl5_alarm_ntc_coil_overheating": {
-                "name": "Zone 5 spoel oververhitting"
-            },
-            "sl5_alarm_timer_ended": {
-                "name": "Zone 5 timer beëindigd"
-            },
-            "sl5_alarm_zone_turned_off": {
-                "name": "Zone 5 uitgeschakeld"
-            },
-            "sl5_bridge_function_active": {
-                "name": "Zone 5 brugfunctie actief"
-            },
-            "sl5_pot_detected": {
-                "name": "Zone 5 pot gedetecteerd"
-            },
-            "sl5_status": {
-                "name": "Zone 5 status"
-            },
-            "sl6_alarm_auto_program_notification": {
-                "name": "Zone 6 automatische programmamelding"
-            },
-            "sl6_alarm_automatic_switch_off_zone": {
-                "name": "Zone 6 automatisch uitgeschakeld"
-            },
-            "sl6_alarm_ntc_coil_overheating": {
-                "name": "Zone 6 spoel oververhitting"
-            },
-            "sl6_alarm_timer_ended": {
-                "name": "Zone 6 timer beëindigd"
-            },
-            "sl6_alarm_zone_turned_off": {
-                "name": "Zone 6 uitgeschakeld"
-            },
-            "sl6_bridge_function_active": {
-                "name": "Zone 6 brugfunctie actief"
-            },
-            "sl6_pot_detected": {
-                "name": "Zone 6 pot gedetecteerd"
-            },
-            "sl6_status": {
-                "name": "Zone 6 status"
-            },
-            "step1_status": {
-                "name": "Stap 1 status"
-            },
-            "step2_status": {
-                "name": "Stap 2 status"
-            },
-            "step3_status": {
-                "name": "Stap 3 status"
-            },
-            "tab_setting_status": {
-                "name": "Tab-instelling"
-            },
-            "tx_failure": {
-                "name": "TX mislukt"
-            },
-            "vacuum_on_off_status": {
-                "name": "Vacuum aan/uit status"
-            },
-            "vari_evap_temp_sens_head_failure": {
-                "name": "Vari verdamper temp sensor hoofd mislukt"
-            },
-            "vari_temp_sens_head_failure": {
-                "name": "Vari temp sensor hoofd mislukt"
-            },
-            "vibration_alarm": {
-                "name": "Trilalarm"
-            },
-            "vibration_sensor_fault": {
-                "name": "Trilsensor fout"
-            },
-            "water_level_switch": {
-                "name": "Waterniveau schakelaar"
-            },
-            "waterbox_full": {
-                "name": "Waterbox vol"
-            }
-        },
-        "climate": {
-            "connectlife": {
-                "state_attributes": {
-                    "fan_mode": {
-                        "state": {
-                            "middle_low": "Midden laag",
-                            "middle_high": "Midden hoog"
-                        }
-                    },
-                    "preset_mode": {
-                        "state": {
-                            "ai": "AI",
-                            "off": "Uit",
-                            "mute": "Stil",
-                            "eco_mute": "Eco stil",
-                            "super": "Super",
-                            "sleep_1": "Slaap 1",
-                            "sleep_2": "Slaap 2",
-                            "sleep_3": "Slaap 3",
-                            "sleep_4": "Slaap 4",
-                            "eco_sleep_1": "Eco slaap 1",
-                            "eco_sleep_2": "Eco slaap 2",
-                            "eco_sleep_3": "Eco slaap 3",
-                            "eco_sleep_4": "Eco slaap 4",
-                            "bedtime": "Bedtijd"
-                        }
-                    },
-                    "swing_mode": {
-                        "state": {
-                            "both_sides": "Beide kanten",
-                            "forward": "Vooruit",
-                            "left": "Links",
-                            "right": "Rechts",
-                            "swing": "Zwaaien"
-                        }
-                    }
-                }
-            }
-        },
-        "humidifier": {
-            "connectlife": {
-                "state_attributes": {
-                    "mode": {
-                        "state": {
-                            "auto": "Auto",
-                            "continuous": "Continu",
-                            "manual": "Handmatig",
-                            "clothes_dry": "Kleding drogen"
-                        }
-                    }
-                }
-            }
-        },
-        "sensor": {
-            "ado_allowed": {
-                "name": "ADO toegestaan"
-            },
-            "alarm_door_closed": {
-                "name": "Deur gesloten"
-            },
-            "alarm_door_opened": {
-                "name": "Deur geopend"
-            },
-            "anticrease_setting": {
-                "name": "Anti-kreuk duur"
-            },
-            "appliance_status": {
-                "state": {
-                    "idle": "Inactief",
-                    "running": "Actief"
-                }
-            },
-            "auto_dose_duration": {
-                "name": "Auto doseer duur"
-            },
-            "auto_dose_refill": {
-                "name": "Auto doseer bijvullen"
-            },
-            "bundling_humidity": {
-                "name": "Bundel vochtigheid"
-            },
-            "bundling_temperature": {
-                "name": "Bundel temperatuur"
-            },
-            "child_lock_setting_status": {
-                "name": "Kinderbeveiliging instelling"
-            },
-            "curent_program_duration": {
-                "name": "Huidige programmaduur"
-            },
-            "curent_program_remaining_time": {
-                "name": "Resterende tijd huidig programma"
-            },
-            "current_baking_step": {
-                "name": "Huidige bakstap",
-                "state": {
-                    "preheat": "Voorverwarmen",
-                    "step_1": "Stap 1",
-                    "step_2": "Stap 2",
-                    "step_3": "Stap 3",
-                    "after_bake_finished": "Na het bakken voltooid"
-                }
-            },
-            "current_program_phase": {
-                "state": {
-                    "not_available": "Niet beschikbaar",
-                    "program_not_selected": "Programma niet geselecteerd",
-                    "program_selected": "Programma geselecteerd",
-                    "delay_start_waiting": "Wachten op uitgestelde start",
-                    "preheat": "Voorverwarmen",
-                    "preheat_finished": "Voorverwarmen voltooid",
-                    "prewash": "Voorwas",
-                    "main_wash": "Hoofdwas",
-                    "drying": "Drogen",
-                    "program_finished": "Voltooid",
-                    "ventilating": "Ventileren",
-                    "idle": "Inactief",
-                    "running": "Actief",
-                    "anti_crease": "Anti-kreuk",
-                    "delay": "Uitgesteld",
-                    "finished": "Voltooid"
-                }
-            },
-            "current_programphase": {
-                "state": {
-                    "running": "Actief"
-                }
-            },
-            "daily_energy_kwh": {
-                "name": "Dagelijks energieverbruik"
-            },
-            "delay_duration_inminutes": {
-                "name": "Uitstelduur"
-            },
-            "delay_start_remaining_time": {
-                "name": "Resterende tijd uitgestelde start"
-            },
-            "delay_start_set_time": {
-                "name": "Ingestelde tijd uitgestelde start"
-            },
-            "delaystart_delayend_duration_inminutes": {
-                "name": "Uitstel start duur"
-            },
-            "delaystart_delayend_remaining_timein_minutes": {
-                "name": "Resterende tijd uitstel start"
-            },
-            "device_status": {
-                "state": {
-                    "demo_mode": "Demomodus",
-                    "failure": "Mislukt",
-                    "idle": "Inactief",
-                    "iq": "IQ",
-                    "locked": "Vergrendeld",
-                    "not_available": "Niet beschikbaar",
-                    "pause": "Gepauzeerd",
-                    "pause_mode": "Pauzemodus",
-                    "production": "Productie",
-                    "running": "Actief",
-                    "service": "Onderhoud",
-                    "stand_by": "Stand-by",
-                    "paused": "Gepauzeerd",
-                    "delay_time_waiting": "Wachten op uitgestelde tijd",
-                    "error": "Fout",
-                    "after_bake_finished": "Na het bakken voltooid"
-                }
-            },
-            "display_brightness_setting_status": {
-                "name": "Helderheid display"
-            },
-            "display_contrast_setting_status": {
-                "name": "Contrast display"
-            },
-            "display_logotype_setting_status": {
-                "name": "Logotype display"
-            },
-            "energy_consumption_in_running_program": {
-                "name": "Energieverbruik in huidig programma"
-            },
-            "environment_humidity": {
-                "name": "Omgevingsvochtigheid"
-            },
-            "error_read_out_1_code": {
-                "name": "Foutcode uitlezen 1"
-            },
-            "error_read_out_1_cycle": {
-                "name": "Foutcyclus uitlezen 1"
-            },
-            "error_read_out_2_code": {
-                "name": "Foutcode uitlezen 2"
-            },
-            "error_read_out_2_cycle": {
-                "name": "Foutcyclus uitlezen 2"
-            },
-            "error_read_out_3_code": {
-                "name": "Foutcode uitlezen 3"
-            },
-            "error_read_out_3_cycle": {
-                "name": "Foutcyclus uitlezen 3"
-            },
-            "extradry_setting": {
-                "name": "Extra droog instelling"
-            },
-            "f_cool_qvalue": {
-                "name": "Koeling"
-            },
-            "f_heat_qvalue": {
-                "name": "Verwarming"
-            },
-            "f_votage": {
-                "name": "Gemeten netspanning"
-            },
-            "fan_sequence_setting_status": {
-                "name": "Ventilatorvolgorde"
-            },
-            "feedback_volumen_setting_status": {
-                "name": "Feedback volume",
-                "state": {
-                    "mute": "Stil",
-                    "low": "Laag",
-                    "mid": "Midden",
-                    "high": "Hoog"
-                }
-            },
-            "freeze_real_temperature": {
-                "name": "Werkelijke vriezertemperatuur"
-            },
-            "freeze_sensor_real_temperature": {
-                "name": "Werkelijke vriezersensortemperatuur"
-            },
-            "fruit_vegetables_temperature": {
-                "name": "Temperatuur fruit en groenten"
-            },
-            "heat_pump_setting_status": {
-                "name": "Warmtepomp"
-            },
-            "high_humidity": {
-                "name": "Hoge vochtigheid"
-            },
-            "high_temperature": {
-                "name": "Hoge temperatuur"
-            },
-            "interior_light_at_power_off_setting_status": {
-                "name": "Interieurverlichting bij uitschakelen"
-            },
-            "interior_light_status": {
-                "name": "Interieurverlichting"
-            },
-            "language_status": {
-                "name": "Taal"
-            },
-            "last_run_program_id": {
-                "name": "Laatst uitgevoerd programma"
-            },
-            "low_humidity": {
-                "name": "Lage vochtigheid"
-            },
-            "low_temperature": {
-                "name": "Lage temperatuur"
-            },
-            "machine_status": {
-                "name": "Machine status",
-                "state": {
-                    "off": "Uit",
-                    "standby": "Standby",
-                    "running": "Actief"
-                }
-            },
-            "measured_vibrations": {
-                "name": "Gemeten trillingen"
-            },
-            "meat_probe_measured_temperature": {
-                "name": "Gemeten temperatuur vleessonde"
-            },
-            "meat_probe_set_temperature": {
-                "name": "Ingestelde temperatuur vleessonde"
-            },
-            "medium_humidity": {
-                "name": "Gemiddelde vochtigheid"
-            },
-            "medium_temperature": {
-                "name": "Gemiddelde temperatuur"
-            },
-            "notification_volumen_setting_status": {
-                "name": "Meldingsvolume"
-            },
-            "oven_temperature": {
-                "name": "Oventemperatuur"
-            },
-            "pressure_calibration_setting_status": {
-                "name": "Drukcalibratie"
-            },
-            "real_humidity": {
-                "name": "Werkelijke vochtigheid"
-            },
-            "real_humidity_b": {
-                "name": "Werkelijke vochtigheid b"
-            },
-            "real_humidity_c": {
-                "name": "Werkelijke vochtigheid c"
-            },
-            "refrigerator_real_temperature": {
-                "name": "Werkelijke koelkasttemperatuur"
-            },
-            "refrigerator_sensor_real_temperature": {
-                "name": "Werkelijke koelkastsensortemperatuur"
-            },
-            "rinse_aid_setting_status": {
-                "name": "Glansspoelmiddel"
-            },
-            "sand_timer1_duration_in_seconds": {
-                "name": "Zandloper 1 duur in seconden"
-            },
-            "sand_timer1_status": {
-                "name": "Zandloper 1 status",
-                "state": {
-                    "started": "Gestart",
-                    "paused": "Gepauzeerd",
-                    "stopped": "Gestopt"
-                }
-            },
-            "sand_timer2_duration_in_seconds": {
-                "name": "Zandloper 2 duur in seconden"
-            },
-            "sand_timer2_status": {
-                "name": "Zandloper 2 status",
-                "state": {
-                    "started": "Gestart",
-                    "paused": "Gepauzeerd",
-                    "stopped": "Gestopt"
-                }
-            },
-            "sand_timer3_duration_in_seconds": {
-                "name": "Zandloper 3 duur in seconden"
-            },
-            "sand_timer3_status": {
-                "name": "Zandloper 3 status",
-                "state": {
-                    "started": "Gestart",
-                    "paused": "Gepauzeerd",
-                    "stopped": "Gestopt"
-                }
-            },
-            "selected_program_id": {
-                "name": "Geselecteerd programma",
-                "state": {
-                    "cotton_storage": "Katoen opslag",
-                    "standard": "Standaard",
-                    "iron": "Strijken",
-                    "mix": "Mix",
-                    "synthetic": "Synthetisch",
-                    "wool": "Wol",
-                    "bed_linen": "Bedlinnen",
-                    "time": "Tijd",
-                    "baby": "Baby",
-                    "sensitive": "Gevoelig",
-                    "shirts": "Shirts",
-                    "sports": "Sport",
-                    "fast89": "Snel89",
-                    "extra_hygiene": "Extra hygiëne",
-                    "remote": "Afstandsbediening",
-                    "none": "Geen"
-                }
-            },
-            "selected_program_id_status": {
-                "name": "Geselecteerd programma",
-                "state": {
-                    "auto": "Auto",
-                    "eco": "Eco",
-                    "one_hour": "1 uur",
-                    "intensive": "Intensief",
-                    "glass": "Glas",
-                    "hygiene": "Hygiëne",
-                    "night": "Nacht",
-                    "clean": "Schoon"
-                }
-            },
-            "selected_program_mode": {
-                "name": "Geselecteerde programmamodus",
-                "state": {
-                    "normal": "Normaal",
-                    "fast": "Snel"
-                }
-            },
-            "selected_program_remaining_time_in_minutes": {
-                "name": "Resterende tijd van geselecteerd programma"
-            },
-            "selected_programduration_inminutes": {
-                "name": "Duur van geselecteerd programma"
-            },
-            "selected_programremaining_time_inminutes": {
-                "name": "Resterende tijd van geselecteerd programma"
-            },
-            "set_progress_type": {
-                "name": "Voortgangstype instellen",
-                "state": {
-                    "oven_set": "Oven ingesteld",
-                    "mw_set": "Magnetron ingesteld",
-                    "mwc_set": "Magnetron combinatie ingesteld",
-                    "st_set": "Stoom ingesteld",
-                    "stc_set": "Stoom combinatie ingesteld",
-                    "fast_set": "Snel ingesteld",
-                    "stage_set": "Fase ingesteld",
-                    "culi_set": "Culinaire ingesteld",
-                    "warming": "Opwarmen",
-                    "defrost": "Ontdooien",
-                    "cleaning": "Reinigen",
-                    "pyrolysis": "Pyrolyse",
-                    "none": "Geen"
-                }
-            },
-            "sl1_active_timer": {
-                "name": "Zone 1 actieve timer",
-                "state": {
-                    "inactive": "Inactief",
-                    "stopwatch": "Stopwatch",
-                    "timer": "Timer"
-                }
-            },
-            "sl1_functions": {
-                "name": "Zone 1 functie",
-                "state": {
-                    "none": "Geen",
-                    "boil": "Koken",
-                    "simmer": "Sudderen",
-                    "keep_warm": "Warm houden",
-                    "wok": "Wok",
-                    "roast": "Braden",
-                    "grill": "Grillen"
-                }
-            },
-            "sl1_ntc_sensor": {
-                "name": "Zone 1 NTC sensor"
-            },
-            "sl1_power_level": {
-                "name": "Zone 1 vermogensniveau"
-            },
-            "sl1_power_level_max": {
-                "name": "Zone 1 maximaal vermogensniveau"
-            },
-            "sl1_zone_shape": {
-                "name": "Zone 1 vorm",
-                "state": {
-                    "round": "Rond",
-                    "square": "Vierkant",
-                    "rectangle_vertical": "Verticaal rechthoek",
-                    "rectangle_horizontal": "Horizontaal rechthoek",
-                    "no_shape": "Geen vorm"
-                }
-            },
-            "sl2_active_timer": {
-                "name": "Zone 2 actieve timer",
-                "state": {
-                    "inactive": "Inactief",
-                    "stopwatch": "Stopwatch",
-                    "timer": "Timer"
-                }
-            },
-            "sl2_functions": {
-                "name": "Zone 2 functie",
-                "state": {
-                    "none": "Geen",
-                    "boil": "Koken",
-                    "simmer": "Sudderen",
-                    "keep_warm": "Warm houden",
-                    "wok": "Wok",
-                    "roast": "Braden",
-                    "grill": "Grillen"
-                }
-            },
-            "sl2_ntc_sensor": {
-                "name": "Zone 2 NTC sensor"
-            },
-            "sl2_power_level": {
-                "name": "Zone 2 vermogensniveau"
-            },
-            "sl2_power_level_max": {
-                "name": "Zone 2 maximaal vermogensniveau"
-            },
-            "sl2_zone_shape": {
-                "name": "Zone 2 vorm",
-                "state": {
-                    "round": "Rond",
-                    "square": "Vierkant",
-                    "rectangle_vertical": "Verticaal rechthoek",
-                    "rectangle_horizontal": "Horizontaal rechthoek",
-                    "no_shape": "Geen vorm"
-                }
-            },
-            "sl3_active_timer": {
-                "name": "Zone 3 actieve timer",
-                "state": {
-                    "inactive": "Inactief",
-                    "stopwatch": "Stopwatch",
-                    "timer": "Timer"
-                }
-            },
-            "sl3_functions": {
-                "name": "Zone 3 functie",
-                "state": {
-                    "none": "Geen",
-                    "boil": "Koken",
-                    "simmer": "Sudderen",
-                    "keep_warm": "Warm houden",
-                    "wok": "Wok",
-                    "roast": "Braden",
-                    "grill": "Grillen"
-                }
-            },
-            "sl3_ntc_sensor": {
-                "name": "Zone 3 NTC sensor"
-            },
-            "sl3_power_level": {
-                "name": "Zone 3 vermogensniveau"
-            },
-            "sl3_power_level_max": {
-                "name": "Zone 3 maximaal vermogensniveau"
-            },
-            "sl3_zone_shape": {
-                "name": "Zone 3 vorm",
-                "state": {
-                    "round": "Rond",
-                    "square": "Vierkant",
-                    "rectangle_vertical": "Verticaal rechthoek",
-                    "rectangle_horizontal": "Horizontaal rechthoek",
-                    "no_shape": "Geen vorm"
-                }
-            },
-            "sl4_active_timer": {
-                "name": "Zone 4 actieve timer",
-                "state": {
-                    "inactive": "Inactief",
-                    "stopwatch": "Stopwatch",
-                    "timer": "Timer"
-                }
-            },
-            "sl4_functions": {
-                "name": "Zone 4 functie",
-                "state": {
-                    "none": "Geen",
-                    "boil": "Koken",
-                    "simmer": "Sudderen",
-                    "keep_warm": "Warm houden",
-                    "wok": "Wok",
-                    "roast": "Braden",
-                    "grill": "Grillen"
-                }
-            },
-            "sl4_ntc_sensor": {
-                "name": "Zone 4 NTC sensor"
-            },
-            "sl4_power_level": {
-                "name": "Zone 4 vermogensniveau"
-            },
-            "sl4_power_level_max": {
-                "name": "Zone 4 maximaal vermogensniveau"
-            },
-            "sl4_zone_shape": {
-                "name": "Zone 4 vorm",
-                "state": {
-                    "round": "Rond",
-                    "square": "Vierkant",
-                    "rectangle_vertical": "Verticaal rechthoek",
-                    "rectangle_horizontal": "Horizontaal rechthoek",
-                    "no_shape": "Geen vorm"
-                }
-            },
-            "sl5_active_timer": {
-                "name": "Zone 5 actieve timer",
-                "state": {
-                    "inactive": "Inactief",
-                    "stopwatch": "Stopwatch",
-                    "timer": "Timer"
-                }
-            },
-            "sl5_functions": {
-                "name": "Zone 5 functie",
-                "state": {
-                    "none": "Geen",
-                    "boil": "Koken",
-                    "simmer": "Sudderen",
-                    "keep_warm": "Warm houden",
-                    "wok": "Wok",
-                    "roast": "Braden",
-                    "grill": "Grillen"
-                }
-            },
-            "sl5_ntc_sensor": {
-                "name": "Zone 5 NTC sensor"
-            },
-            "sl5_power_level": {
-                "name": "Zone 5 vermogensniveau"
-            },
-            "sl5_power_level_max": {
-                "name": "Zone 5 maximaal vermogensniveau"
-            },
-            "sl5_zone_shape": {
-                "name": "Zone 5 vorm",
-                "state": {
-                    "round": "Rond",
-                    "square": "Vierkant",
-                    "rectangle_vertical": "Verticaal rechthoek",
-                    "rectangle_horizontal": "Horizontaal rechthoek",
-                    "no_shape": "Geen vorm"
-                }
-            },
-            "sl6_active_timer": {
-                "name": "Zone 6 actieve timer",
-                "state": {
-                    "inactive": "Inactief",
-                    "stopwatch": "Stopwatch",
-                    "timer": "Timer"
-                }
-            },
-            "sl6_functions": {
-                "name": "Zone 6 functie",
-                "state": {
-                    "none": "Geen",
-                    "boil": "Koken",
-                    "simmer": "Sudderen",
-                    "keep_warm": "Warm houden",
-                    "wok": "Wok",
-                    "roast": "Braden",
-                    "grill": "Grillen"
-                }
-            },
-            "sl6_ntc_sensor": {
-                "name": "Zone 6 NTC sensor"
-            },
-            "sl6_power_level": {
-                "name": "Zone 6 vermogensniveau"
-            },
-            "sl6_power_level_max": {
-                "name": "Zone 6 maximaal vermogensniveau"
-            },
-            "sl6_zone_shape": {
-                "name": "Zone 6 vorm",
-                "state": {
-                    "round": "Rond",
-                    "square": "Vierkant",
-                    "rectangle_vertical": "Verticaal rechthoek",
-                    "rectangle_horizontal": "Horizontaal rechthoek",
-                    "no_shape": "Geen vorm"
-                }
-            },
-            "step1_duration": {
-                "name": "Stap 1 duur"
-            },
-            "step1_heater_system": {
-                "name": "Stap 1 verwarmingssysteem",
-                "state": {
-                    "hot_air": "Hete lucht",
-                    "eco_hot_air": "Eco hete lucht",
-                    "top_bottom": "Boven onder",
-                    "hot_air_bottom": "Hete lucht onder",
-                    "bottom_fan": "Onder ventilator",
-                    "bottom": "Onder",
-                    "top": "Boven",
-                    "small_grill": "Kleine grill",
-                    "large_grill": "Grote grill",
-                    "large_grill_fan": "Grote grill ventilator",
-                    "pro_roasting": "Pro braden",
-                    "hotairmicro": "Hete lucht micro",
-                    "grillfanmicro": "Grill ventilator micro",
-                    "micro": "Micro",
-                    "hot_air_steam_1": "Hete lucht stoom 1",
-                    "hot_air_steam_2": "Hete lucht stoom 2",
-                    "hot_air_steam_3": "Hete lucht stoom 3",
-                    "fast_preheat": "Snel voorverwarmen",
-                    "pyro": "Pyro",
-                    "defrost": "Ontdooien",
-                    "keep_warm": "Warm houden",
-                    "plates": "Borden",
-                    "aqua_clean": "Aqua schoon",
-                    "steam_clean": "Stoom schoon",
-                    "regenerate": "Regenereren",
-                    "descale": "Ontkalken",
-                    "microwave_defrost": "Magnetron ontdooien",
-                    "sous_vide": "Sous vide",
-                    "low_temp_steam": "Lage temperatuur stoom",
-                    "steam": "Stoom",
-                    "quick": "Snel",
-                    "clean_air": "Schone lucht",
-                    "defrost_auto": "Automatisch ontdooien",
-                    "sabbath": "Sabbat",
-                    "programs": "Programma's",
-                    "warming": "Opwarmen",
-                    "microwave_clean": "Magnetron schoon",
-                    "hot_air_micro": "Hete lucht micro",
-                    "grill_fan_micro": "Grill ventilator micro"
-                }
-            },
-            "step1_remaining_time": {
-                "name": "Stap 1 resterende tijd"
-            },
-            "step1_set_temperature": {
-                "name": "Stap 1 ingestelde temperatuur"
-            },
-            "step2_duration": {
-                "name": "Stap 2 duur"
-            },
-            "step2_heater_system": {
-                "name": "Stap 2 verwarmingssysteem",
-                "state": {
-                    "hot_air": "Hete lucht",
-                    "eco_hot_air": "Eco hete lucht",
-                    "top_bottom": "Boven onder",
-                    "hot_air_bottom": "Hete lucht onder",
-                    "bottom_fan": "Onder ventilator",
-                    "bottom": "Onder",
-                    "top": "Boven",
-                    "small_grill": "Kleine grill",
-                    "large_grill": "Grote grill",
-                    "large_grill_fan": "Grote grill ventilator",
-                    "pro_roasting": "Pro braden",
-                    "hot_air_micro": "Hete lucht micro",
-                    "grill_fan_micro": "Grill ventilator micro",
-                    "micro": "Micro",
-                    "hot_air_steam_1": "Hete lucht stoom 1",
-                    "hot_air_steam_2": "Hete lucht stoom 2",
-                    "hot_air_steam_3": "Hete lucht stoom 3",
-                    "fast_preheat": "Snel voorverwarmen",
-                    "pyrolysis": "Pyrolyse",
-                    "defrost": "Ontdooien",
-                    "keep_warm": "Warm houden",
-                    "plates": "Borden",
-                    "aqua_clean": "Aqua schoon",
-                    "steam_clean": "Stoom schoon",
-                    "regenerate": "Regenereren",
-                    "descale": "Ontkalken",
-                    "microwave_defrost": "Magnetron ontdooien",
-                    "sous_vide": "Sous vide",
-                    "low_temp_steam": "Lage temperatuur stoom",
-                    "steam": "Stoom",
-                    "quick": "Snel",
-                    "clean_air": "Schone lucht",
-                    "defrost_auto": "Automatisch ontdooien",
-                    "sabbath": "Sabbat",
-                    "programs": "Programma's",
-                    "warming": "Opwarmen",
-                    "microwave_clean": "Magnetron schoon"
-                }
-            },
-            "step2_remaining_time": {
-                "name": "Stap 2 resterende tijd"
-            },
-            "step2_set_temperature": {
-                "name": "Stap 2 ingestelde temperatuur"
-            },
-            "step3_duration": {
-                "name": "Stap 3 duur"
-            },
-            "step3_heater_system": {
-                "name": "Stap 3 verwarmingssysteem",
-                "state": {
-                    "hot_air": "Hete lucht",
-                    "eco_hot_air": "Eco hete lucht",
-                    "top_bottom": "Boven onder",
-                    "hot_air_bottom": "Hete lucht onder",
-                    "bottom_fan": "Onder ventilator",
-                    "bottom": "Onder",
-                    "top": "Boven",
-                    "small_grill": "Kleine grill",
-                    "large_grill": "Grote grill",
-                    "large_grill_fan": "Grote grill ventilator",
-                    "pro_roasting": "Pro braden",
-                    "hot_air_micro": "Hete lucht micro",
-                    "grill_fan_micro": "Grill ventilator micro",
-                    "micro": "Micro",
-                    "hot_air_steam_1": "Hete lucht stoom 1",
-                    "hot_air_steam_2": "Hete lucht stoom 2",
-                    "hot_air_steam_3": "Hete lucht stoom 3",
-                    "fast_preheat": "Snel voorverwarmen",
-                    "pyro": "Pyro",
-                    "defrost": "Ontdooien",
-                    "keep_warm": "Warm houden",
-                    "plates": "Borden",
-                    "aqua_clean": "Aqua schoon",
-                    "steam_clean": "Stoom schoon",
-                    "regenerate": "Regenereren",
-                    "descale": "Ontkalken",
-                    "microwave_defrost": "Magnetron ontdooien",
-                    "sous_vide": "Sous vide",
-                    "low_temp_steam": "Lage temperatuur stoom",
-                    "steam": "Stoom",
-                    "quick": "Snel",
-                    "clean_air": "Schone lucht",
-                    "defrost_auto": "Automatisch ontdooien",
-                    "sabbath": "Sabbat",
-                    "programs": "Programma's",
-                    "warming": "Opwarmen",
-                    "microwave_clean": "Magnetron schoon"
-                }
-            },
-            "step3_remaining_time": {
-                "name": "Stap 3 resterende tijd"
-            },
-            "step3_set_temperature": {
-                "name": "Stap 3 ingestelde temperatuur"
-            },
-            "super_rinse_setting_status": {
-                "name": "Super spoelen"
-            },
-            "t_sleep": {
-                "name": "Slaap"
-            },
-            "temperature_room_judge": {
-                "name": "Temperatuur kamer beoordeling"
-            },
-            "total_energy_consumption": {
-                "name": "Totale energieverbruik"
-            },
-            "total_number_of_cycles": {
-                "name": "Totaal aantal cycli"
-            },
-            "total_passed_time": {
-                "name": "Totale verstreken tijd"
-            },
-            "total_remaining_time": {
-                "name": "Totale resterende tijd"
-            },
-            "total_run_time": {
-                "name": "Totale looptijd"
-            },
-            "total_time_of_cooking_in_hours": {
-                "name": "Totale kooktijd"
-            },
-            "total_water_consumption": {
-                "name": "Totale waterverbruik"
-            },
-            "utc_datetime_bdc_delaystart_delayend_timestamp": {
-                "name": "BDC UitstelStart UitstelEinde"
-            },
-            "variation_real_temperature": {
-                "name": "Werkelijke variatietemperatuur"
-            },
-            "variation_sensor_real_temperature": {
-                "name": "Werkelijke variatiesensortemperatuur"
-            },
-            "water_consumption_in_running_program": {
-                "name": "Waterverbruik in huidig programma"
-            },
-            "water_consumption_int": {
-                "name": "Waterverbruik"
-            },
-            "water_hardness_setting_status": {
-                "name": "Waterhardheid"
-            },
-            "water_inlet_setting_status": {
-                "name": "Watertoevoer"
-            },
-            "water_save_setting_status": {
-                "name": "Waterbesparing"
-            },
-            "zone_number": {
-                "name": "Aantal zones"
-            }
-        },
-        "switch": {
-            "anticrease": {
-                "name": "Anti-kreuk"
-            },
-            "auto_dose_setting_status": {
-                "name": "Automatisch doseren"
-            },
-            "autodose": {
-                "name": "Automatisch doseren"
-            },
-            "automatic_ice_making": {
-                "name": "Automatisch ijs maken"
-            },
-            "autotubclean": {
-                "name": "Automatisch trommel reinigen"
-            },
-            "child_lock": {
-                "name": "Kinderbeveiliging"
-            },
-            "drum_light": {
-                "name": "Trommelverlichting"
-            },
-            "holiday_mode": {
-                "name": "Vakantiemodus"
-            },
-            "mute": {
-                "name": "Stil"
-            },
-            "natural_dry": {
-                "name": "Natuurlijk drogen"
-            },
-            "odor_control_setting": {
-                "name": "Geurcontrole"
-            },
-            "t_air": {
-                "name": "Lucht"
-            },
-            "t_beep": {
-                "name": "Pieptoon"
-            },
-            "t_eco": {
-                "name": "Eco"
-            },
-            "t_fan_mute": {
-                "name": "Ventilator stil"
-            },
-            "t_power": {
-                "name": "Stroom"
-            },
-            "t_purify": {
-                "name": "Zuiveren"
-            },
-            "t_sleep": {
-                "name": "Slaap"
-            },
-            "t_sterilization": {
-                "name": "Sterilisatie"
-            },
-            "t_super": {
-                "name": "Super"
-            },
-            "t_tms": {
-                "name": "AI"
-            }
-        },
-        "select": {
-            "auto_dose_quantity_setting_status": {
-                "name": "Auto doseer hoeveelheid"
-            },
-            "dry_level": {
-                "name": "Droogniveau",
-                "state": {
-                    "low": "Laag",
-                    "medium": "Middel",
-                    "high": "Hoog"
-                }
-            },
-            "dry_time": {
-                "name": "Droogtijd",
-                "state": {
-                    "wardrobe": "Kast",
-                    "pre-ironing": "Voor-strijken",
-                    "extra_dry": "Extra droog"
-                }
-            },
-            "lightbrightness": {
-                "name": "Lichthelderheid"
-            },
-            "lightcolortemperature": {
-                "name": "Lichtkleurtemperatuur"
-            },
-            "motorlevel": {
-                "name": "Motorniveau"
-            },
-            "selected_program_id": {
-                "name": "Geselecteerd programma",
-                "state": {
-                    "auto": "Auto",
-                    "anti_allergy": "Anti-allergie",
-                    "refresh": "Vernieuwen",
-                    "sports": "Sport",
-                    "towels": "Handdoeken",
-                    "time": "Tijd",
-                    "cotton": "Katoen",
-                    "baby": "Baby",
-                    "synthetic": "Synthetisch",
-                    "wool": "Wol",
-                    "delicates": "Fijn",
-                    "fast30": "Snel 30",
-                    "shirts": "Shirts",
-                    "bed_linen": "Bedlinnen",
-                    "down": "Dons"
-                }
-            },
-            "t_fan_speed": {
-                "name": "Ventilatorsnelheid",
-                "state": {
-                    "auto": "Auto",
-                    "low": "Laag",
-                    "high": "Hoog"
-                }
-            },
-            "t_sleep": {
-                "name": "Slaapmodus",
-                "state": {
-                    "off": "Uit",
-                    "general": "Algemeen",
-                    "for_old": "Voor ouderen",
-                    "for_young": "Voor jongeren",
-                    "for_kid": "Voor kinderen"
-                }
-            },
-            "t_swing_angle": {
-                "name": "Zwenkhoek",
-                "state": {
-                    "swing": "Zwaaien",
-                    "auto": "Auto",
-                    "angle_1": "Hoek 1",
-                    "angle_2": "Hoek 2",
-                    "angle_3": "Hoek 3",
-                    "angle_4": "Hoek 4",
-                    "angle_5": "Hoek 5",
-                    "angle_6": "Hoek 6"
-                }
-            },
-            "t_swing_follow": {
-                "name": "AI ventilatie",
-                "state": {
-                    "off": "Uit",
-                    "follow": "Volgen",
-                    "not_follow": "Niet volgen"
-                }
-            }
-        },
-        "water_heater": {
-            "connectlife": {
-                "state": {
-                    "auto": "Auto"
-                }
-            }
-        },
-        "number": {
-            "freeze_max_temperature": {
-                "name": "Vriezer max temperatuur"
-            },
-            "freeze_min_temperature": {
-                "name": "Vriezer min temperatuur"
-            },
-            "freeze_temperature": {
-                "name": "Vriezer temperatuur"
-            },
-            "refrigerator_max_temperature": {
-                "name": "Koelkast max temperatuur"
-            },
-            "refrigerator_min_temperature": {
-                "name": "Koelkast min temperatuur"
-            },
-            "refrigerator_temperature": {
-                "name": "Koelkast temperatuur"
-            },
-            "variation_max_temperature": {
-                "name": "Variatie max temperatuur"
-            },
-            "variation_min_temperature": {
-                "name": "Variatie min temperatuur"
-            },
-            "variation_temperature": {
-                "name": "Variatie temperatuur"
-            }
-        }
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "ado_allowed": {
+        "name": "ADO toegestaan"
+      },
+      "alarm_1": {
+        "name": "Alarm 1"
+      },
+      "alarm_10": {
+        "name": "Alarm 10"
+      },
+      "alarm_11": {
+        "name": "Alarm 11"
+      },
+      "alarm_12": {
+        "name": "Alarm 12"
+      },
+      "alarm_2": {
+        "name": "Alarm 2"
+      },
+      "alarm_3": {
+        "name": "Alarm 3"
+      },
+      "alarm_4": {
+        "name": "Alarm 4"
+      },
+      "alarm_5": {
+        "name": "Alarm 5"
+      },
+      "alarm_6": {
+        "name": "Alarm 6"
+      },
+      "alarm_7": {
+        "name": "Alarm 7"
+      },
+      "alarm_8": {
+        "name": "Alarm 8"
+      },
+      "alarm_9": {
+        "name": "Alarm 9"
+      },
+      "alarm_alarm_time_reached": {
+        "name": "Alarmtijd bereikt"
+      },
+      "alarm_auto_dose_refill": {
+        "name": "Auto doseer bijvullen"
+      },
+      "alarm_auto_program_notification": {
+        "name": "Auto program melding"
+      },
+      "alarm_autodose_level10": {
+        "name": "Autodose niveau 10"
+      },
+      "alarm_autodose_level20": {
+        "name": "Autodose niveau 20"
+      },
+      "alarm_automatic_switch_off_zone": {
+        "name": "Automatische uitschakelzone"
+      },
+      "alarm_baking_finished": {
+        "name": "Bakken voltooid"
+      },
+      "alarm_clean_the_filters": {
+        "name": "Reinig de filters"
+      },
+      "alarm_descale_now": {
+        "name": "Ontkalk nu"
+      },
+      "alarm_door_closed": {
+        "name": "Deur gesloten"
+      },
+      "alarm_door_opened": {
+        "name": "Deur geopend"
+      },
+      "alarm_external_autodose_level15": {
+        "name": "Externe autodose niveau 15"
+      },
+      "alarm_external_autodose_level30": {
+        "name": "Externe autodose niveau 30"
+      },
+      "alarm_hob_hood_started": {
+        "name": "Kookplaatkap gestart"
+      },
+      "alarm_ntc_coil_overheating": {
+        "name": "NTC spoel oververhitting"
+      },
+      "alarm_ntc_power": {
+        "name": "NTC vermogen"
+      },
+      "alarm_ntc_tc": {
+        "name": "NTC TC"
+      },
+      "alarm_preheat_reached": {
+        "name": "Voorverwarming bereikt"
+      },
+      "alarm_preheating_ready": {
+        "name": "Voorverwarming gereed"
+      },
+      "alarm_program_done": {
+        "name": "Programma voltooid"
+      },
+      "alarm_program_pause": {
+        "name": "Programma gepauzeerd"
+      },
+      "alarm_remote_start_canceled": {
+        "name": "Afstandsbediening geannuleerd"
+      },
+      "alarm_rinse_aid_refill": {
+        "name": "Glansspoelmiddel bijvullen"
+      },
+      "alarm_rinse_aid_refill_external": {
+        "name": "Extern glansspoelmiddel bijvullen"
+      },
+      "alarm_run_selfcleaning": {
+        "name": "Zelfreiniging uitvoeren"
+      },
+      "alarm_salt_refill": {
+        "name": "Onthardingszout bijvullen"
+      },
+      "alarm_sani_program_finished": {
+        "name": "Sani-programma voltooid"
+      },
+      "alarm_steam_empty": {
+        "name": "Stoom leeg"
+      },
+      "alarm_temperature_reached": {
+        "name": "Temperatuur bereikt"
+      },
+      "alarm_timer_ended": {
+        "name": "Timer be\u00ebindigd"
+      },
+      "alarm_turn_food": {
+        "name": "Draai voedsel"
+      },
+      "alarm_voltage": {
+        "name": "Spanning"
+      },
+      "alarm_warning_fastpreheat": {
+        "name": "Waarschuwing snelle voorverwarming"
+      },
+      "alarm_warning_microwave": {
+        "name": "Waarschuwing magnetron"
+      },
+      "alarm_warning_steam": {
+        "name": "Waarschuwing stoom"
+      },
+      "alarm_water_tank_empty": {
+        "name": "Watertank leeg"
+      },
+      "alarm_water_tank_missing": {
+        "name": "Watertank ontbreekt"
+      },
+      "alarm_zone_turned_off": {
+        "name": "Zone uitgeschakeld"
+      },
+      "charcoal_filter_expiration_alarm": {
+        "name": "Waarschuwing houtskoolfilter verlopen"
+      },
+      "child_lock": {
+        "name": "Kinderbeveiliging"
+      },
+      "child_lock_status": {
+        "name": "Kinderbeveiliging"
+      },
+      "clean_filter": {
+        "name": "Filter reinigen"
+      },
+      "delay_start": {
+        "name": "Uitgestelde start"
+      },
+      "delay_start_status": {
+        "name": "Uitgestelde start"
+      },
+      "delaystart_delayend_mode": {
+        "name": "Uitgestelde start modus"
+      },
+      "demo_mode": {
+        "name": "Demomodus"
+      },
+      "door": {
+        "name": "Deur"
+      },
+      "door_status": {
+        "name": "Deur"
+      },
+      "eco_mode": {
+        "name": "ECO-modus"
+      },
+      "error_0": {
+        "name": "Fout 0"
+      },
+      "error_1": {
+        "name": "Fout 1"
+      },
+      "error_10": {
+        "name": "Fout 10"
+      },
+      "error_11": {
+        "name": "Fout 11"
+      },
+      "error_12": {
+        "name": "Fout 12"
+      },
+      "error_13": {
+        "name": "Fout 13"
+      },
+      "error_14": {
+        "name": "Fout 14"
+      },
+      "error_15": {
+        "name": "Fout 15"
+      },
+      "error_16": {
+        "name": "Fout 16"
+      },
+      "error_2": {
+        "name": "Fout 2"
+      },
+      "error_3": {
+        "name": "Fout 3"
+      },
+      "error_4": {
+        "name": "Fout 4"
+      },
+      "error_5": {
+        "name": "Fout 5"
+      },
+      "error_6": {
+        "name": "Fout 6"
+      },
+      "error_7": {
+        "name": "Fout 7"
+      },
+      "error_8": {
+        "name": "Fout 8"
+      },
+      "error_9": {
+        "name": "Fout 9"
+      },
+      "f_e_filterclean": {
+        "name": "Filter reinigen"
+      },
+      "f_e_pump": {
+        "name": "Pomp"
+      },
+      "f_e_push": {
+        "name": "Duwen"
+      },
+      "f_e_temp": {
+        "name": "Temperatuur"
+      },
+      "f_e_tubetemp": {
+        "name": "Buis temperatuur"
+      },
+      "f_e_waterfull": {
+        "name": "Water vol"
+      },
+      "f_e_wetsensor": {
+        "name": "Natte sensor"
+      },
+      "fill_salt": {
+        "name": "Onthardingszout bijvullen"
+      },
+      "float_switch": {
+        "name": "Vlotterschakelaar"
+      },
+      "free_defrosting_failure": {
+        "name": "Vriezer ontdooien mislukt"
+      },
+      "free_evap_temp_sens_head_failure": {
+        "name": "Vriezer verdamper temp sensor hoofd mislukt"
+      },
+      "free_fan_failure": {
+        "name": "Vriezer ventilator mislukt"
+      },
+      "free_room_over_temp_alarm_failure": {
+        "name": "Vriezer kamer over temp alarm mislukt"
+      },
+      "free_temp_sens_head_failure": {
+        "name": "Vriezer temp sensor hoofd mislukt"
+      },
+      "frost_state": {
+        "name": "Vorst toestand"
+      },
+      "hard_pairing_status": {
+        "name": "Harde koppelingsstatus"
+      },
+      "humidity_sensor": {
+        "name": "Vochtigheidssensor"
+      },
+      "humidity_sensor_failure": {
+        "name": "Vochtigheidssensor mislukt"
+      },
+      "ice_making_machine_failure": {
+        "name": "Ijsmachine mislukt"
+      },
+      "light": {
+        "name": "Licht"
+      },
+      "low_wine_area_c_evaporator_fault": {
+        "name": "Lage wijngebied c verdamper fout"
+      },
+      "low_wine_area_c_fan_fault": {
+        "name": "Lage wijngebied c ventilator fout"
+      },
+      "low_wine_area_c_humdy_fault": {
+        "name": "Lage wijngebied c vochtigheid fout"
+      },
+      "low_wine_area_c_temp_fault": {
+        "name": "Lage wijngebied c temperatuur fout"
+      },
+      "mid_wine_area_b_evaporator_fault": {
+        "name": "Midden wijngebied b verdamper fout"
+      },
+      "mid_wine_area_b_fan_fault": {
+        "name": "Midden wijngebied b ventilator fout"
+      },
+      "mid_wine_area_b_humdy_fault": {
+        "name": "Midden wijngebied b vochtigheid fout"
+      },
+      "mid_wine_area_b_temp_fault": {
+        "name": "Midden wijngebied b temperatuur fout"
+      },
+      "open_freeze_door_alarm": {
+        "name": "Vriezer deur open alarm"
+      },
+      "open_refrigerator_door_alarm": {
+        "name": "Koelkast deur open alarm"
+      },
+      "open_the_door_alarm": {
+        "name": "Deur open alarm"
+      },
+      "open_variation_door_alarm": {
+        "name": "Variatie deur open alarm"
+      },
+      "preheat": {
+        "name": "Voorverwarmen"
+      },
+      "quiet_mode_status": {
+        "name": "Stille modus status"
+      },
+      "reed_switch": {
+        "name": "Reed schakelaar"
+      },
+      "refr_defrosting_failure": {
+        "name": "Koelkast ontdooien mislukt"
+      },
+      "refr_dry_wet_room_sens_failure": {
+        "name": "Koelkast droge natte kamer sensor mislukt"
+      },
+      "refr_evap_temp_sens_head_failure": {
+        "name": "Koelkast verdamper temp sensor hoofd mislukt"
+      },
+      "refr_fan_failure": {
+        "name": "Koelkast ventilator mislukt"
+      },
+      "refr_room_open": {
+        "name": "Koelkast kamer open"
+      },
+      "refr_room_over_temp_alarm": {
+        "name": "Koelkast kamer over temp alarm"
+      },
+      "refr_temp_sens_head_failure": {
+        "name": "Koelkast temp sensor hoofd mislukt"
+      },
+      "refr_var_room_sens_failure": {
+        "name": "Koelkast variabele kamer sensor mislukt"
+      },
+      "remote_control_mode_monitoring": {
+        "name": "Afstandsbediening modus bewaking"
+      },
+      "remote_control_monitoring_set_commands_actions": {
+        "name": "Afstandsbediening"
+      },
+      "rinse_aid_refill": {
+        "name": "Glansspoelmiddel bijvullen"
+      },
+      "rx_failure": {
+        "name": "RX mislukt"
+      },
+      "sabbath_mode_status": {
+        "name": "Sabbatmodus status"
+      },
+      "sabbath_mode_switch_status": {
+        "name": "Sabbatmodus schakelstatus"
+      },
+      "save_mode": {
+        "name": "Spaarstand"
+      },
+      "selected_program_anticrease_status": {
+        "name": "Anti-kreuk"
+      },
+      "selected_program_auto_door_open_function": {
+        "name": "Geselecteerd programma automatische deuropening"
+      },
+      "selected_program_extradry_status": {
+        "name": "Extra droog"
+      },
+      "selected_program_steamfinish": {
+        "name": "Stoomafwerking"
+      },
+      "session_pairing_active": {
+        "name": "Sessie koppelingsactief"
+      },
+      "sl1_alarm_auto_program_notification": {
+        "name": "Zone 1 automatische programmamelding"
+      },
+      "sl1_alarm_automatic_switch_off_zone": {
+        "name": "Zone 1 automatisch uitgeschakeld"
+      },
+      "sl1_alarm_ntc_coil_overheating": {
+        "name": "Zone 1 spoel oververhitting"
+      },
+      "sl1_alarm_timer_ended": {
+        "name": "Zone 1 timer be\u00ebindigd"
+      },
+      "sl1_alarm_zone_turned_off": {
+        "name": "Zone 1 uitgeschakeld"
+      },
+      "sl1_bridge_function_active": {
+        "name": "Zone 1 brugfunctie actief"
+      },
+      "sl1_pot_detected": {
+        "name": "Zone 1 pot gedetecteerd"
+      },
+      "sl1_status": {
+        "name": "Zone 1 status"
+      },
+      "sl2_alarm_auto_program_notification": {
+        "name": "Zone 2 automatische programmamelding"
+      },
+      "sl2_alarm_automatic_switch_off_zone": {
+        "name": "Zone 2 automatisch uitgeschakeld"
+      },
+      "sl2_alarm_ntc_coil_overheating": {
+        "name": "Zone 2 spoel oververhitting"
+      },
+      "sl2_alarm_timer_ended": {
+        "name": "Zone 2 timer be\u00ebindigd"
+      },
+      "sl2_alarm_zone_turned_off": {
+        "name": "Zone 2 uitgeschakeld"
+      },
+      "sl2_bridge_function_active": {
+        "name": "Zone 2 brugfunctie actief"
+      },
+      "sl2_pot_detected": {
+        "name": "Zone 2 pot gedetecteerd"
+      },
+      "sl2_status": {
+        "name": "Zone 2 status"
+      },
+      "sl3_alarm_auto_program_notification": {
+        "name": "Zone 3 automatische programmamelding"
+      },
+      "sl3_alarm_automatic_switch_off_zone": {
+        "name": "Zone 3 automatisch uitgeschakeld"
+      },
+      "sl3_alarm_ntc_coil_overheating": {
+        "name": "Zone 3 spoel oververhitting"
+      },
+      "sl3_alarm_timer_ended": {
+        "name": "Zone 3 timer be\u00ebindigd"
+      },
+      "sl3_alarm_zone_turned_off": {
+        "name": "Zone 3 uitgeschakeld"
+      },
+      "sl3_bridge_function_active": {
+        "name": "Zone 3 brugfunctie actief"
+      },
+      "sl3_pot_detected": {
+        "name": "Zone 3 pot gedetecteerd"
+      },
+      "sl3_status": {
+        "name": "Zone 3 status"
+      },
+      "sl4_alarm_auto_program_notification": {
+        "name": "Zone 4 automatische programmamelding"
+      },
+      "sl4_alarm_automatic_switch_off_zone": {
+        "name": "Zone 4 automatisch uitgeschakeld"
+      },
+      "sl4_alarm_ntc_coil_overheating": {
+        "name": "Zone 4 spoel oververhitting"
+      },
+      "sl4_alarm_timer_ended": {
+        "name": "Zone 4 timer be\u00ebindigd"
+      },
+      "sl4_alarm_zone_turned_off": {
+        "name": "Zone 4 uitgeschakeld"
+      },
+      "sl4_bridge_function_active": {
+        "name": "Zone 4 brugfunctie actief"
+      },
+      "sl4_pot_detected": {
+        "name": "Zone 4 pot gedetecteerd"
+      },
+      "sl4_status": {
+        "name": "Zone 4 status"
+      },
+      "sl5_alarm_auto_program_notification": {
+        "name": "Zone 5 automatische programmamelding"
+      },
+      "sl5_alarm_automatic_switch_off_zone": {
+        "name": "Zone 5 automatisch uitgeschakeld"
+      },
+      "sl5_alarm_ntc_coil_overheating": {
+        "name": "Zone 5 spoel oververhitting"
+      },
+      "sl5_alarm_timer_ended": {
+        "name": "Zone 5 timer be\u00ebindigd"
+      },
+      "sl5_alarm_zone_turned_off": {
+        "name": "Zone 5 uitgeschakeld"
+      },
+      "sl5_bridge_function_active": {
+        "name": "Zone 5 brugfunctie actief"
+      },
+      "sl5_pot_detected": {
+        "name": "Zone 5 pot gedetecteerd"
+      },
+      "sl5_status": {
+        "name": "Zone 5 status"
+      },
+      "sl6_alarm_auto_program_notification": {
+        "name": "Zone 6 automatische programmamelding"
+      },
+      "sl6_alarm_automatic_switch_off_zone": {
+        "name": "Zone 6 automatisch uitgeschakeld"
+      },
+      "sl6_alarm_ntc_coil_overheating": {
+        "name": "Zone 6 spoel oververhitting"
+      },
+      "sl6_alarm_timer_ended": {
+        "name": "Zone 6 timer be\u00ebindigd"
+      },
+      "sl6_alarm_zone_turned_off": {
+        "name": "Zone 6 uitgeschakeld"
+      },
+      "sl6_bridge_function_active": {
+        "name": "Zone 6 brugfunctie actief"
+      },
+      "sl6_pot_detected": {
+        "name": "Zone 6 pot gedetecteerd"
+      },
+      "sl6_status": {
+        "name": "Zone 6 status"
+      },
+      "step1_status": {
+        "name": "Stap 1 status"
+      },
+      "step2_status": {
+        "name": "Stap 2 status"
+      },
+      "step3_status": {
+        "name": "Stap 3 status"
+      },
+      "tab_setting_status": {
+        "name": "Tab-instelling"
+      },
+      "tx_failure": {
+        "name": "TX mislukt"
+      },
+      "vacuum_on_off_status": {
+        "name": "Vacuum aan/uit status"
+      },
+      "vari_evap_temp_sens_head_failure": {
+        "name": "Vari verdamper temp sensor hoofd mislukt"
+      },
+      "vari_temp_sens_head_failure": {
+        "name": "Vari temp sensor hoofd mislukt"
+      },
+      "vibration_alarm": {
+        "name": "Trilalarm"
+      },
+      "vibration_sensor_fault": {
+        "name": "Trilsensor fout"
+      },
+      "water_level_switch": {
+        "name": "Waterniveau schakelaar"
+      },
+      "waterbox_full": {
+        "name": "Waterbox vol"
+      }
+    },
+    "climate": {
+      "connectlife": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "middle_high": "Midden hoog",
+              "middle_low": "Midden laag"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "ai": "AI",
+              "bedtime": "Bedtijd",
+              "eco_mute": "Eco stil",
+              "eco_sleep_1": "Eco slaap 1",
+              "eco_sleep_2": "Eco slaap 2",
+              "eco_sleep_3": "Eco slaap 3",
+              "eco_sleep_4": "Eco slaap 4",
+              "mute": "Stil",
+              "off": "Uit",
+              "sleep_1": "Slaap 1",
+              "sleep_2": "Slaap 2",
+              "sleep_3": "Slaap 3",
+              "sleep_4": "Slaap 4",
+              "super": "Super"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "both_sides": "Beide kanten",
+              "forward": "Vooruit",
+              "left": "Links",
+              "right": "Rechts",
+              "swing": "Zwaaien"
+            }
+          }
+        }
+      }
+    },
+    "humidifier": {
+      "connectlife": {
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "auto": "Auto",
+              "clothes_dry": "Kleding drogen",
+              "continuous": "Continu",
+              "manual": "Handmatig"
+            }
+          }
+        }
+      }
+    },
+    "number": {
+      "freeze_max_temperature": {
+        "name": "Vriezer max temperatuur"
+      },
+      "freeze_min_temperature": {
+        "name": "Vriezer min temperatuur"
+      },
+      "freeze_temperature": {
+        "name": "Vriezer temperatuur"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Koelkast max temperatuur"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Koelkast min temperatuur"
+      },
+      "refrigerator_temperature": {
+        "name": "Koelkast temperatuur"
+      },
+      "variation_max_temperature": {
+        "name": "Variatie max temperatuur"
+      },
+      "variation_min_temperature": {
+        "name": "Variatie min temperatuur"
+      },
+      "variation_temperature": {
+        "name": "Variatie temperatuur"
+      }
+    },
+    "select": {
+      "auto_dose_quantity_setting_status": {
+        "name": "Auto doseer hoeveelheid"
+      },
+      "dry_level": {
+        "name": "Droogniveau",
+        "state": {
+          "high": "Hoog",
+          "low": "Laag",
+          "medium": "Middel"
+        }
+      },
+      "dry_time": {
+        "name": "Droogtijd",
+        "state": {
+          "extra_dry": "Extra droog",
+          "pre-ironing": "Voor-strijken",
+          "wardrobe": "Kast"
+        }
+      },
+      "lightbrightness": {
+        "name": "Lichthelderheid"
+      },
+      "lightcolortemperature": {
+        "name": "Lichtkleurtemperatuur"
+      },
+      "motorlevel": {
+        "name": "Motorniveau"
+      },
+      "selected_program_id": {
+        "name": "Geselecteerd programma",
+        "state": {
+          "anti_allergy": "Anti-allergie",
+          "auto": "Auto",
+          "baby": "Baby",
+          "bed_linen": "Bedlinnen",
+          "cotton": "Katoen",
+          "delicates": "Fijn",
+          "down": "Dons",
+          "fast30": "Snel 30",
+          "refresh": "Vernieuwen",
+          "shirts": "Shirts",
+          "sports": "Sport",
+          "synthetic": "Synthetisch",
+          "time": "Tijd",
+          "towels": "Handdoeken",
+          "wool": "Wol"
+        }
+      },
+      "t_fan_speed": {
+        "name": "Ventilatorsnelheid",
+        "state": {
+          "auto": "Auto",
+          "high": "Hoog",
+          "low": "Laag"
+        }
+      },
+      "t_sleep": {
+        "name": "Slaapmodus",
+        "state": {
+          "for_kid": "Voor kinderen",
+          "for_old": "Voor ouderen",
+          "for_young": "Voor jongeren",
+          "general": "Algemeen",
+          "off": "Uit"
+        }
+      },
+      "t_swing_angle": {
+        "name": "Zwenkhoek",
+        "state": {
+          "angle_1": "Hoek 1",
+          "angle_2": "Hoek 2",
+          "angle_3": "Hoek 3",
+          "angle_4": "Hoek 4",
+          "angle_5": "Hoek 5",
+          "angle_6": "Hoek 6",
+          "auto": "Auto",
+          "swing": "Zwaaien"
+        }
+      },
+      "t_swing_follow": {
+        "name": "AI ventilatie",
+        "state": {
+          "follow": "Volgen",
+          "not_follow": "Niet volgen",
+          "off": "Uit"
+        }
+      }
+    },
+    "sensor": {
+      "ado_allowed": {
+        "name": "ADO toegestaan"
+      },
+      "alarm_door_closed": {
+        "name": "Deur gesloten"
+      },
+      "alarm_door_opened": {
+        "name": "Deur geopend"
+      },
+      "anticrease_setting": {
+        "name": "Anti-kreuk duur"
+      },
+      "appliance_status": {
+        "state": {
+          "idle": "Inactief",
+          "running": "Actief"
+        }
+      },
+      "auto_dose_duration": {
+        "name": "Auto doseer duur"
+      },
+      "auto_dose_refill": {
+        "name": "Auto doseer bijvullen"
+      },
+      "bundling_humidity": {
+        "name": "Bundel vochtigheid"
+      },
+      "bundling_temperature": {
+        "name": "Bundel temperatuur"
+      },
+      "child_lock_setting_status": {
+        "name": "Kinderbeveiliging instelling"
+      },
+      "curent_program_duration": {
+        "name": "Huidige programmaduur"
+      },
+      "curent_program_remaining_time": {
+        "name": "Resterende tijd huidig programma"
+      },
+      "current_baking_step": {
+        "name": "Huidige bakstap",
+        "state": {
+          "after_bake_finished": "Na het bakken voltooid",
+          "preheat": "Voorverwarmen",
+          "step_1": "Stap 1",
+          "step_2": "Stap 2",
+          "step_3": "Stap 3"
+        }
+      },
+      "current_program_phase": {
+        "state": {
+          "anti_crease": "Anti-kreuk",
+          "delay": "Uitgesteld",
+          "delay_start_waiting": "Wachten op uitgestelde start",
+          "drying": "Drogen",
+          "finished": "Voltooid",
+          "idle": "Inactief",
+          "main_wash": "Hoofdwas",
+          "not_available": "Niet beschikbaar",
+          "preheat": "Voorverwarmen",
+          "preheat_finished": "Voorverwarmen voltooid",
+          "prewash": "Voorwas",
+          "program_finished": "Voltooid",
+          "program_not_selected": "Programma niet geselecteerd",
+          "program_selected": "Programma geselecteerd",
+          "running": "Actief",
+          "ventilating": "Ventileren"
+        }
+      },
+      "current_programphase": {
+        "state": {
+          "running": "Actief"
+        }
+      },
+      "daily_energy_kwh": {
+        "name": "Dagelijks energieverbruik"
+      },
+      "delay_duration_inminutes": {
+        "name": "Uitstelduur"
+      },
+      "delay_start_remaining_time": {
+        "name": "Resterende tijd uitgestelde start"
+      },
+      "delay_start_set_time": {
+        "name": "Ingestelde tijd uitgestelde start"
+      },
+      "delaystart_delayend_duration_inminutes": {
+        "name": "Uitstel start duur"
+      },
+      "delaystart_delayend_remaining_timein_minutes": {
+        "name": "Resterende tijd uitstel start"
+      },
+      "device_status": {
+        "state": {
+          "after_bake_finished": "Na het bakken voltooid",
+          "delay_time_waiting": "Wachten op uitgestelde tijd",
+          "demo_mode": "Demomodus",
+          "error": "Fout",
+          "failure": "Mislukt",
+          "idle": "Inactief",
+          "iq": "IQ",
+          "locked": "Vergrendeld",
+          "not_available": "Niet beschikbaar",
+          "pause": "Gepauzeerd",
+          "pause_mode": "Pauzemodus",
+          "paused": "Gepauzeerd",
+          "production": "Productie",
+          "running": "Actief",
+          "service": "Onderhoud",
+          "stand_by": "Stand-by"
+        }
+      },
+      "display_brightness_setting_status": {
+        "name": "Helderheid display"
+      },
+      "display_contrast_setting_status": {
+        "name": "Contrast display"
+      },
+      "display_logotype_setting_status": {
+        "name": "Logotype display"
+      },
+      "energy_consumption_in_running_program": {
+        "name": "Energieverbruik in huidig programma"
+      },
+      "environment_humidity": {
+        "name": "Omgevingsvochtigheid"
+      },
+      "error_read_out_1_code": {
+        "name": "Foutcode uitlezen 1"
+      },
+      "error_read_out_1_cycle": {
+        "name": "Foutcyclus uitlezen 1"
+      },
+      "error_read_out_2_code": {
+        "name": "Foutcode uitlezen 2"
+      },
+      "error_read_out_2_cycle": {
+        "name": "Foutcyclus uitlezen 2"
+      },
+      "error_read_out_3_code": {
+        "name": "Foutcode uitlezen 3"
+      },
+      "error_read_out_3_cycle": {
+        "name": "Foutcyclus uitlezen 3"
+      },
+      "extradry_setting": {
+        "name": "Extra droog instelling"
+      },
+      "f_cool_qvalue": {
+        "name": "Koeling"
+      },
+      "f_heat_qvalue": {
+        "name": "Verwarming"
+      },
+      "f_votage": {
+        "name": "Gemeten netspanning"
+      },
+      "fan_sequence_setting_status": {
+        "name": "Ventilatorvolgorde"
+      },
+      "feedback_volumen_setting_status": {
+        "name": "Feedback volume",
+        "state": {
+          "high": "Hoog",
+          "low": "Laag",
+          "mid": "Midden",
+          "mute": "Stil"
+        }
+      },
+      "freeze_real_temperature": {
+        "name": "Werkelijke vriezertemperatuur"
+      },
+      "freeze_sensor_real_temperature": {
+        "name": "Werkelijke vriezersensortemperatuur"
+      },
+      "fruit_vegetables_temperature": {
+        "name": "Temperatuur fruit en groenten"
+      },
+      "heat_pump_setting_status": {
+        "name": "Warmtepomp"
+      },
+      "high_humidity": {
+        "name": "Hoge vochtigheid"
+      },
+      "high_temperature": {
+        "name": "Hoge temperatuur"
+      },
+      "interior_light_at_power_off_setting_status": {
+        "name": "Interieurverlichting bij uitschakelen"
+      },
+      "interior_light_status": {
+        "name": "Interieurverlichting"
+      },
+      "language_status": {
+        "name": "Taal"
+      },
+      "last_run_program_id": {
+        "name": "Laatst uitgevoerd programma"
+      },
+      "low_humidity": {
+        "name": "Lage vochtigheid"
+      },
+      "low_temperature": {
+        "name": "Lage temperatuur"
+      },
+      "machine_status": {
+        "name": "Machine status",
+        "state": {
+          "off": "Uit",
+          "running": "Actief",
+          "standby": "Standby"
+        }
+      },
+      "measured_vibrations": {
+        "name": "Gemeten trillingen"
+      },
+      "meat_probe_measured_temperature": {
+        "name": "Gemeten temperatuur vleessonde"
+      },
+      "meat_probe_set_temperature": {
+        "name": "Ingestelde temperatuur vleessonde"
+      },
+      "medium_humidity": {
+        "name": "Gemiddelde vochtigheid"
+      },
+      "medium_temperature": {
+        "name": "Gemiddelde temperatuur"
+      },
+      "notification_volumen_setting_status": {
+        "name": "Meldingsvolume"
+      },
+      "oven_temperature": {
+        "name": "Oventemperatuur"
+      },
+      "pressure_calibration_setting_status": {
+        "name": "Drukcalibratie"
+      },
+      "real_humidity": {
+        "name": "Werkelijke vochtigheid"
+      },
+      "real_humidity_b": {
+        "name": "Werkelijke vochtigheid b"
+      },
+      "real_humidity_c": {
+        "name": "Werkelijke vochtigheid c"
+      },
+      "refrigerator_real_temperature": {
+        "name": "Werkelijke koelkasttemperatuur"
+      },
+      "refrigerator_sensor_real_temperature": {
+        "name": "Werkelijke koelkastsensortemperatuur"
+      },
+      "rinse_aid_setting_status": {
+        "name": "Glansspoelmiddel"
+      },
+      "sand_timer1_duration_in_seconds": {
+        "name": "Zandloper 1 duur in seconden"
+      },
+      "sand_timer1_status": {
+        "name": "Zandloper 1 status",
+        "state": {
+          "paused": "Gepauzeerd",
+          "started": "Gestart",
+          "stopped": "Gestopt"
+        }
+      },
+      "sand_timer2_duration_in_seconds": {
+        "name": "Zandloper 2 duur in seconden"
+      },
+      "sand_timer2_status": {
+        "name": "Zandloper 2 status",
+        "state": {
+          "paused": "Gepauzeerd",
+          "started": "Gestart",
+          "stopped": "Gestopt"
+        }
+      },
+      "sand_timer3_duration_in_seconds": {
+        "name": "Zandloper 3 duur in seconden"
+      },
+      "sand_timer3_status": {
+        "name": "Zandloper 3 status",
+        "state": {
+          "paused": "Gepauzeerd",
+          "started": "Gestart",
+          "stopped": "Gestopt"
+        }
+      },
+      "selected_program_id": {
+        "name": "Geselecteerd programma",
+        "state": {
+          "baby": "Baby",
+          "bed_linen": "Bedlinnen",
+          "cotton_storage": "Katoen opslag",
+          "extra_hygiene": "Extra hygi\u00ebne",
+          "fast89": "Snel89",
+          "iron": "Strijken",
+          "mix": "Mix",
+          "none": "Geen",
+          "remote": "Afstandsbediening",
+          "sensitive": "Gevoelig",
+          "shirts": "Shirts",
+          "sports": "Sport",
+          "standard": "Standaard",
+          "synthetic": "Synthetisch",
+          "time": "Tijd",
+          "wool": "Wol"
+        }
+      },
+      "selected_program_id_status": {
+        "name": "Geselecteerd programma",
+        "state": {
+          "auto": "Auto",
+          "clean": "Schoon",
+          "eco": "Eco",
+          "glass": "Glas",
+          "hygiene": "Hygi\u00ebne",
+          "intensive": "Intensief",
+          "night": "Nacht",
+          "one_hour": "1 uur"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Geselecteerde programmamodus",
+        "state": {
+          "fast": "Snel",
+          "normal": "Normaal"
+        }
+      },
+      "selected_program_remaining_time_in_minutes": {
+        "name": "Resterende tijd van geselecteerd programma"
+      },
+      "selected_programduration_inminutes": {
+        "name": "Duur van geselecteerd programma"
+      },
+      "selected_programremaining_time_inminutes": {
+        "name": "Resterende tijd van geselecteerd programma"
+      },
+      "set_progress_type": {
+        "name": "Voortgangstype instellen",
+        "state": {
+          "cleaning": "Reinigen",
+          "culi_set": "Culinaire ingesteld",
+          "defrost": "Ontdooien",
+          "fast_set": "Snel ingesteld",
+          "mw_set": "Magnetron ingesteld",
+          "mwc_set": "Magnetron combinatie ingesteld",
+          "none": "Geen",
+          "oven_set": "Oven ingesteld",
+          "pyrolysis": "Pyrolyse",
+          "st_set": "Stoom ingesteld",
+          "stage_set": "Fase ingesteld",
+          "stc_set": "Stoom combinatie ingesteld",
+          "warming": "Opwarmen"
+        }
+      },
+      "sl1_active_timer": {
+        "name": "Zone 1 actieve timer",
+        "state": {
+          "inactive": "Inactief",
+          "stopwatch": "Stopwatch",
+          "timer": "Timer"
+        }
+      },
+      "sl1_functions": {
+        "name": "Zone 1 functie",
+        "state": {
+          "boil": "Koken",
+          "grill": "Grillen",
+          "keep_warm": "Warm houden",
+          "none": "Geen",
+          "roast": "Braden",
+          "simmer": "Sudderen",
+          "wok": "Wok"
+        }
+      },
+      "sl1_ntc_sensor": {
+        "name": "Zone 1 NTC sensor"
+      },
+      "sl1_power_level": {
+        "name": "Zone 1 vermogensniveau"
+      },
+      "sl1_power_level_max": {
+        "name": "Zone 1 maximaal vermogensniveau"
+      },
+      "sl1_zone_shape": {
+        "name": "Zone 1 vorm",
+        "state": {
+          "no_shape": "Geen vorm",
+          "rectangle_horizontal": "Horizontaal rechthoek",
+          "rectangle_vertical": "Verticaal rechthoek",
+          "round": "Rond",
+          "square": "Vierkant"
+        }
+      },
+      "sl2_active_timer": {
+        "name": "Zone 2 actieve timer",
+        "state": {
+          "inactive": "Inactief",
+          "stopwatch": "Stopwatch",
+          "timer": "Timer"
+        }
+      },
+      "sl2_functions": {
+        "name": "Zone 2 functie",
+        "state": {
+          "boil": "Koken",
+          "grill": "Grillen",
+          "keep_warm": "Warm houden",
+          "none": "Geen",
+          "roast": "Braden",
+          "simmer": "Sudderen",
+          "wok": "Wok"
+        }
+      },
+      "sl2_ntc_sensor": {
+        "name": "Zone 2 NTC sensor"
+      },
+      "sl2_power_level": {
+        "name": "Zone 2 vermogensniveau"
+      },
+      "sl2_power_level_max": {
+        "name": "Zone 2 maximaal vermogensniveau"
+      },
+      "sl2_zone_shape": {
+        "name": "Zone 2 vorm",
+        "state": {
+          "no_shape": "Geen vorm",
+          "rectangle_horizontal": "Horizontaal rechthoek",
+          "rectangle_vertical": "Verticaal rechthoek",
+          "round": "Rond",
+          "square": "Vierkant"
+        }
+      },
+      "sl3_active_timer": {
+        "name": "Zone 3 actieve timer",
+        "state": {
+          "inactive": "Inactief",
+          "stopwatch": "Stopwatch",
+          "timer": "Timer"
+        }
+      },
+      "sl3_functions": {
+        "name": "Zone 3 functie",
+        "state": {
+          "boil": "Koken",
+          "grill": "Grillen",
+          "keep_warm": "Warm houden",
+          "none": "Geen",
+          "roast": "Braden",
+          "simmer": "Sudderen",
+          "wok": "Wok"
+        }
+      },
+      "sl3_ntc_sensor": {
+        "name": "Zone 3 NTC sensor"
+      },
+      "sl3_power_level": {
+        "name": "Zone 3 vermogensniveau"
+      },
+      "sl3_power_level_max": {
+        "name": "Zone 3 maximaal vermogensniveau"
+      },
+      "sl3_zone_shape": {
+        "name": "Zone 3 vorm",
+        "state": {
+          "no_shape": "Geen vorm",
+          "rectangle_horizontal": "Horizontaal rechthoek",
+          "rectangle_vertical": "Verticaal rechthoek",
+          "round": "Rond",
+          "square": "Vierkant"
+        }
+      },
+      "sl4_active_timer": {
+        "name": "Zone 4 actieve timer",
+        "state": {
+          "inactive": "Inactief",
+          "stopwatch": "Stopwatch",
+          "timer": "Timer"
+        }
+      },
+      "sl4_functions": {
+        "name": "Zone 4 functie",
+        "state": {
+          "boil": "Koken",
+          "grill": "Grillen",
+          "keep_warm": "Warm houden",
+          "none": "Geen",
+          "roast": "Braden",
+          "simmer": "Sudderen",
+          "wok": "Wok"
+        }
+      },
+      "sl4_ntc_sensor": {
+        "name": "Zone 4 NTC sensor"
+      },
+      "sl4_power_level": {
+        "name": "Zone 4 vermogensniveau"
+      },
+      "sl4_power_level_max": {
+        "name": "Zone 4 maximaal vermogensniveau"
+      },
+      "sl4_zone_shape": {
+        "name": "Zone 4 vorm",
+        "state": {
+          "no_shape": "Geen vorm",
+          "rectangle_horizontal": "Horizontaal rechthoek",
+          "rectangle_vertical": "Verticaal rechthoek",
+          "round": "Rond",
+          "square": "Vierkant"
+        }
+      },
+      "sl5_active_timer": {
+        "name": "Zone 5 actieve timer",
+        "state": {
+          "inactive": "Inactief",
+          "stopwatch": "Stopwatch",
+          "timer": "Timer"
+        }
+      },
+      "sl5_functions": {
+        "name": "Zone 5 functie",
+        "state": {
+          "boil": "Koken",
+          "grill": "Grillen",
+          "keep_warm": "Warm houden",
+          "none": "Geen",
+          "roast": "Braden",
+          "simmer": "Sudderen",
+          "wok": "Wok"
+        }
+      },
+      "sl5_ntc_sensor": {
+        "name": "Zone 5 NTC sensor"
+      },
+      "sl5_power_level": {
+        "name": "Zone 5 vermogensniveau"
+      },
+      "sl5_power_level_max": {
+        "name": "Zone 5 maximaal vermogensniveau"
+      },
+      "sl5_zone_shape": {
+        "name": "Zone 5 vorm",
+        "state": {
+          "no_shape": "Geen vorm",
+          "rectangle_horizontal": "Horizontaal rechthoek",
+          "rectangle_vertical": "Verticaal rechthoek",
+          "round": "Rond",
+          "square": "Vierkant"
+        }
+      },
+      "sl6_active_timer": {
+        "name": "Zone 6 actieve timer",
+        "state": {
+          "inactive": "Inactief",
+          "stopwatch": "Stopwatch",
+          "timer": "Timer"
+        }
+      },
+      "sl6_functions": {
+        "name": "Zone 6 functie",
+        "state": {
+          "boil": "Koken",
+          "grill": "Grillen",
+          "keep_warm": "Warm houden",
+          "none": "Geen",
+          "roast": "Braden",
+          "simmer": "Sudderen",
+          "wok": "Wok"
+        }
+      },
+      "sl6_ntc_sensor": {
+        "name": "Zone 6 NTC sensor"
+      },
+      "sl6_power_level": {
+        "name": "Zone 6 vermogensniveau"
+      },
+      "sl6_power_level_max": {
+        "name": "Zone 6 maximaal vermogensniveau"
+      },
+      "sl6_zone_shape": {
+        "name": "Zone 6 vorm",
+        "state": {
+          "no_shape": "Geen vorm",
+          "rectangle_horizontal": "Horizontaal rechthoek",
+          "rectangle_vertical": "Verticaal rechthoek",
+          "round": "Rond",
+          "square": "Vierkant"
+        }
+      },
+      "step1_duration": {
+        "name": "Stap 1 duur"
+      },
+      "step1_heater_system": {
+        "name": "Stap 1 verwarmingssysteem",
+        "state": {
+          "aqua_clean": "Aqua schoon",
+          "bottom": "Onder",
+          "bottom_fan": "Onder ventilator",
+          "clean_air": "Schone lucht",
+          "defrost": "Ontdooien",
+          "defrost_auto": "Automatisch ontdooien",
+          "descale": "Ontkalken",
+          "eco_hot_air": "Eco hete lucht",
+          "fast_preheat": "Snel voorverwarmen",
+          "grill_fan_micro": "Grill ventilator micro",
+          "grillfanmicro": "Grill ventilator micro",
+          "hot_air": "Hete lucht",
+          "hot_air_bottom": "Hete lucht onder",
+          "hot_air_micro": "Hete lucht micro",
+          "hot_air_steam_1": "Hete lucht stoom 1",
+          "hot_air_steam_2": "Hete lucht stoom 2",
+          "hot_air_steam_3": "Hete lucht stoom 3",
+          "hotairmicro": "Hete lucht micro",
+          "keep_warm": "Warm houden",
+          "large_grill": "Grote grill",
+          "large_grill_fan": "Grote grill ventilator",
+          "low_temp_steam": "Lage temperatuur stoom",
+          "micro": "Micro",
+          "microwave_clean": "Magnetron schoon",
+          "microwave_defrost": "Magnetron ontdooien",
+          "plates": "Borden",
+          "pro_roasting": "Pro braden",
+          "programs": "Programma's",
+          "pyro": "Pyro",
+          "quick": "Snel",
+          "regenerate": "Regenereren",
+          "sabbath": "Sabbat",
+          "small_grill": "Kleine grill",
+          "sous_vide": "Sous vide",
+          "steam": "Stoom",
+          "steam_clean": "Stoom schoon",
+          "top": "Boven",
+          "top_bottom": "Boven onder",
+          "warming": "Opwarmen"
+        }
+      },
+      "step1_remaining_time": {
+        "name": "Stap 1 resterende tijd"
+      },
+      "step1_set_temperature": {
+        "name": "Stap 1 ingestelde temperatuur"
+      },
+      "step2_duration": {
+        "name": "Stap 2 duur"
+      },
+      "step2_heater_system": {
+        "name": "Stap 2 verwarmingssysteem",
+        "state": {
+          "aqua_clean": "Aqua schoon",
+          "bottom": "Onder",
+          "bottom_fan": "Onder ventilator",
+          "clean_air": "Schone lucht",
+          "defrost": "Ontdooien",
+          "defrost_auto": "Automatisch ontdooien",
+          "descale": "Ontkalken",
+          "eco_hot_air": "Eco hete lucht",
+          "fast_preheat": "Snel voorverwarmen",
+          "grill_fan_micro": "Grill ventilator micro",
+          "hot_air": "Hete lucht",
+          "hot_air_bottom": "Hete lucht onder",
+          "hot_air_micro": "Hete lucht micro",
+          "hot_air_steam_1": "Hete lucht stoom 1",
+          "hot_air_steam_2": "Hete lucht stoom 2",
+          "hot_air_steam_3": "Hete lucht stoom 3",
+          "keep_warm": "Warm houden",
+          "large_grill": "Grote grill",
+          "large_grill_fan": "Grote grill ventilator",
+          "low_temp_steam": "Lage temperatuur stoom",
+          "micro": "Micro",
+          "microwave_clean": "Magnetron schoon",
+          "microwave_defrost": "Magnetron ontdooien",
+          "plates": "Borden",
+          "pro_roasting": "Pro braden",
+          "programs": "Programma's",
+          "pyrolysis": "Pyrolyse",
+          "quick": "Snel",
+          "regenerate": "Regenereren",
+          "sabbath": "Sabbat",
+          "small_grill": "Kleine grill",
+          "sous_vide": "Sous vide",
+          "steam": "Stoom",
+          "steam_clean": "Stoom schoon",
+          "top": "Boven",
+          "top_bottom": "Boven onder",
+          "warming": "Opwarmen"
+        }
+      },
+      "step2_remaining_time": {
+        "name": "Stap 2 resterende tijd"
+      },
+      "step2_set_temperature": {
+        "name": "Stap 2 ingestelde temperatuur"
+      },
+      "step3_duration": {
+        "name": "Stap 3 duur"
+      },
+      "step3_heater_system": {
+        "name": "Stap 3 verwarmingssysteem",
+        "state": {
+          "aqua_clean": "Aqua schoon",
+          "bottom": "Onder",
+          "bottom_fan": "Onder ventilator",
+          "clean_air": "Schone lucht",
+          "defrost": "Ontdooien",
+          "defrost_auto": "Automatisch ontdooien",
+          "descale": "Ontkalken",
+          "eco_hot_air": "Eco hete lucht",
+          "fast_preheat": "Snel voorverwarmen",
+          "grill_fan_micro": "Grill ventilator micro",
+          "hot_air": "Hete lucht",
+          "hot_air_bottom": "Hete lucht onder",
+          "hot_air_micro": "Hete lucht micro",
+          "hot_air_steam_1": "Hete lucht stoom 1",
+          "hot_air_steam_2": "Hete lucht stoom 2",
+          "hot_air_steam_3": "Hete lucht stoom 3",
+          "keep_warm": "Warm houden",
+          "large_grill": "Grote grill",
+          "large_grill_fan": "Grote grill ventilator",
+          "low_temp_steam": "Lage temperatuur stoom",
+          "micro": "Micro",
+          "microwave_clean": "Magnetron schoon",
+          "microwave_defrost": "Magnetron ontdooien",
+          "plates": "Borden",
+          "pro_roasting": "Pro braden",
+          "programs": "Programma's",
+          "pyro": "Pyro",
+          "quick": "Snel",
+          "regenerate": "Regenereren",
+          "sabbath": "Sabbat",
+          "small_grill": "Kleine grill",
+          "sous_vide": "Sous vide",
+          "steam": "Stoom",
+          "steam_clean": "Stoom schoon",
+          "top": "Boven",
+          "top_bottom": "Boven onder",
+          "warming": "Opwarmen"
+        }
+      },
+      "step3_remaining_time": {
+        "name": "Stap 3 resterende tijd"
+      },
+      "step3_set_temperature": {
+        "name": "Stap 3 ingestelde temperatuur"
+      },
+      "super_rinse_setting_status": {
+        "name": "Super spoelen"
+      },
+      "t_sleep": {
+        "name": "Slaap"
+      },
+      "temperature_room_judge": {
+        "name": "Temperatuur kamer beoordeling"
+      },
+      "total_energy_consumption": {
+        "name": "Totale energieverbruik"
+      },
+      "total_number_of_cycles": {
+        "name": "Totaal aantal cycli"
+      },
+      "total_passed_time": {
+        "name": "Totale verstreken tijd"
+      },
+      "total_remaining_time": {
+        "name": "Totale resterende tijd"
+      },
+      "total_run_time": {
+        "name": "Totale looptijd"
+      },
+      "total_time_of_cooking_in_hours": {
+        "name": "Totale kooktijd"
+      },
+      "total_water_consumption": {
+        "name": "Totale waterverbruik"
+      },
+      "utc_datetime_bdc_delaystart_delayend_timestamp": {
+        "name": "BDC UitstelStart UitstelEinde"
+      },
+      "variation_real_temperature": {
+        "name": "Werkelijke variatietemperatuur"
+      },
+      "variation_sensor_real_temperature": {
+        "name": "Werkelijke variatiesensortemperatuur"
+      },
+      "water_consumption_in_running_program": {
+        "name": "Waterverbruik in huidig programma"
+      },
+      "water_consumption_int": {
+        "name": "Waterverbruik"
+      },
+      "water_hardness_setting_status": {
+        "name": "Waterhardheid"
+      },
+      "water_inlet_setting_status": {
+        "name": "Watertoevoer"
+      },
+      "water_save_setting_status": {
+        "name": "Waterbesparing"
+      },
+      "zone_number": {
+        "name": "Aantal zones"
+      }
+    },
+    "switch": {
+      "anticrease": {
+        "name": "Anti-kreuk"
+      },
+      "auto_dose_setting_status": {
+        "name": "Automatisch doseren"
+      },
+      "autodose": {
+        "name": "Automatisch doseren"
+      },
+      "automatic_ice_making": {
+        "name": "Automatisch ijs maken"
+      },
+      "autotubclean": {
+        "name": "Automatisch trommel reinigen"
+      },
+      "child_lock": {
+        "name": "Kinderbeveiliging"
+      },
+      "drum_light": {
+        "name": "Trommelverlichting"
+      },
+      "holiday_mode": {
+        "name": "Vakantiemodus"
+      },
+      "mute": {
+        "name": "Stil"
+      },
+      "natural_dry": {
+        "name": "Natuurlijk drogen"
+      },
+      "odor_control_setting": {
+        "name": "Geurcontrole"
+      },
+      "t_air": {
+        "name": "Lucht"
+      },
+      "t_beep": {
+        "name": "Pieptoon"
+      },
+      "t_eco": {
+        "name": "Eco"
+      },
+      "t_fan_mute": {
+        "name": "Ventilator stil"
+      },
+      "t_power": {
+        "name": "Stroom"
+      },
+      "t_purify": {
+        "name": "Zuiveren"
+      },
+      "t_sleep": {
+        "name": "Slaap"
+      },
+      "t_sterilization": {
+        "name": "Sterilisatie"
+      },
+      "t_super": {
+        "name": "Super"
+      },
+      "t_tms": {
+        "name": "AI"
+      }
+    },
+    "water_heater": {
+      "connectlife": {
+        "state": {
+          "auto": "Auto"
+        }
+      }
+    }
+  },
+  "issues": {
+    "unavailable_device": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "Genegeerd \"{device_name} niet langer beschikbaar\". Het apparaat en al zijn entiteiten zullen nog steeds in het register worden vermeld."
+        },
+        "step": {
+          "init": {
+            "description": "Het apparaat \"{device_name}\" is niet langer beschikbaar in uw ConnectLife-account. Als u dit apparaat niet meer heeft, kunt u het uit Home Assistant verwijderen.",
+            "menu_options": {
+              "ignore": "Negeren",
+              "remove": "Verwijderen"
+            },
+            "title": "{device_name} niet langer beschikbaar"
+          },
+          "remove": {
+            "description": "Het apparaat \"{device_name}\" en al zijn entiteiten zullen worden verwijderd uit Home Assistant.",
+            "title": "Verwijder {device_name}"
+          }
+        }
+      },
+      "title": "{device_name} niet langer beschikbaar"
+    }
+  },
+  "options": {
+    "error": {
+      "test_server_invalid": "Ongeldige test server URL",
+      "test_server_required": "Ontwikkelingsmodus vereist test server URL"
+    },
+    "step": {
+      "configure_device": {
+        "data": {
+          "disable_beep": "Schakel piep uit"
+        },
+        "description": "Configureer een apparaat."
+      },
+      "development": {
+        "data": {
+          "development_mode": "Ontwikkelingsmodus",
+          "test_server_url": "Test server URL"
+        },
+        "description": "Schakel ontwikkelingsmodus in om verbinding te maken met de testserver in plaats van de ConnectLife API."
+      },
+      "init": {
+        "menu_options": {
+          "development": "Configureer ontwikkelingsmodus",
+          "select_device": "Configureer een apparaat"
+        }
+      },
+      "select_device": {
+        "data": {
+          "device": "Selecteer apparaat"
+        },
+        "description": "Configureer een apparaat."
+      }
+    }
+  },
+  "selector": {
+    "actions": {
+      "options": {
+        "1": "Start",
+        "2": "Stop",
+        "3": "Pauze",
+        "4": "Deur openen"
+      }
+    }
+  },
+  "services": {
+    "set_action": {
+      "description": "Stelt actie in voor apparaat. Gebruik voorzichtig.",
+      "fields": {
+        "action": {
+          "description": "Actie om in te stellen.",
+          "name": "Actie"
+        }
+      },
+      "name": "Actie instellen"
+    },
+    "set_value": {
+      "description": "Stelt een waarde in voor de status. Gebruik voorzichtig.",
+      "fields": {
+        "value": {
+          "description": "Waarde om in te stellen.",
+          "name": "Waarde"
+        }
+      },
+      "name": "Waarde instellen"
+    }
+  }
 }

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -117,8 +117,12 @@ def main(basedir):
 
 def load_ha_strings():
     print(f"Fetching HA strings from {HA_STRINGS_URL}")
-    with urllib.request.urlopen(HA_STRINGS_URL) as r:
-        return json.load(r)
+    try:
+        with urllib.request.urlopen(HA_STRINGS_URL, timeout=30) as r:
+            return json.load(r)
+    except Exception as e:
+        print(f"Failed to fetch HA strings: {e}")
+        exit(1)
 
 
 def resolve_key(ha_strings, key):

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -1,11 +1,17 @@
 import json
+import urllib.request
 from os import listdir
 from os.path import isfile, join
 
 import yaml
 
+from scripts import sort_translations
+
+HA_STRINGS_URL = "https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/strings.json"
+
 
 def main(basedir):
+    ha_strings = load_ha_strings()
     with open(f'{basedir}/strings.json', 'r') as f:
         strings = json.load(f)
     device_dir = f'{basedir}/data_dictionaries'
@@ -99,8 +105,45 @@ def main(basedir):
         strings["entity"][k] = dict(sorted(v.items()))
 
     with open(f'{basedir}/strings.json', 'w') as f:
-        json.dump(strings, f, indent=2)
+        json.dump(strings, f, indent=2, sort_keys=True)
         f.write("\n")
+
+    en = expand_keys(strings, ha_strings)
+    with open(f'{basedir}/translations/en.json', 'w') as f:
+        json.dump(en, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    sort_translations.main(basedir)
+
+def load_ha_strings():
+    print(f"Fetching HA strings from {HA_STRINGS_URL}")
+    with urllib.request.urlopen(HA_STRINGS_URL) as r:
+        return json.load(r)
+
+
+def resolve_key(ha_strings, key):
+    """Resolve a key like 'common::config_flow::data::username' against HA strings."""
+    parts = key.split("::")
+    obj = ha_strings
+    for part in parts:
+        if not isinstance(obj, dict) or part not in obj:
+            return None
+        obj = obj[part]
+    return obj
+
+
+def expand_keys(obj, ha_strings):
+    if isinstance(obj, dict):
+        return {k: expand_keys(v, ha_strings) for k, v in obj.items()}
+    if isinstance(obj, str) and obj.startswith("[%key:") and obj.endswith("%]"):
+        key = obj[6:-2]
+        value = resolve_key(ha_strings, key)
+        if value is None:
+            print(f"Unknown HA common string: {key}")
+            exit(1)
+        return value
+    return obj
+
 
 def is_number(s: str) -> bool:
     try:

--- a/scripts/sort_translations.py
+++ b/scripts/sort_translations.py
@@ -1,0 +1,22 @@
+import json
+from os import listdir
+from os.path import join
+
+
+def main(basedir):
+    translations_dir = f'{basedir}/translations'
+    for filename in sorted(listdir(translations_dir)):
+        if filename.endswith('.json'):
+            sort_json(join(translations_dir, filename))
+
+
+def sort_json(filepath):
+    with open(filepath, 'r') as f:
+        data = json.load(f)
+    with open(filepath, 'w') as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    main("custom_components/connectlife")


### PR DESCRIPTION
## Summary

Inspired by #424, this PR takes over the sorting and improves the translation tooling:

- **Sort all translation files** — `strings.json` and all `translations/*.json` files are now sorted alphabetically (matching HA core convention)
- **Generate `en.json` automatically** — `gen_strings.py` now writes `translations/en.json` with `[%key:...]` references expanded using HA core's `strings.json` (fetched from GitHub). Previously `en.json` was a manual copy with unexpanded references, which rendered as literal `[%key:...]` text in the HA UI.
- **Add `scripts/sort_translations.py`** — standalone script for sorting translation files without regenerating strings, useful for translation contributors
- **Deterministic output** — `sort_keys=True` ensures `gen_strings.py` produces consistent output regardless of processing order
- **Documentation** — updated `CLAUDE.md` and `DEVELOPMENT.md` with new commands and a "Providing translations" section

## Changes

- `scripts/gen_strings.py` — add `sort_keys=True`, generate `en.json` with key expansion, sort translations
- `scripts/sort_translations.py` — new standalone sort script
- `custom_components/connectlife/strings.json` — re-sorted
- `custom_components/connectlife/translations/*.json` — re-sorted, `en.json` keys expanded
- `CLAUDE.md` — document new commands
- `DEVELOPMENT.md` — add translation contribution guide

## Test plan

- [x] `uv run python -m scripts.gen_strings` runs without errors
- [x] `strings.json` retains `[%key:...]` references
- [x] `translations/en.json` has expanded English values (no `[%key:...]`)
- [x] `uv run python -m scripts.sort_translations` is idempotent
- [x] `uv run python -m scripts.validate_mappings` passes
- [x] No keys added or removed in any JSON file (verified programmatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)