### PR TITLE
Add CI workflow for validation, tests, and type checking

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,12 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv sync
       - run: uv run python -m scripts.gen_strings
-      - run: git diff --exit-code
+      - name: Check strings and translations are up to date
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Strings or translations are out of date. Run 'uv run python -m scripts.gen_strings' and commit the changes."
+            exit 1
+          fi
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,41 @@
+name: Validate mappings and check types
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-mappings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync
+      - run: uv run python -m scripts.validate_mappings
+
+  gen-strings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync
+      - run: uv run python -m scripts.gen_strings
+      - run: git diff --exit-code
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync
+      - run: uv run pytest
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync
+      - run: uv run pyright


### PR DESCRIPTION
## Summary
- Add GitHub Action (`validate.yaml`) triggered on PRs and pushes to main
- Four parallel jobs: validate mappings, verify gen_strings output is up to date, run pytest, run pyright

## Test plan
- [x] Verify all four jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)