### PR TITLE
Add device mapping for 025-1wj100404v0w (WF3S1014-SVW002) and update default

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -31,6 +31,7 @@
 |                      | Washing machine          | 025              | 1wj090660v0w           |
 | WF5S9045BW           | Washing machine          | 025              | 1wj090728v0w           |
 | WD3S9043BB3          | Washing machine          | 025              | 1wj090913v0f           |
+| WF3S1014-SVW002      | Washing machine          | 025              | 1wj100404v0w           |
 | WFQR1014             | Washing machine          | 025              | 1wj100649v0t           |
 | WF3S1043BW3          | Washing machine          | 025              | 1wj100722v0w           |
 | HWFS1015AB           | Washing machine          | 025              | 1wj100923v0f           |

--- a/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
@@ -1,0 +1,81 @@
+# WF3S1014-SVW002-000
+properties:
+  - property: Current_program_phase
+    icon: mdi:state-machine
+    sensor:
+      read_only: true
+      device_class: enum
+      options:
+        0: not_available
+        1: weigh
+        2: prewash
+        3: main_wash
+        4: rinse
+        7: spin-dry
+        8: drying
+        10: finished
+        11: delay_start_waiting
+  - property: Selected_program_ID
+    icon: mdi:playlist-check
+    select:
+      options:
+        1: cotton_dry
+        2: synthetic_dry
+        4: refresh
+        5: anti_allergy
+        6: drum_cleaning
+        7: cotton
+        8: synthetic
+        10: wool
+        11: fast15
+        12: mix
+        14: spin-dry
+        16: baby
+        18: sports
+        20: rinse_spin
+        21: delicates
+        22: clean_dry_60
+        41: power49
+        44: bed_linen
+        45: jeans
+        55: hand_wash
+        90: auto
+  - property: QuickerMode
+    icon: mdi:clock-fast
+    select:
+      options:
+        0: none
+        1: level_1
+        2: level_2
+  - property: DelayEndTime
+    icon: mdi:clock-outline
+    number:
+      min_value: 4
+      max_value: 24
+      device_class: duration
+      unit: h
+  - property: Electricit_consumption_decimal
+    icon: mdi:lightning-bolt
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      device_class: energy
+      unit: kWh
+      multiplier: 0.01
+  - property: Water_consumption_decimal
+    icon: mdi:water
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      device_class: water
+      unit: L
+      multiplier: 0.01
+  - property: ApplicationPermissions
+    icon: mdi:cellphone-wireless
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      device_class: enum
+      options:
+        2: disabled
+        3: enabled

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -86,6 +86,7 @@ properties:
       state_class: total_increasing
   - property: Electricit_consumption_decimal
     icon: mdi:lightning-bolt
+    entity_category: diagnostic
     sensor:
       device_class: energy
       unit: kWh
@@ -591,8 +592,12 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: Spintime_Index
-    hide: true
+    icon: mdi:timer-sand
     entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
   - property: Stain_removal
     hide: true
     entity_category: diagnostic
@@ -873,8 +878,12 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: washing_program_kg
-    hide: true
+    icon: mdi:weight-kilogram
     entity_category: diagnostic
+    sensor:
+      device_class: weight
+      unit: kg
+      read_only: true
   - property: washingtime
     hide: true
     entity_category: diagnostic
@@ -1102,8 +1111,15 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: Spin_speed_rpm
-    hide: true
-    entity_category: diagnostic
+    icon: mdi:rotate-3d-variant
+    select:
+      options:
+        0: none
+        6: "600"
+        8: "800"
+        10: "1000"
+        12: "1200"
+        14: "1400"
   - property: dry_time
     hide: true
     entity_category: diagnostic
@@ -1111,5 +1127,12 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: temperature
-    hide: true
-    entity_category: diagnostic
+    icon: mdi:thermometer-lines
+    select:
+      options:
+        0: cold
+        2: "20"
+        3: "30"
+        4: "40"
+        6: "60"
+        9: "90"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1265,6 +1265,9 @@
       }
     },
     "number": {
+      "delayendtime": {
+        "name": "Delay end time"
+      },
       "delayendtime_hour": {
         "name": "Delayendtime hour"
       },
@@ -1442,6 +1445,14 @@
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "quickermode": {
+        "name": "Quicker mode",
+        "state": {
+          "level_1": "Level 1",
+          "level_2": "Level 2",
+          "none": "None"
         }
       },
       "sand_timer_1_status_cmd": {
@@ -1783,6 +1794,8 @@
       "applicationpermissions": {
         "name": "Application permissions",
         "state": {
+          "disabled": "Disabled",
+          "enabled": "Enabled",
           "granted": "Granted",
           "not_granted": "Not granted"
         }
@@ -3809,6 +3822,9 @@
       },
       "washing_machine_type_max_speed": {
         "name": "Washing machine type max speed"
+      },
+      "washing_program_kg": {
+        "name": "Washing program weight"
       },
       "water_consumption": {
         "name": "Water consumption"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1265,6 +1265,9 @@
       }
     },
     "number": {
+      "delayendtime": {
+        "name": "Delay end time"
+      },
       "delayendtime_hour": {
         "name": "Delayendtime hour"
       },
@@ -1442,6 +1445,14 @@
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "quickermode": {
+        "name": "Quicker mode",
+        "state": {
+          "level_1": "Level 1",
+          "level_2": "Level 2",
+          "none": "None"
         }
       },
       "sand_timer_1_status_cmd": {
@@ -1783,6 +1794,8 @@
       "applicationpermissions": {
         "name": "Application permissions",
         "state": {
+          "disabled": "Disabled",
+          "enabled": "Enabled",
           "granted": "Granted",
           "not_granted": "Not granted"
         }
@@ -3809,6 +3822,9 @@
       },
       "washing_machine_type_max_speed": {
         "name": "Washing machine type max speed"
+      },
+      "washing_program_kg": {
+        "name": "Washing program weight"
       },
       "water_consumption": {
         "name": "Water consumption"


### PR DESCRIPTION
## Summary

Closes #415

- Add device mapping for washing machine WF3S1014-SVW002-000 (device ID `025-1wj100404v0w`)
- Promote commonly duplicated properties to default `025.yaml`
- Update strings and translations

### New feature file (7 overrides)

| Property | Type | Override reason |
|---|---|---|
| `Current_program_phase` | sensor enum | Device-specific phase options |
| `Selected_program_ID` | select | Device-specific program list (21 programs) |
| `QuickerMode` | select | New property unique to this device |
| `DelayEndTime` | number | Writable (default is read-only sensor) |
| `Electricit_consumption_decimal` | sensor | Adds `multiplier: 0.01` |
| `Water_consumption_decimal` | sensor | Unhides with `multiplier: 0.01` |
| `ApplicationPermissions` | sensor enum | Device-specific options |

### Default 025.yaml updates

- **Promote `Spin_speed_rpm`** from hidden to select (defined identically in 10 feature files)
- **Promote `temperature`** from hidden to select (defined identically in 9 feature files)
- **Promote `Spintime_Index`** from hidden to visible duration sensor (case variant of existing `spintime_index`)
- **Promote `washing_program_kg`** from hidden to visible weight sensor
- **Add `entity_category: diagnostic`** to `Electricit_consumption_decimal`

## Test plan

- [x] Validate data dictionaries: `uv run python -m scripts.validate_mappings`
- [x] Verify strings generation: `uv run python -m scripts.gen_strings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)