### PR TITLE
Feat: mapped new status for 025 and mapped error code.

### DIFF
--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -20,6 +20,7 @@ properties:
         1: standby
         2: running
         3: paused
+        4: alarm
   - property: Detergent_display
     icon: mdi:spray
     binary_sensor:
@@ -822,8 +823,14 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: error_code
-    hide: true
+    icon: mdi:alert-circle-outline
     entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: none
+        100: unbalance_alarm
   - property: hottime
     hide: true
     entity_category: diagnostic

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2967,7 +2967,11 @@
         "name": "Error 9_1"
       },
       "error_code": {
-        "name": "Error code"
+        "name": "Error code",
+        "state": {
+          "none": "None",
+          "unbalance_alarm": "Unbalance alarm"
+        }
       },
       "error_f10": {
         "name": "Error f10"
@@ -3479,6 +3483,7 @@
       "machine_status": {
         "name": "Machine status",
         "state": {
+          "alarm": "Alarm",
           "off": "Off",
           "paused": "Paused",
           "running": "Running",

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1873,7 +1873,11 @@
         "name": "Reale Umgebungstemperatur"
       },
       "error_code": {
-        "name": "Fehlercode"
+        "name": "Fehlercode",
+        "state": {
+          "none": "Kein Fehler",
+          "unbalance_alarm": "Unwucht-Alarm"
+        }
       },
       "error_read_out_1_code": {
         "name": "Fehlercode 1 auslesen"
@@ -2037,6 +2041,7 @@
       "machine_status": {
         "name": "Maschinenstatus",
         "state": {
+          "alarm": "Alarm",
           "off": "Aus",
           "paused": "Pausiert",
           "running": "L\u00e4uft",

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2967,7 +2967,11 @@
         "name": "Error 9_1"
       },
       "error_code": {
-        "name": "Error code"
+        "name": "Error code",
+        "state": {
+          "none": "None",
+          "unbalance_alarm": "Unbalance alarm"
+        }
       },
       "error_f10": {
         "name": "Error f10"
@@ -3479,6 +3483,7 @@
       "machine_status": {
         "name": "Machine status",
         "state": {
+          "alarm": "Alarm",
           "off": "Off",
           "paused": "Paused",
           "running": "Running",

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -893,7 +893,11 @@
         "name": "Humedad ambiental"
       },
       "error_code": {
-        "name": "C\u00f3digo error"
+        "name": "C\u00f3digo error",
+        "state": {
+          "none": "Ninguno",
+          "unbalance_alarm": "Alarma de desequilibrio"
+        }
       },
       "extradry_setting": {
         "name": "Configuraci\u00f3n extra-seco"
@@ -942,6 +946,7 @@
       "machine_status": {
         "name": "Estado Maquina",
         "state": {
+          "alarm": "Alarma",
           "off": "Apagada",
           "running": "En Marcha",
           "standby": "Suspendida"

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -197,7 +197,11 @@
         "name": "Estimation \u00e9nerg\u00e9tique"
       },
       "error_code": {
-        "name": "Code erreur"
+        "name": "Code erreur",
+        "state": {
+          "none": "Aucun",
+          "unbalance_alarm": "Alarme d\u00e9s\u00e9quilibre"
+        }
       },
       "filterclean_washflag": {
         "name": "Indicateur nettoyage filtre"
@@ -218,7 +222,10 @@
         "name": "Dernier cycle"
       },
       "machine_status": {
-        "name": "\u00c9tat machine"
+        "name": "\u00c9tat machine",
+        "state": {
+          "alarm": "Alarme"
+        }
       },
       "mainwashtimeuseindex": {
         "name": "Index dur\u00e9e lavage"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1938,7 +1938,11 @@
         "name": "Werkelijke omgevingstemperatuur"
       },
       "error_code": {
-        "name": "Foutmelding"
+        "name": "Foutmelding",
+        "state": {
+          "none": "Geen",
+          "unbalance_alarm": "Onbalans alarm"
+        }
       },
       "error_read_out_1_code": {
         "name": "Foutcode uitlezen 1"
@@ -2105,6 +2109,7 @@
       "machine_status": {
         "name": "Machine status",
         "state": {
+          "alarm": "Alarm",
           "off": "Uit",
           "paused": "Gepauzeerd",
           "running": "Draait",


### PR DESCRIPTION
Hi @oyvindwe,

I received today an error code, I decided to map it to be easier to understand, and I noticed that the machine status changed to 4 as well, that wasn't mapped. I mapped to the same name as in the native app `Alarm`. 

Let me know if you think that need any change.