### PR TITLE
Add frost protection switch for AC

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -137,6 +137,10 @@ properties:
       device_class: voltage
       unit: V
     hide: true
+  - property: t_8heat
+    switch:
+      device_class: switch
+    icon: mdi:snowflake-thermometer
   - property: t_beep
     binary_sensor:
       options:

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -6511,6 +6511,9 @@
       "super_rinse_setting_status": {
         "name": "Super rinse setting status"
       },
+      "t_8heat": {
+        "name": "Frost protection"
+      },
       "t_air": {
         "name": "Air"
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -6511,6 +6511,9 @@
       "super_rinse_setting_status": {
         "name": "Super rinse setting status"
       },
+      "t_8heat": {
+        "name": "Frost protection"
+      },
       "t_air": {
         "name": "Air"
       },


### PR DESCRIPTION
## Summary
- Add `t_8heat` switch to AC data dictionary (009.yaml) as "Frost protection"

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)