### PR TITLE
Add electrical sensors for heat pump (016)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/016.yaml
+++ b/custom_components/connectlife/data_dictionaries/016.yaml
@@ -1,4 +1,23 @@
 properties:
+  - property: f_electricity
+    sensor:
+      device_class: current
+      unit: A
+      read_only: true
+    hide: true
+  - property: f_power_consumption
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+      state_class: total_increasing
+    icon: mdi:lightning-bolt
+  - property: f_votage
+    sensor:
+      device_class: voltage
+      unit: V
+      read_only: true
+    hide: true
   - property: f_water_tank_temp
     water_heater:
       target: current_temperature


### PR DESCRIPTION
## Changes
- Map `f_electricity` to current (A).
- Map `f_votage` to voltage (V).
- Map `f_power_consumption` to energy (kWh).

## ⚠️ Breaking
For users whose heat pumps report any of these properties: the device class and/or unit change from the previous fall-through behaviour, so existing history must be repaired at https://my.home-assistant.io/redirect/developer_statistics/ after updating.

Related: #454.