### PR TITLE
Add combine field to merge split properties into single sensors

### DIFF
--- a/custom_components/connectlife/data_dictionaries/013.yaml
+++ b/custom_components/connectlife/data_dictionaries/013.yaml
@@ -991,24 +991,20 @@ properties:
 - property: Sabbath_mode_status
   unavailable: 0
   binary_sensor: {}
-- property: Sand_timer_1_duration_hours
-  hide: true
-  sensor:
-    device_class: duration
-    unit: h
-    unknown_value: 255
-- property: Sand_timer_1_duration_minutes
-  hide: true
-  sensor:
-    device_class: duration
-    unit: min
-    unknown_value: 255
-- property: Sand_timer_1_duration_seconds
+- property: Sand_timer_1_duration
   hide: true
   sensor:
     device_class: duration
     unit: s
-    unknown_value: 255
+  combine:
+    - property: Sand_timer_1_duration_hours
+      multiplier: 3600
+      unknown_value: 255
+    - property: Sand_timer_1_duration_minutes
+      multiplier: 60
+      unknown_value: 255
+    - property: Sand_timer_1_duration_seconds
+      unknown_value: 255
 - property: Sand_timer_1_end_utc_datetime_bdc_timestamp
   hide: true
   sensor:
@@ -1042,24 +1038,20 @@ properties:
       1: stop
       2: pause
       3: cancel
-- property: Sand_timer_2_duration_hours
-  hide: true
-  sensor:
-    device_class: duration
-    unit: h
-    unknown_value: 255
-- property: Sand_timer_2_duration_minutes
-  hide: true
-  sensor:
-    device_class: duration
-    unit: min
-    unknown_value: 255
-- property: Sand_timer_2_duration_seconds
+- property: Sand_timer_2_duration
   hide: true
   sensor:
     device_class: duration
     unit: s
-    unknown_value: 255
+  combine:
+    - property: Sand_timer_2_duration_hours
+      multiplier: 3600
+      unknown_value: 255
+    - property: Sand_timer_2_duration_minutes
+      multiplier: 60
+      unknown_value: 255
+    - property: Sand_timer_2_duration_seconds
+      unknown_value: 255
 - property: Sand_timer_2_end_utc_datetime_bdc_timestamp
   hide: true
   sensor:
@@ -1093,24 +1085,20 @@ properties:
       1: stop
       2: pause
       3: cancel
-- property: Sand_timer_3_duration_hours
-  hide: true
-  sensor:
-    device_class: duration
-    unit: h
-    unknown_value: 255
-- property: Sand_timer_3_duration_minutes
-  hide: true
-  sensor:
-    device_class: duration
-    unit: min
-    unknown_value: 255
-- property: Sand_timer_3_duration_seconds
+- property: Sand_timer_3_duration
   hide: true
   sensor:
     device_class: duration
     unit: s
-    unknown_value: 255
+  combine:
+    - property: Sand_timer_3_duration_hours
+      multiplier: 3600
+      unknown_value: 255
+    - property: Sand_timer_3_duration_minutes
+      multiplier: 60
+      unknown_value: 255
+    - property: Sand_timer_3_duration_seconds
+      unknown_value: 255
 - property: Sand_timer_3_end_utc_datetime_bdc_timestamp
   hide: true
   sensor:

--- a/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
@@ -20,13 +20,6 @@ properties:
       options:
         0: false
         1: true
-  - property: Electricit_consumption_int
-    icon: mdi:lightning-bolt
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
   - property: Energy_estimate
     icon: mdi:lightning-bolt
     sensor:

--- a/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
@@ -91,14 +91,6 @@ properties:
       12: "1200"
       14: "1400"
 
-- property: Electricit_consumption_int
-  hide: true
-  sensor:
-    read_only: true
-    device_class: energy
-    unit: kWh
-  icon: 'mdi:lightning-bolt'
-
 - property: Energy_estimate
   icon: mdi:lightning-bolt
   # Estimates power consumption (0%-100%) for the selected program and options in 10 percentage steps, based on selected program options.
@@ -176,17 +168,6 @@ properties:
   icon: mdi:heat-wave
   switch:
     device_class: switch
-
-- property: Water_consumption_int
-  icon: mdi:water
-  # Not sure what the value actually represents
-  hide: true
-  sensor:
-    read_only: true
-    state_class: total_increasing
-    device_class: water
-    unit: L
-  #  multiplier: .1 # don't know if needed
 
 - property: dry_time
   # Sample value: 3

--- a/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
@@ -54,22 +54,6 @@ properties:
       max_value: 24
       device_class: duration
       unit: h
-  - property: Electricit_consumption_decimal
-    icon: mdi:lightning-bolt
-    entity_category: diagnostic
-    sensor:
-      read_only: true
-      device_class: energy
-      unit: kWh
-      multiplier: 0.01
-  - property: Water_consumption_decimal
-    icon: mdi:water
-    entity_category: diagnostic
-    sensor:
-      read_only: true
-      device_class: water
-      unit: L
-      multiplier: 0.01
   - property: ApplicationPermissions
     icon: mdi:cellphone-wireless
     entity_category: diagnostic

--- a/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
@@ -26,12 +26,14 @@ properties:
       13: anti_crease
       14: delay
       15: finished
-- property: Electricit_consumption_decimal
+- property: Electricit_consumption
   icon: mdi:lightning-bolt
   sensor:
     read_only: true
     device_class: energy
     unit: kWh
+  combine:
+    - property: Electricit_consumption_decimal
 - property: Energy_estimate
   icon: mdi:lightning-bolt
   sensor:

--- a/custom_components/connectlife/data_dictionaries/025-1wj100923v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100923v0f.yaml
@@ -113,9 +113,3 @@ properties:
       device_class: duration
       unit: min
       read_only: true
-  - property: Water_consumption_int
-    icon: mdi:water
-    sensor:
-      state_class: total_increasing
-      device_class: water
-      unit: L

--- a/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
@@ -35,13 +35,15 @@ properties:
     unit: rpm
     multiplier: 100
   icon: 'mdi:speedometer'
-- property: Electricit_consumption_decimal
+- property: Electricit_consumption
   icon: mdi:lightning-bolt
-  sensor: # Sample value: 27
+  sensor:
     read_only: true
     device_class: energy
     state_class: total
     unit: kWh
+  combine:
+    - property: Electricit_consumption_decimal
 - property: Program_end_to_shutdown_time_in_minutes
   sensor:
     read_only: true

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -77,27 +77,17 @@ properties:
       unit: kWh
       read_only: true
       state_class: total
-  - property: Electricit_consumption_int
+  - property: Electricit_consumption
     icon: mdi:lightning-bolt
     sensor:
       device_class: energy
       unit: kWh
       read_only: true
       state_class: total_increasing
-  - property: Electricit_consumption_decimal
-    icon: mdi:lightning-bolt
-    entity_category: diagnostic
-    sensor:
-      device_class: energy
-      unit: kWh
-      read_only: true
-  - property: Water_consumption_int
-    icon: mdi:water
-    sensor:
-      device_class: water
-      unit: L
-      read_only: true
-      state_class: total_increasing
+    combine:
+      - property: Electricit_consumption_int
+      - property: Electricit_consumption_decimal
+        multiplier: 0.01
   - property: Water_consumption
     icon: mdi:water
     sensor:
@@ -105,6 +95,10 @@ properties:
       unit: L
       read_only: true
       state_class: total_increasing
+    combine:
+      - property: Water_consumption_int
+      - property: Water_consumption_decimal
+        multiplier: 0.01
   - property: Daily_energy_consumption
     icon: mdi:lightning-bolt
     sensor:
@@ -791,9 +785,6 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: WaterLevelIndex
-    hide: true
-    entity_category: diagnostic
-  - property: Water_consumption_decimal
     hide: true
     entity_category: diagnostic
   - property: Water_hardness_setting

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -595,18 +595,28 @@ properties:
   - property: Stain_removal
     hide: true
     entity_category: diagnostic
-  - property: StandardElectricitConsumption_int
+  - property: StandardElectricitConsumption
     hide: true
     entity_category: diagnostic
-  - property: StandardElectricitconsumption_decimal
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+    combine:
+      - property: StandardElectricitConsumption_int
+      - property: StandardElectricitconsumption_decimal
+        multiplier: 0.01
+  - property: StandardWaterConsumption
     hide: true
     entity_category: diagnostic
-  - property: StandardWaterConsumption_decimal
-    hide: true
-    entity_category: diagnostic
-  - property: StandardWaterConsumption_int
-    hide: true
-    entity_category: diagnostic
+    sensor:
+      device_class: water
+      unit: L
+      read_only: true
+    combine:
+      - property: StandardWaterConsumption_int
+      - property: StandardWaterConsumption_decimal
+        multiplier: 0.01
   - property: Temp_Index
     hide: true
     entity_category: diagnostic

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -233,12 +233,17 @@ properties:
   - property: Sound_setting
     # Sample value: 0
     hide: true
-  - property: StandardElectricitConsumption_int
-    # Sample value: 0
+  - property: StandardElectricitConsumption
     hide: true
-  - property: StandardElectricitconsumption_decimal
-    # Sample value: 0
-    hide: true
+    entity_category: diagnostic
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+    combine:
+      - property: StandardElectricitConsumption_int
+      - property: StandardElectricitconsumption_decimal
+        multiplier: 0.01
   - property: Steam
     # Sample value: 0
     hide: true

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -134,10 +134,17 @@ properties:
   - property: DryingWizzard_ClothingType_twelfth
     # Sample value: 0
     hide: true
-  - property: Electricit_consumption_decimal
-    # Sample value: 0
-  - property: Electricit_consumption_int
-    # Sample value: 0
+  - property: Electricit_consumption
+    icon: mdi:lightning-bolt
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+      state_class: total_increasing
+    combine:
+      - property: Electricit_consumption_int
+      - property: Electricit_consumption_decimal
+        multiplier: 0.01
   - property: Favour_program_ID
     # Sample value: 0
   - property: Hard_pairing_commond

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -83,7 +83,8 @@ Note that translation keys must be lowercase!
 
 | Item                       | Type                               | Description                                                                                                                                                                                                                                                                            |
 |----------------------------|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `property`                 | string                             | Name of status/property.                                                                                                                                                                                                                                                               |
+| `property`                 | string                             | Name of status/property. Can also be a virtual name when used with `combine`.                                                                                                                                                                                                          |
+| `combine`                  | list of [CombineSource](#combine)  | Combine multiple source properties into a single sensor value. See [Combine](#combine).                                                                                                                                                                                                |
 | `disable`                  | `true`, `false`                    | If Home Assistant should not create an entity for this property. Defaults to `false`.                                                                                                                                                                                                  |
 | `hide`                     | `true`, `false`                    | If Home Assistant should initially hide the entity for this property. Defaults to `false`, but is set to `true` for unknown properties.                                                                                                                                                |
 | `icon`                     | `mdi:eye`, etc.                    | Icon to use for the entity.                                                                                                                                                                                                                                                            |
@@ -101,6 +102,72 @@ If an entity mapping is not given, the property is mapped to a sensor entity.
 
 It is not necessary to include items with empty values. A [JSON schema](properties-schema.json) is provided so data dictionaries can be
 validated.
+
+## Combine
+
+Some devices split a single value across two properties, e.g., an integer part and a decimal part, or hours and minutes.
+The `combine` field creates a single sensor entity from multiple source properties.
+
+The combined value is the sum of each source value multiplied by its multiplier:
+
+```
+combined_value = sum(source_value * multiplier)
+```
+
+The sensor-level `multiplier` (if set) is applied after the combination.
+
+| Item            | Type    | Description                                                                    |
+|-----------------|---------|--------------------------------------------------------------------------------|
+| `property`      | string  | Name of a source property.                                                     |
+| `multiplier`    | number  | Multiplier for the source value. Default `1`.                                  |
+| `unknown_value` | integer | If the source has this value, it is treated as 0 (same as a missing property). |
+
+Properties referenced as combine sources are automatically disabled (no separate entity is created for them).
+
+Combined sensor entities are implicitly read-only.
+
+The `property` name on the combined entry can be a virtual name that does not exist in the device API. In that case, the
+entity is created when any of the source properties exist.
+
+If the `property` name matches an actual API property (e.g., when a property exists both as a split value on some devices
+and as a single value on others), the entity falls back to the direct API value when no combine sources are available.
+
+### Examples
+
+Combining integer and decimal parts:
+
+```yaml
+- property: Electricit_consumption
+  icon: mdi:lightning-bolt
+  sensor:
+    device_class: energy
+    unit: kWh
+    read_only: true
+    state_class: total_increasing
+  combine:
+    - property: Electricit_consumption_int
+    - property: Electricit_consumption_decimal
+      multiplier: 0.01
+```
+
+Combining hours, minutes, and seconds into a total duration in seconds:
+
+```yaml
+- property: Sand_timer_1_duration
+  hide: true
+  sensor:
+    device_class: duration
+    unit: s
+  combine:
+    - property: Sand_timer_1_duration_hours
+      multiplier: 3600
+      unknown_value: 255
+    - property: Sand_timer_1_duration_minutes
+      multiplier: 60
+      unknown_value: 255
+    - property: Sand_timer_1_duration_seconds
+      unknown_value: 255
+```
 
 ## Type `BinarySensor`
 
@@ -224,15 +291,15 @@ Remember to add [translation strings](#translation-strings) for the options.
 Sensor entities are usually read-only, but this integration provides a `set_value` service that can be applied on
 the `sensor.connectlife` entities, unless the sensor is set to `read_only: true`.
 
-| Item            | Type                                            | Description                                                                                                                                                                                                              |
-|-----------------|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `read_only`     | `true`, `false`                                 | If this property is known to be read-only (prevents `set_value` service).                                                                                                                                                |
+| Item            | Type                                            | Description                                                                                                                                                                                                               |
+|-----------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `read_only`     | `true`, `false`                                 | If this property is known to be read-only (prevents `set_value` service).                                                                                                                                                 |
 | `state_class`   | `measurement`, `total`, `total_increasing`      | Name of any [SensorStateClass enum](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes). For integer properties, defaults to `measurement`. Not allowed when `device_class` is `enum`. |
-| `device_class`  | `duration`, `energy`, `water`, etc.             | Name of any [SensorDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes).                                                                                            |
-| `unit`          | `min`, `kWh`, `L`, etc., _or_ `property.<name>` | Required if `device_class` is set, except not allowed when `device_class` is `aqi`, `ph` or `enum`.                                                                                                                      |
-| `multiplier`    | number, e.g. `0.1` or `10`                      | Required if the unit in the API is not supported in Home Assistant, e.g. hWh can be multiplied by 0.1 to get kWh.                                                                                                        |
-| `options`       | dictionary of integer to string                 | Required if `device_class` is set to `enum`.                                                                                                                                                                             |
-| `unknown_value` | integer                                         | The value used by the API to signal unknown value.                                                                                                                                                                       |
+| `device_class`  | `duration`, `energy`, `water`, etc.             | Name of any [SensorDeviceClass enum](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes).                                                                                             |
+| `unit`          | `min`, `kWh`, `L`, etc., _or_ `property.<name>` | Required if `device_class` is set, except not allowed when `device_class` is `aqi`, `ph` or `enum`.                                                                                                                       |
+| `multiplier`    | number, e.g. `0.1` or `10`                      | Required if the unit in the API is not supported in Home Assistant, e.g. hWh can be multiplied by 0.1 to get kWh.                                                                                                         |
+| `options`       | dictionary of integer to string                 | Required if `device_class` is set to `enum`.                                                                                                                                                                              |
+| `unknown_value` | integer                                         | The value used by the API to signal unknown value.                                                                                                                                                                        |
 
 For device class `enum`, remember to add [translation strings](#translation-strings) for the options.
 
@@ -251,7 +318,7 @@ type `water_heater`, a water heater entity is created for the appliance.
 | Item            | Type                                               | Description                                                                                                                                                                                                                                                  |
 |-----------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `target`        | string                                             | Any  of these [water heater entity](https://developers.home-assistant.io/docs/core/entity/water-heater#properties) attributes: `current_operation`, `current_temperature`, `state`, `target_temperature`, `temperature_unit`, or the special target `is_on`. |
-| `options`       | dictionary of integer to string or boolean         | Required for `current_operation`, `is_away_mode_on`, state`, and`temperature_unit`.                                                                                                                                                                         |
+| `options`       | dictionary of integer to string or boolean         | Required for `current_operation`, `is_away_mode_on`, state`, and`temperature_unit`.                                                                                                                                                                          |
 | `unknown_value` | integer                                            | The value used by the API to signal unknown value.                                                                                                                                                                                                           |
 | `min_value`     | [IntegerOrTemperature](#type-integerortemperature) | Minimum allowed value. Supported for `target_temperature` (temperature).                                                                                                                                                                                     |
 | `max_value`     | [IntegerOrTemperature](#type-integerortemperature) | Maximum allowed value. Supported for `target_temperature` (temperature).                                                                                                                                                                                     |

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -52,6 +52,13 @@
           "description": "Property name",
           "type": "string"
         },
+        "combine": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CombineSource"
+          },
+          "description": "Combine multiple source properties into a single sensor value. The combined value is the sum of each source value times its multiplier."
+        },
         "binary_sensor": {
           "$ref": "#/$defs/BinarySensor"
         },
@@ -342,6 +349,27 @@
           "description": "Map of integer to string or boolean. Required for targets current_operation (string), state (string), temperature_unit (string), and is_away_mode_on (boolean)."
         }
       }
+    },
+    "CombineSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "property": {
+          "type": "string",
+          "description": "Name of a source property to combine."
+        },
+        "multiplier": {
+          "type": "number",
+          "description": "Multiplier for the source value before summing.",
+          "default": 1
+        },
+        "unknown_value": {
+          "$ref": "#/$defs/UnknownValue"
+        }
+      },
+      "required": [
+        "property"
+      ]
     },
     "BinarySensorDeviceClass": {
       "type": "string",

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -426,7 +426,7 @@ class Dictionaries:
                 "No data dictionary found for %s (%s)", appliance.device_nickname, key
             )
 
-        for prop in properties.values():
+        for prop in list(properties.values()):
             if prop.combine:
                 for source in prop.combine:
                     properties[source[PROPERTY]].disable = True

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 import logging
 import pkgutil
+from typing import TypedDict
 
 from connectlife.appliance import ConnectLifeAppliance
 from homeassistant.const import Platform, EntityCategory
@@ -47,12 +48,22 @@ TARGET = "target"
 READ_ONLY = "read_only"
 STATE_CLASS = "state_class"
 SWITCH = "switch"
+COMBINE = "combine"
 UNAVAILABLE = "unavailable"
 ENTITY_CATEGORY = "entity_category"
 UNKNOWN_VALUE = "unknown_value"
 UNIT = "unit"
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _CombineSourceRequired(TypedDict):
+    property: str
+
+
+class CombineSource(_CombineSourceRequired, total=False):
+    multiplier: float
+    unknown_value: int
 
 
 class BinarySensor:
@@ -321,6 +332,7 @@ class Property:
     disable: bool
     unavailable: int | None
     entity_category: EntityCategory | None
+    combine: list[CombineSource] | None
     binary_sensor: BinarySensor
     climate: Climate
     humidifier: Humidifier
@@ -343,6 +355,7 @@ class Property:
             if ENTITY_CATEGORY in entry
             else None
         )
+        self.combine = entry[COMBINE] if COMBINE in entry else None
 
         if Platform.BINARY_SENSOR in entry:
             self.binary_sensor = BinarySensor(self.name, entry[Platform.BINARY_SENSOR])
@@ -412,6 +425,11 @@ class Dictionaries:
             _LOGGER.warning(
                 "No data dictionary found for %s (%s)", appliance.device_nickname, key
             )
+
+        for prop in properties.values():
+            if prop.combine:
+                for source in prop.combine:
+                    properties[source[PROPERTY]].disable = True
 
         dictionary = Dictionary(climate=climate, properties=properties)
         cls.dictionaries[key] = dictionary

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -52,6 +52,19 @@ async def async_setup_entry(
                 appliance.status_list[s],
             )
         )
+        async_add_entities(
+            ConnectLifeStatusSensor(
+                coordinator, appliance, name, prop, dictionary
+            )
+            for name, prop in dictionary.properties.items()
+            if prop.combine
+            and name not in appliance.status_list
+            and hasattr(prop, Platform.SENSOR)
+            and any(
+                src["property"] in appliance.status_list
+                for src in prop.combine
+            )
+        )
     async_add_entities(
         ConnectLifeEnergySensor(coordinator, energy_coordinator, appliance)
         for appliance in coordinator.data.values()
@@ -79,28 +92,26 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.SENSOR)
         self.status = status
-        self.read_only = dd_entry.sensor.read_only
+        self.combine = dd_entry.combine
+        self.read_only = True if self.combine else dd_entry.sensor.read_only
         self.multiplier = dd_entry.sensor.multiplier
         self.unknown_value = dd_entry.sensor.unknown_value
 
         device_class = dd_entry.sensor.device_class
         self.options_map: dict[int, str] | None = None
         options = None
+        current_value = self.coordinator.data[self.device_id].status_list.get(status)
         if device_class == SensorDeviceClass.ENUM and dd_entry.sensor.options is not None:
             self.options_map = dd_entry.sensor.options
             options = list(self.options_map.values())
-        elif device_class is None and isinstance(
-            self.coordinator.data[self.device_id].status_list[status], datetime.datetime
-        ):
+        elif device_class is None and isinstance(current_value, datetime.datetime):
             device_class = SensorDeviceClass.TIMESTAMP
         if device_class == SensorDeviceClass.TIMESTAMP and self.unknown_value is None:
             self.unknown_value = MAX_DATETIME
         state_class = dd_entry.sensor.state_class
         if (
             state_class is None
-            and isinstance(
-                self.coordinator.data[self.device_id].status_list[status], int
-            )
+            and (isinstance(current_value, int) or self.combine)
             and device_class != SensorDeviceClass.ENUM
         ):
             state_class = SensorStateClass.MEASUREMENT
@@ -122,8 +133,32 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
 
     @callback
     def update_state(self):
-        if self.status in self.coordinator.data[self.device_id].status_list:
-            value = self.coordinator.data[self.device_id].status_list[self.status]
+        status_list = self.coordinator.data[self.device_id].status_list
+        if self.combine:
+            value = 0.0
+            has_sources = False
+            for source in self.combine:
+                src_value = status_list.get(source["property"])
+                if src_value is not None and isinstance(src_value, (int, float)):
+                    if "unknown_value" in source and src_value == source["unknown_value"]:
+                        continue
+                    value += src_value * source.get("multiplier", 1)
+                    has_sources = True
+            if has_sources:
+                if value == self.unknown_value:
+                    self._attr_native_value = None
+                else:
+                    if self.multiplier is not None:
+                        value *= self.multiplier
+                    self._attr_native_value = value
+                self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
+                return
+            elif self.status not in status_list:
+                self._attr_native_value = None
+                self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
+                return
+        if self.status in status_list:
+            value = status_list[self.status]
             if self.device_class == SensorDeviceClass.ENUM and self.options_map is not None:
                 if value in self.options_map:
                     value = self.options_map[value]

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2005,11 +2005,8 @@
       "dryopen_defaultspinspeed": {
         "name": "Dry open default spin speed"
       },
-      "electricit_consumption_decimal": {
-        "name": "Electricit consumption decimal"
-      },
-      "electricit_consumption_int": {
-        "name": "Electricit consumption int"
+      "electricit_consumption": {
+        "name": "Electricity consumption"
       },
       "energy": {
         "name": "Energy"
@@ -2379,13 +2376,7 @@
           "stopped": "Stopped"
         }
       },
-      "sand_timer_1_duration_hours": {
-        "name": "Sand timer 1 duration hours"
-      },
-      "sand_timer_1_duration_minutes": {
-        "name": "Sand timer 1 duration minutes"
-      },
-      "sand_timer_1_duration_seconds": {
+      "sand_timer_1_duration": {
         "name": "Sand timer 1 duration"
       },
       "sand_timer_1_end_utc_datetime_bdc_timestamp": {
@@ -2407,13 +2398,7 @@
           "stopped": "Stopped"
         }
       },
-      "sand_timer_2_duration_hours": {
-        "name": "Sand timer 2 duration hours"
-      },
-      "sand_timer_2_duration_minutes": {
-        "name": "Sand timer 2 duration minutes"
-      },
-      "sand_timer_2_duration_seconds": {
+      "sand_timer_2_duration": {
         "name": "Sand timer 2 duration"
       },
       "sand_timer_2_end_utc_datetime_bdc_timestamp": {
@@ -2435,13 +2420,7 @@
           "stopped": "Stopped"
         }
       },
-      "sand_timer_3_duration_hours": {
-        "name": "Sand timer 3 duration hours"
-      },
-      "sand_timer_3_duration_minutes": {
-        "name": "Sand timer 3 duration minutes"
-      },
-      "sand_timer_3_duration_seconds": {
+      "sand_timer_3_duration": {
         "name": "Sand timer 3 duration"
       },
       "sand_timer_3_end_utc_datetime_bdc_timestamp": {
@@ -3829,14 +3808,8 @@
       "water_consumption": {
         "name": "Water consumption"
       },
-      "water_consumption_decimal": {
-        "name": "Water consumption decimal"
-      },
       "water_consumption_in_running_program": {
         "name": "Water consumption in running program"
-      },
-      "water_consumption_int": {
-        "name": "Water consumption"
       },
       "water_hardness": {
         "name": "Water hardness"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2897,6 +2897,12 @@
       "spintime_index": {
         "name": "Spin time index"
       },
+      "standardelectricitconsumption": {
+        "name": "Standard electricity consumption"
+      },
+      "standardwaterconsumption": {
+        "name": "Standard water consumption"
+      },
       "status": {
         "name": "Device status",
         "state": {

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1961,11 +1961,8 @@
       "dryopen_defaultspinspeed": {
         "name": "Standard Schleudergeschwindigkeit"
       },
-      "electricit_consumption_decimal": {
-        "name": "Stromverbrauch (Dezimal)"
-      },
-      "electricit_consumption_int": {
-        "name": "Stromverbrauch (Ganzzahl)"
+      "electricit_consumption": {
+        "name": "Stromverbrauch"
       },
       "energy_consumption_in_running_program": {
         "name": "Energieverbrauch im laufenden Programm"
@@ -2326,14 +2323,8 @@
           "stopped": "Gestoppt"
         }
       },
-      "sand_timer_1_duration_hours": {
-        "name": "Timer 1 Dauer Stunden"
-      },
-      "sand_timer_1_duration_minutes": {
-        "name": "Timer 1 Dauer Minuten"
-      },
-      "sand_timer_1_duration_seconds": {
-        "name": "Timer 1 Dauer Sekunden"
+      "sand_timer_1_duration": {
+        "name": "Timer 1 Dauer"
       },
       "sand_timer_1_end_utc_datetime_bdc_timestamp": {
         "name": "Timer 1 Endzeit UTC"
@@ -2354,14 +2345,8 @@
           "stopped": "Gestoppt"
         }
       },
-      "sand_timer_2_duration_hours": {
-        "name": "Timer 2 Dauer Stunden"
-      },
-      "sand_timer_2_duration_minutes": {
-        "name": "Timer 2 Dauer Minuten"
-      },
-      "sand_timer_2_duration_seconds": {
-        "name": "Timer 2 Dauer Sekunden"
+      "sand_timer_2_duration": {
+        "name": "Timer 2 Dauer"
       },
       "sand_timer_2_end_utc_datetime_bdc_timestamp": {
         "name": "Timer 2 Endzeit UTC"
@@ -2382,14 +2367,8 @@
           "stopped": "Gestoppt"
         }
       },
-      "sand_timer_3_duration_hours": {
-        "name": "Timer 3 Dauer Stunden"
-      },
-      "sand_timer_3_duration_minutes": {
-        "name": "Timer 3 Dauer Minuten"
-      },
-      "sand_timer_3_duration_seconds": {
-        "name": "Timer 3 Dauer Sekunden"
+      "sand_timer_3_duration": {
+        "name": "Timer 3 Dauer"
       },
       "sand_timer_3_end_utc_datetime_bdc_timestamp": {
         "name": "Timer 3 Endzeit UTC"
@@ -3760,14 +3739,8 @@
       "water_consumption": {
         "name": "Wasserverbrauch"
       },
-      "water_consumption_decimal": {
-        "name": "Wasserverbrauch (Dezimal)"
-      },
       "water_consumption_in_running_program": {
         "name": "Wasserverbrauch im laufenden Programm"
-      },
-      "water_consumption_int": {
-        "name": "Wasserverbrauch"
       },
       "water_hardness": {
         "name": "Wasserh\u00e4rte"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2005,11 +2005,8 @@
       "dryopen_defaultspinspeed": {
         "name": "Dry open default spin speed"
       },
-      "electricit_consumption_decimal": {
-        "name": "Electricit consumption decimal"
-      },
-      "electricit_consumption_int": {
-        "name": "Electricit consumption int"
+      "electricit_consumption": {
+        "name": "Electricity consumption"
       },
       "energy": {
         "name": "Energy"
@@ -2379,13 +2376,7 @@
           "stopped": "Stopped"
         }
       },
-      "sand_timer_1_duration_hours": {
-        "name": "Sand timer 1 duration hours"
-      },
-      "sand_timer_1_duration_minutes": {
-        "name": "Sand timer 1 duration minutes"
-      },
-      "sand_timer_1_duration_seconds": {
+      "sand_timer_1_duration": {
         "name": "Sand timer 1 duration"
       },
       "sand_timer_1_end_utc_datetime_bdc_timestamp": {
@@ -2407,13 +2398,7 @@
           "stopped": "Stopped"
         }
       },
-      "sand_timer_2_duration_hours": {
-        "name": "Sand timer 2 duration hours"
-      },
-      "sand_timer_2_duration_minutes": {
-        "name": "Sand timer 2 duration minutes"
-      },
-      "sand_timer_2_duration_seconds": {
+      "sand_timer_2_duration": {
         "name": "Sand timer 2 duration"
       },
       "sand_timer_2_end_utc_datetime_bdc_timestamp": {
@@ -2435,13 +2420,7 @@
           "stopped": "Stopped"
         }
       },
-      "sand_timer_3_duration_hours": {
-        "name": "Sand timer 3 duration hours"
-      },
-      "sand_timer_3_duration_minutes": {
-        "name": "Sand timer 3 duration minutes"
-      },
-      "sand_timer_3_duration_seconds": {
+      "sand_timer_3_duration": {
         "name": "Sand timer 3 duration"
       },
       "sand_timer_3_end_utc_datetime_bdc_timestamp": {
@@ -3829,14 +3808,8 @@
       "water_consumption": {
         "name": "Water consumption"
       },
-      "water_consumption_decimal": {
-        "name": "Water consumption decimal"
-      },
       "water_consumption_in_running_program": {
         "name": "Water consumption in running program"
-      },
-      "water_consumption_int": {
-        "name": "Water consumption"
       },
       "water_hardness": {
         "name": "Water hardness"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2897,6 +2897,12 @@
       "spintime_index": {
         "name": "Spin time index"
       },
+      "standardelectricitconsumption": {
+        "name": "Standard electricity consumption"
+      },
+      "standardwaterconsumption": {
+        "name": "Standard water consumption"
+      },
       "status": {
         "name": "Device status",
         "state": {

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -932,8 +932,8 @@
           "iron": "Seco plancha"
         }
       },
-      "electricit_consumption_int": {
-        "name": "Energia consumida"
+      "electricit_consumption": {
+        "name": "Consumo de electricidad"
       },
       "energy_consumption_in_running_program": {
         "name": "Energia consumida programa en curso"
@@ -1600,9 +1600,6 @@
       },
       "water_consumption_in_running_program": {
         "name": "Agua consumida en programa actual"
-      },
-      "water_consumption_int": {
-        "name": "Agua consumida"
       },
       "zone_number": {
         "name": "N\u00famero de zonas"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1561,9 +1561,6 @@
       "water_consumption_in_running_program": {
         "name": "Waterverbruik in huidig programma"
       },
-      "water_consumption_int": {
-        "name": "Waterverbruik"
-      },
       "water_hardness_setting_status": {
         "name": "Waterhardheid"
       },


### PR DESCRIPTION
## Summary

Closes #410

Some devices split values across two API properties (e.g., `Electricit_consumption_int` + `Electricit_consumption_decimal`, or `Sand_timer_1_duration_hours` + `Sand_timer_1_duration_minutes` + `Sand_timer_1_duration_seconds`). This PR adds a `combine` field to the data dictionary schema that creates a single sensor entity from multiple source properties.

- **New `combine` field**: List of source properties with optional multipliers and unknown_value. Combined value = sum of (source value × multiplier).
- **Auto-disable sources**: Properties referenced as combine sources are automatically disabled — no duplicate entities. Uses `list()` snapshot to avoid mutating `defaultdict` during iteration.
- **Virtual property names**: The combined property name doesn't need to exist in the API. Entity is created when any source property exists in the device's status list.
- **Fallback**: When a combined property name also exists as a direct API value (e.g., `Water_consumption`), falls back to the direct value if no combine sources are available.

### Applied to

- **025.yaml** (washing machine): `Electricit_consumption` (int + decimal × 0.01), `Water_consumption` (int + decimal × 0.01), `StandardElectricitConsumption` (int + decimal × 0.01), `StandardWaterConsumption` (int + decimal × 0.01)
- **030.yaml** (tumble dryer): `Electricit_consumption` (int + decimal × 0.01), `StandardElectricitConsumption` (int + decimal × 0.01)
- **013.yaml** (oven): `Sand_timer_1/2/3_duration` (hours × 3600 + minutes × 60 + seconds, with unknown_value: 255)
- Feature overlay files cleaned up for devices that report values differently

### Not in scope

- Writable combined entities (combine is sensor-only)
- `datetime` combine mode (year/month/day/hour/minute → timestamp) — planned for follow-up
- `string` combine mode (hour + minute → "HH:MM") — planned for follow-up

## Test plan

- [x] Validate YAML: `uv run python -m scripts.validate_mappings`
- [x] Type check: `uv run pyright`
- [x] Verify combined sensor shows correct value for device with both `_int` and `_decimal` properties
- [x] Verify source properties (`_int`, `_decimal`, `_hours`, `_minutes`, `_seconds`) do not create separate entities
- [x] Verify no `dictionary changed size during iteration` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)