### PR TITLE
Show unexpected enum values instead of unknown

### DIFF
--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -54,19 +54,20 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.SELECT, config_entry)
         self.status = status
-        self.options_map = dd_entry.select.options
+        # Copy: unmapped values are added per-entity, avoid leaking to other appliances.
+        self.options_map = dict(dd_entry.select.options)
         self.reverse_options_map = {v: k for k, v in self.options_map.items()}
         self.command_name = (
             dd_entry.select.command_name if dd_entry.select.command_name else status
         )
         self.command_adjust = dd_entry.select.command_adjust
+        self._attr_options = list(self.options_map.values())
         self.entity_description = SelectEntityDescription(
             key=self._attr_unique_id,
             entity_registry_visible_default=not dd_entry.hide,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             translation_key=self.to_translation_key(status),
-            options=list(self.options_map.values()),
             entity_category=dd_entry.entity_category,
         )
         self.update_state()
@@ -78,13 +79,18 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
             if value in self.options_map:
                 value = self.options_map[value]
             else:
-                _LOGGER.warning(
-                    "Got unexpected value %d for %s (%s)",
-                    value,
-                    self.status,
-                    self.nickname,
-                )
-                _value = None
+                str_value = str(value)
+                if str_value not in self._attr_options:
+                    _LOGGER.warning(
+                        "Got unexpected value %s for %s (%s)",
+                        str_value,
+                        self.status,
+                        self.nickname,
+                    )
+                    self.options_map[value] = str_value
+                    self.reverse_options_map[str_value] = value
+                    self._attr_options = [*self._attr_options, str_value]
+                value = str_value
             self._attr_current_option = value
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -99,11 +99,11 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
 
         device_class = dd_entry.sensor.device_class
         self.options_map: dict[int, str] | None = None
-        options = None
         current_value = self.coordinator.data[self.device_id].status_list.get(status)
         if device_class == SensorDeviceClass.ENUM and dd_entry.sensor.options is not None:
-            self.options_map = dd_entry.sensor.options
-            options = list(self.options_map.values())
+            # Copy: unmapped values are added per-entity, avoid leaking to other appliances.
+            self.options_map = dict(dd_entry.sensor.options)
+            self._attr_options = list(self.options_map.values())
         elif device_class is None and isinstance(current_value, datetime.datetime):
             device_class = SensorDeviceClass.TIMESTAMP
         if device_class == SensorDeviceClass.TIMESTAMP and self.unknown_value is None:
@@ -124,7 +124,6 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
             native_unit_of_measurement=to_unit(
                 dd_entry.sensor.unit, appliance=appliance, dictionary=dictionary
             ),
-            options=options,
             state_class=state_class,
             translation_key=self.to_translation_key(status),
             entity_category=dd_entry.entity_category,
@@ -163,13 +162,17 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
                 if value in self.options_map:
                     value = self.options_map[value]
                 elif value != self.unknown_value:
-                    _LOGGER.warning(
-                        "Got unexpected value %d for %s (%s)",
-                        value,
-                        self.status,
-                        self.nickname,
-                    )
-                    value = None
+                    str_value = str(value)
+                    if self._attr_options is not None and str_value not in self._attr_options:
+                        _LOGGER.warning(
+                            "Got unexpected value %s for %s (%s)",
+                            str_value,
+                            self.status,
+                            self.nickname,
+                        )
+                        self.options_map[value] = str_value
+                        self._attr_options = [*self._attr_options, str_value]
+                    value = str_value
             if value == self.unknown_value:
                 self._attr_native_value = None
             else:


### PR DESCRIPTION
## Summary
- Sensor and select entities now propagate unexpected enum values as strings instead of showing "unknown"
- Options list is extended at runtime so HA accepts them, and the warning fires once per new value
- `options_map` is copied per entity to prevent mutations from leaking across appliances sharing the same data dictionary
- Fixes a pre-existing bug in select where unexpected values leaked as raw ints (`_value` vs `value` typo)

Fixes #314

## Test plan
- [x] Type checks pass (`uv run pyright`)
- [x] Tests pass (`uv run pytest tests/`)
- [x] Verified with test server: `Appliance_status=0` and `Current_programphase=11` on a tumble dryer now show as `"0"` and `"11"` instead of "unknown"; warning logged once per value
- [x] Verified with test server: `Dry_Level=99` on a washer-dryer select now shows as `"99"` instead of "unknown"
- [x] Verified with test server: Originally unknown value on select can be selected after changing to a known value


🤖 Generated with [Claude Code](https://claude.com/claude-code)