### PR TITLE
Remove problem device_class from Alarm_run_selfcleaning

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -81,8 +81,7 @@ properties:
   - property: Alarm_run_selfcleaning
     entity_category: diagnostic
     binary_sensor:
-      device_class: problem
-    icon: mdi:dishwasher-alert
+    icon: mdi:dishwasher
   - property: Alarm_salt_refill
     entity_category: diagnostic
     binary_sensor:


### PR DESCRIPTION
## Summary
- Drops `device_class: problem` from `Alarm_run_selfcleaning` in `015.yaml` and aligns its icon with the other non-alarm dishwasher sensors.
- Closes #244. Follow-up to #260, which missed this property.

## Test plan
- [x] `uv run python -m scripts.validate_mappings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)