### PR TITLE
Map f_electricity to ampere and add AC power/energy sensors

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -1,5 +1,25 @@
 # Portable air conditioner
 properties:
+- property: f_electricity
+  sensor:
+    device_class: current
+    unit: A
+    read_only: true
+  hide: true
+- property: f_power_consumption
+  sensor:
+    device_class: energy
+    unit: kWh
+    read_only: true
+    state_class: total_increasing
+  icon: mdi:lightning-bolt
+- property: f_power_display
+  sensor:
+    device_class: power
+    unit: W
+    read_only: true
+    state_class: measurement
+  icon: mdi:flash
 - property: f_temp_in
   icon: mdi:temp
   climate:

--- a/custom_components/connectlife/data_dictionaries/007.yaml
+++ b/custom_components/connectlife/data_dictionaries/007.yaml
@@ -20,9 +20,29 @@ properties:
   - property: f_e_wetsensor
     binary_sensor:
       device_class: problem
+  - property: f_electricity
+    sensor:
+      device_class: current
+      unit: A
+      read_only: true
+    hide: true
   - property: f_humidity
     humidifier:
       target: current_humidity
+  - property: f_power_consumption
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+      state_class: total_increasing
+    icon: mdi:lightning-bolt
+  - property: f_power_display
+    sensor:
+      device_class: power
+      unit: W
+      read_only: true
+      state_class: measurement
+    icon: mdi:flash
   - property: t_fan_speed
     icon: mdi:fan
     select:

--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -174,10 +174,10 @@ properties:
     disable: true
   - property: f_electricity
     sensor:
-      device_class: energy
+      device_class: current
+      unit: A
       read_only: true
-      unit: kWh
-      state_class: total_increasing
+    hide: true
   - property: f_humidity
     climate:
       target: current_humidity

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -120,6 +120,12 @@ properties:
     disable: true
   - property: f_ecm
     disable: true
+  - property: f_electricity
+    sensor:
+      device_class: current
+      unit: A
+      read_only: true
+    hide: true
   - property: f_heat_qvalue
     sensor:
       unit: BTU/h
@@ -129,6 +135,20 @@ properties:
     climate:
       target: current_humidity
       unknown_value: 128
+  - property: f_power_consumption
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+      state_class: total_increasing
+    icon: mdi:lightning-bolt
+  - property: f_power_display
+    sensor:
+      device_class: power
+      unit: W
+      read_only: true
+      state_class: measurement
+    icon: mdi:flash
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -3093,10 +3093,16 @@
         "name": "Cooling"
       },
       "f_electricity": {
-        "name": "Electricity"
+        "name": "Current"
       },
       "f_heat_qvalue": {
         "name": "Heating"
+      },
+      "f_power_consumption": {
+        "name": "Energy consumption"
+      },
+      "f_power_display": {
+        "name": "Power"
       },
       "f_votage": {
         "name": "Measured grid voltage"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -3093,10 +3093,16 @@
         "name": "Cooling"
       },
       "f_electricity": {
-        "name": "Electricity"
+        "name": "Current"
       },
       "f_heat_qvalue": {
         "name": "Heating"
+      },
+      "f_power_consumption": {
+        "name": "Energy consumption"
+      },
+      "f_power_display": {
+        "name": "Power"
       },
       "f_votage": {
         "name": "Measured grid voltage"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1965,7 +1965,7 @@
         "name": "Koeling"
       },
       "f_electricity": {
-        "name": "Elektriciteit"
+        "name": "Stroom"
       },
       "f_heat_qvalue": {
         "name": "Verwarming"


### PR DESCRIPTION
Covers:
- Portable AC (006)
- Dehumidifier (007)
- Window AC (008)
- Split AC (009)

## Changes
- Correct `f_electricity` from energy (kWh) to current (A).
- Add previously-unmapped `f_power_display` (W).
- Add previously-unmapped `f_power_consumption` (kWh).

## ⚠️ Breaking
For users whose devices report any of these properties: the device class and/or unit change, so existing history must be repaired at https://my.home-assistant.io/redirect/developer_statistics/ after updating.

## Test plan
- [x] Confirm new `Power` (W) and `Energy consumption` (kWh) sensors appear for devices that report the underlying properties (AC feature codes 100-103, 114-124, 128, 129).
- [x] Confirm `Current` sensor (formerly `Electricity`) now reads in A rather than kWh on 008 devices.
- [x] Confirm sensor doesn't appear for devices/features that don't report the property (e.g. 009-104/106/109).
- [x] Repair long-term statistics on an 008 device that had the old kWh sensor.

Fixes #174, #187, #291, #297.