### PR TITLE
fix: Remove duplicate daily_energy_kwh from 026 refrigerator

### DIFF
--- a/custom_components/connectlife/data_dictionaries/026.yaml
+++ b/custom_components/connectlife/data_dictionaries/026.yaml
@@ -129,14 +129,6 @@ properties:
       state_class: total_increasing
       device_class: energy
       unit: kWh
-  - property: daily_energy_kwh
-    hide: true
-    entity_category: diagnostic
-    sensor:
-      read_only: true
-      state_class: total_increasing
-      device_class: energy
-      unit: kWh
   - property: date_display_format_status
     hide: true
   - property: date_format_status


### PR DESCRIPTION
daily_energy_kwh duplicates daily_energy_consumption, causing "ID already exists" errors for refrigerators with both properties.