### PR TITLE
fix: Add state_class to dryer energy sensor

### DIFF
--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -288,6 +288,7 @@ properties:
       device_class: energy
       unit: Wh
       read_only: true
+      state_class: total_increasing
   - property: error_code
     # Sample value: 0
     hide: true


### PR DESCRIPTION
device_class energy requires state_class total or total_increasing, not the default measurement.