### PR TITLE
Add reauth flow and bump connectlife to 0.7.2

### DIFF
--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await api.login()
     except LifeConnectAuthError as ex:
-        raise ConfigEntryError from ex
+        raise ConfigEntryAuthFailed from ex
     except LifeConnectError as ex:
         raise ConfigEntryNotReady from ex
     coordinator = ConnectLifeCoordinator(hass, api)

--- a/custom_components/connectlife/config_flow.py
+++ b/custom_components/connectlife/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -74,6 +75,38 @@ class ConnectLifeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication when credentials become invalid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication confirmation."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            reauth_entry = self._get_reauth_entry()
+            data = {**reauth_entry.data, **user_input}
+            try:
+                await validate_input(data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(reauth_entry, data=data)
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
-  "requirements": ["connectlife==0.7.1"],
+  "requirements": ["connectlife==0.7.2"],
   "version": "0.30.0"
 }

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -9,6 +10,13 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "description": "Please re-enter your ConnectLife credentials."
+      },
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",
@@ -9,6 +10,13 @@
       "unknown": "Unexpected error"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        },
+        "description": "Please re-enter your ConnectLife credentials."
+      },
       "user": {
         "data": {
           "password": "Password",

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "connectlife-ha"
-version = "0.27.0"
+version = "0.30.0"
 source = { virtual = "." }
 dependencies = [
     { name = "connectlife" },


### PR DESCRIPTION
## Summary

- Add `async_step_reauth` to config flow so Home Assistant can prompt for new credentials when authentication fails, instead of crashing with `UnknownStep`
- Change initial login in `async_setup_entry` to raise `ConfigEntryAuthFailed` (was `ConfigEntryError`) so the reauth flow is also triggered on startup, not only during coordinator polling
- Bump connectlife to 0.7.2, which fixes transport errors (DNS, timeouts) being misclassified as auth failures (oyvindwe/connectlife#61)

Fixes oyvindwe/connectlife#60

## Test plan
- [x] Tested with test server `--auth_error_rate 25` — reauth flow triggers and re-entering credentials recovers the integration
- [x] Tested transport error recovery — started HA without test server, then started it; integration self-healed without reload
- [x] pyright passes
- [x] Translations generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)