### PR TITLE
Update 015 (dishwasher) mappings and split labels per model

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -1,1 +1,46 @@
-# Uses default mappings
+# ASKO dishwashers (older feature code; also used pre-firmware-update on the
+# same device that later identifies as 015-dishwasher-60.2)
+#
+# See 015-dishwasher-60.2.yaml for the per-program mode availability notes.
+properties:
+  - property: Selected_program_id_status
+    select:
+      options:
+        0: eco
+        1: auto
+        2: intensive
+        3: quick_pro
+        4: time_program
+        5: hygiene
+        6: rinse_and_hold
+        7: self_cleaning
+      command:
+        name: Selected_program_id
+    icon: mdi:clipboard-list
+  - property: Selected_program_mode
+    select:
+      options:
+        0: "not_available"
+        2: "normal"
+        4: "speed"
+        5: "night"
+      command:
+        name: Program_mode
+        adjust: 1
+    icon: mdi:cube-outline
+  - property: Time_program_set_duration_status
+    select:
+      options:
+        0: "not_available"
+        1: "not_set"
+        2: "15_min"
+        3: "30_min"
+        4: "45_min"
+        5: "1_h"
+        6: "1_h_30_min"
+        7: "2_h"
+        8: "2_h_30_min"
+      command:
+        name: Time_program_set_duration
+        adjust: 1
+    icon: mdi:timer-outline

--- a/custom_components/connectlife/data_dictionaries/015-1ux0s1005k15.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-1ux0s1005k15.yaml
@@ -1,1 +1,28 @@
-# Uses default mappings
+# Hisense WD16-E722BXi / HSAP16FB (Gorenje-style program labels, per PR #360)
+properties:
+  - property: Selected_program_id_status
+    select:
+      options:
+        0: auto
+        1: eco
+        2: one_hour
+        3: intensive
+        4: glass
+        5: hygiene
+        6: night
+        7: clean
+      command:
+        name: Selected_program_id
+    icon: mdi:clipboard-list
+  - property: Selected_program_mode
+    select:
+      options:
+        0: "0"
+        1: "1"
+        2: normal
+        3: "3"
+        4: fast
+      command:
+        name: Program_mode
+        adjust: 1
+    icon: mdi:cube-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
@@ -1,1 +1,28 @@
-# Uses default mappings
+# Gorenje GS673B60W
+properties:
+  - property: Selected_program_id_status
+    select:
+      options:
+        0: auto
+        1: eco
+        2: one_hour
+        3: intensive
+        4: glass
+        5: hygiene
+        6: night
+        7: clean
+      command:
+        name: Selected_program_id
+    icon: mdi:clipboard-list
+  - property: Selected_program_mode
+    select:
+      options:
+        0: "0"
+        1: "1"
+        2: normal
+        3: "3"
+        4: fast
+      command:
+        name: Program_mode
+        adjust: 1
+    icon: mdi:cube-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
@@ -1,1 +1,28 @@
-# Uses default mappings
+# Pelgrim GVWC330L
+properties:
+  - property: Selected_program_id_status
+    select:
+      options:
+        0: auto
+        1: eco
+        2: one_hour
+        3: intensive
+        4: glass
+        5: hygiene
+        6: night
+        7: clean
+      command:
+        name: Selected_program_id
+    icon: mdi:clipboard-list
+  - property: Selected_program_mode
+    select:
+      options:
+        0: "0"
+        1: "1"
+        2: normal
+        3: "3"
+        4: fast
+      command:
+        name: Program_mode
+        adjust: 1
+    icon: mdi:cube-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -1,1 +1,52 @@
-# Uses default mappings
+# ASKO dishwasher (firmware-updated variant of 015-000)
+#
+# Mode availability observed per program:
+#   Auto / Hygiene / Rinse and hold / Self cleaning: only normal
+#   Eco / Intensive: normal, speed, night
+#   Quick pro: normal, speed
+#   Time program: no mode; set duration via Time_program_set_duration_status instead
+#
+# Modes "none", "green", "intensive", "uv", "heat_boost", "storage" were
+# never offered by this device — excluded from the select.
+properties:
+  - property: Selected_program_id_status
+    select:
+      options:
+        0: eco
+        1: auto
+        2: intensive
+        3: quick_pro
+        4: time_program
+        5: hygiene
+        6: rinse_and_hold
+        7: self_cleaning
+      command:
+        name: Selected_program_id
+    icon: mdi:clipboard-list
+  - property: Selected_program_mode
+    select:
+      options:
+        0: "not_available"
+        2: "normal"
+        4: "speed"
+        5: "night"
+      command:
+        name: Program_mode
+        adjust: 1
+    icon: mdi:cube-outline
+  - property: Time_program_set_duration_status
+    select:
+      options:
+        0: "not_available"
+        1: "not_set"
+        2: "15_min"
+        3: "30_min"
+        4: "45_min"
+        5: "1_h"
+        6: "1_h_30_min"
+        7: "2_h"
+        8: "2_h_30_min"
+      command:
+        name: Time_program_set_duration
+        adjust: 1
+    icon: mdi:timer-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
@@ -1,1 +1,43 @@
-# Uses default mappings
+# Assumed ASKO family (untested); labels copied from 015-dishwasher-60.2
+properties:
+  - property: Selected_program_id_status
+    select:
+      options:
+        0: eco
+        1: auto
+        2: intensive
+        3: quick_pro
+        4: time_program
+        5: hygiene
+        6: rinse_and_hold
+        7: self_cleaning
+      command:
+        name: Selected_program_id
+    icon: mdi:clipboard-list
+  - property: Selected_program_mode
+    select:
+      options:
+        0: "not_available"
+        2: "normal"
+        4: "speed"
+        5: "night"
+      command:
+        name: Program_mode
+        adjust: 1
+    icon: mdi:cube-outline
+  - property: Time_program_set_duration_status
+    select:
+      options:
+        0: "not_available"
+        1: "not_set"
+        2: "15_min"
+        3: "30_min"
+        4: "45_min"
+        5: "1_h"
+        6: "1_h_30_min"
+        7: "2_h"
+        8: "2_h_30_min"
+      command:
+        name: Time_program_set_duration
+        adjust: 1
+    icon: mdi:timer-outline

--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -98,6 +98,7 @@ properties:
       device_class: duration
       unit: min
   - property: Auto_dose_quantity_setting_status
+    entity_category: config
     unavailable: 0
     select:
       options:
@@ -116,6 +117,7 @@ properties:
       device_class: problem
     icon: mdi:dishwasher-alert
   - property: Auto_dose_setting_status
+    entity_category: config
     unavailable: 0
     switch:
       "off": 1
@@ -124,6 +126,7 @@ properties:
         name: Auto_dose_setting
         adjust: 1
   - property: Child_lock
+    entity_category: config
     unavailable: 0
     switch:
       "off": 1
@@ -382,15 +385,18 @@ properties:
     icon: mdi:information
     hide: true
   - property: Feedback_volumen_setting_status
-    sensor:
-      device_class: enum
+    entity_category: config
+    unavailable: 0
+    select:
       options:
-        1: mute
-        2: low
-        3: mid
-        4: high
+        1: "mute"
+        2: "low"
+        3: "mid"
+        4: "high"
+      command:
+        name: Feedback_volumen_setting
+        adjust: 1
     icon: mdi:volume-low
-    hide: true
   - property: Fill_salt
     binary_sensor:
       device_class: problem
@@ -405,6 +411,7 @@ properties:
   - property: High_temperature_status
     hide: true
   - property: Interior_light_at_power_off_setting_status
+    entity_category: config
     unavailable: 0
     switch:
       "off": 1
@@ -430,18 +437,24 @@ properties:
   - property: MDO_on_demand_allowed
     hide: true
   - property: Notification_volumen_setting_status
-    sensor:
-      read_only: true
-    icon: mdi:information
-    hide: true
+    entity_category: config
+    unavailable: 0
+    select:
+      options:
+        1: "mute"
+        2: "low"
+        3: "mid"
+        4: "high"
+      command:
+        name: Notification_volumen_setting
+        adjust: 1
+    icon: mdi:volume-low
   - property: Odor_control_setting
+    entity_category: config
     unavailable: 0
     switch:
       "off": 1
       "on": 2
-      command:
-        name: Oder_control_setting
-        adjust: 1
   - property: Pressure_calibration_setting_status
     sensor:
       read_only: true
@@ -450,25 +463,32 @@ properties:
   - property: Remote_control_monitoring_set_commands
     hide: true
   - property: Remote_control_monitoring_set_commands_actions
+    unavailable: 0
+    binary_sensor:
+      options:
+        1: off
+        2: on
     hide: true
   - property: Rinse_aid_refill
     binary_sensor:
       device_class: problem
     icon: mdi:flare
   - property: Rinse_aid_setting_status
-    sensor:
-      device_class: enum
+    entity_category: config
+    unavailable: 0
+    select:
       options:
-        0: "-2"
-        1: "-1"
+        1: "tab"
         2: "0"
         3: "1"
         4: "2"
         5: "3"
         6: "4"
         7: "5"
+      command:
+        name: Rinse_aid_setting
+        adjust: 1
     icon: mdi:white-balance-sunny
-    hide: true
   - property: Sani_Lock
     hide: true
   - property: Sani_Lock_allowed
@@ -487,28 +507,12 @@ properties:
   - property: Selected_program_extra_drying_function
     hide: true
   - property: Selected_program_id_status
+    # Varies per model. Override as select in feature specific file.
     sensor:
-      device_class: enum
-      options:
-        0: auto
-        1: eco
-        2: one_hour
-        3: intensive
-        4: glass
-        5: hygiene
-        6: night
-        7: clean
     icon: mdi:clipboard-list
   - property: Selected_program_mode
+    # Varies per model. Override as select in feature specific file.
     sensor:
-      device_class: enum
-      options:
-        0: "0"
-        1: "1"
-        2: normal
-        3: "3"
-        4: fast
-        7: "7"
     icon: mdi:cube-outline
   - property: Selected_program_storage_function
     hide: true
@@ -539,6 +543,7 @@ properties:
   - property: Super_rinse_on_demand_allowed
     hide: true
   - property: Super_rinse_setting_status
+    entity_category: config
     unavailable: 0
     switch:
       "off": 1
@@ -549,6 +554,7 @@ properties:
   - property: Super_rinse_status
     hide: true
   - property: Tab_setting_status
+    entity_category: config
     unavailable: 0
     switch:
       "off": 1
@@ -594,8 +600,8 @@ properties:
     hide: true
     icon: mdi:water-outline
   - property: Water_hardness_setting_status
-    sensor:
-      device_class: enum
+    entity_category: config
+    select:
       options:
         0: not_set
         1: "0.0-0.9 mmol/L"
@@ -608,8 +614,10 @@ properties:
         8: "5.3-7.0 mmol/L"
         9: "7.1-8.8 mmol/L"
         10: "8.9+ mmol/L"
+      command:
+        name: Water_hardness_setting
+        adjust: 1
     icon: mdi:water-opacity
-    hide: true
   - property: Water_inlet_setting_status
     sensor:
       read_only: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1393,6 +1393,15 @@
           "none": "None"
         }
       },
+      "feedback_volumen_setting_status": {
+        "name": "Feedback volume",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "mid": "Mid",
+          "mute": "Mute"
+        }
+      },
       "language_status": {
         "name": "Language",
         "state": {
@@ -1402,6 +1411,15 @@
       },
       "motorlevel": {
         "name": "Motor level"
+      },
+      "notification_volumen_setting_status": {
+        "name": "Notification volume",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "mid": "Mid",
+          "mute": "Mute"
+        }
       },
       "oven_temperature_unit": {
         "name": "Oven temperature unit",
@@ -1416,6 +1434,12 @@
           "level_1": "Level 1",
           "level_2": "Level 2",
           "none": "None"
+        }
+      },
+      "rinse_aid_setting_status": {
+        "name": "Rinse aid",
+        "state": {
+          "tab": "TAB"
         }
       },
       "sand_timer_1_status_cmd": {
@@ -1495,6 +1519,33 @@
           "towels": "Towels",
           "wash_and_dry_49": "Wash and dry 49",
           "wool": "Wool"
+        }
+      },
+      "selected_program_id_status": {
+        "name": "Program",
+        "state": {
+          "auto": "Auto",
+          "clean": "Clean",
+          "eco": "Eco",
+          "glass": "Glass",
+          "hygiene": "Hygiene",
+          "intensive": "Intensive",
+          "night": "Night",
+          "one_hour": "One hour",
+          "quick_pro": "Quick pro",
+          "rinse_and_hold": "Rinse and hold",
+          "self_cleaning": "Self cleaning",
+          "time_program": "Time program"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Mode",
+        "state": {
+          "fast": "Fast",
+          "night": "Night",
+          "normal": "Normal",
+          "not_available": "Not available",
+          "speed": "Speed"
         }
       },
       "softener": {
@@ -1702,6 +1753,20 @@
           "24h": "24h"
         }
       },
+      "time_program_set_duration_status": {
+        "name": "Time program duration",
+        "state": {
+          "15_min": "00:15",
+          "1_h": "01:00",
+          "1_h_30_min": "01:30",
+          "2_h": "02:00",
+          "2_h_30_min": "02:30",
+          "30_min": "00:30",
+          "45_min": "00:45",
+          "not_available": "Not available",
+          "not_set": "Not set"
+        }
+      },
       "volume": {
         "name": "Volume"
       },
@@ -1715,6 +1780,12 @@
       },
       "water_hardness": {
         "name": "Water hardness"
+      },
+      "water_hardness_setting_status": {
+        "name": "Water hardness setting status",
+        "state": {
+          "not_set": "Not set"
+        }
       }
     },
     "sensor": {
@@ -3122,15 +3193,6 @@
       "favour_program_id": {
         "name": "Favour program ID"
       },
-      "feedback_volumen_setting_status": {
-        "name": "Feedback volume",
-        "state": {
-          "high": "High",
-          "low": "Low",
-          "mid": "Mid",
-          "mute": "Mute"
-        }
-      },
       "filter_alarm_time": {
         "name": "Filter alarm time"
       },
@@ -3628,9 +3690,6 @@
       "notification_sounds_volume_setting": {
         "name": "Notification sounds volume setting"
       },
-      "notification_volumen_setting_status": {
-        "name": "Notification volume"
-      },
       "ntc_sensor_1": {
         "name": "NTC sensor 1"
       },
@@ -3955,9 +4014,6 @@
       "rgb_normal_mode_r_value": {
         "name": "RGB normal mode R value"
       },
-      "rinse_aid_setting_status": {
-        "name": "Rinse aid"
-      },
       "rinse_flag": {
         "name": "Rinse flag"
       },
@@ -4228,25 +4284,17 @@
       "selected_program_id_status": {
         "name": "Selected program",
         "state": {
-          "auto": "Auto",
           "baby": "Baby",
-          "clean": "Clean",
           "color": "Color",
           "down_feathers": "Down feathers",
           "draining": "Draining",
           "drum_cleaning": "Drum Cleaning",
-          "eco": "Eco",
           "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra Hygiene",
           "fast_20": "Fast 20'",
-          "glass": "Glass",
-          "hygiene": "Hygiene",
-          "intensive": "Intensive",
           "intensive_59_32": "Intensive 59'/32'",
           "mix_synthetic": "Mix/Synthetic",
-          "night": "Night",
           "no_program_selected": "No program selected",
-          "one_hour": "1 hour",
           "pet_hair_removal": "Pet hair removal",
           "rinsing_softening": "Rinsing & Softening",
           "shirts": "Shirts",
@@ -4266,11 +4314,7 @@
         "name": "Selected program lower wash function"
       },
       "selected_program_mode": {
-        "name": "Selected program mode",
-        "state": {
-          "fast": "Fast",
-          "normal": "Normal"
-        }
+        "name": "Selected program mode"
       },
       "selected_program_mode2_status": {
         "name": "Selected program mode 2 status"
@@ -5939,7 +5983,7 @@
         "name": "Time auto flag"
       },
       "time_program_set_duration_status": {
-        "name": "Time program set duration status"
+        "name": "Time program duration"
       },
       "time_program_set_time_status": {
         "name": "Time program set time status"
@@ -6287,10 +6331,7 @@
         "name": "Water hardness setting"
       },
       "water_hardness_setting_status": {
-        "name": "Water hardness",
-        "state": {
-          "not_set": "Not set"
-        }
+        "name": "Water hardness"
       },
       "water_heat_switch": {
         "name": "Water heat switch"
@@ -6470,7 +6511,7 @@
         "name": "Interior light"
       },
       "interior_light_at_power_off_setting_status": {
-        "name": "Interior light at power off setting status"
+        "name": "Interior light at power off"
       },
       "key_sound": {
         "name": "Key sound"
@@ -6515,7 +6556,7 @@
         "name": "Step pre bake status"
       },
       "super_rinse_setting_status": {
-        "name": "Super rinse setting status"
+        "name": "Super rinse"
       },
       "t_8heat": {
         "name": "Frost protection"
@@ -6548,7 +6589,7 @@
         "name": "AI"
       },
       "tab_setting_status": {
-        "name": "Tab setting status"
+        "name": "Detergent TAB"
       },
       "time_save": {
         "name": "Time save"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1362,6 +1362,15 @@
           "none": "Keine"
         }
       },
+      "feedback_volumen_setting_status": {
+        "name": "Feedback-Lautst\u00e4rke",
+        "state": {
+          "high": "Hoch",
+          "low": "Niedrig",
+          "mid": "Mittel",
+          "mute": "Stumm"
+        }
+      },
       "language_status": {
         "name": "Sprache",
         "state": {
@@ -1372,11 +1381,26 @@
       "motorlevel": {
         "name": "Motorleistung"
       },
+      "notification_volumen_setting_status": {
+        "name": "Benachrichtigungslautst\u00e4rke",
+        "state": {
+          "high": "Hoch",
+          "low": "Niedrig",
+          "mid": "Mittel",
+          "mute": "Stumm"
+        }
+      },
       "oven_temperature_unit": {
         "name": "Ofen Temperatureinheit",
         "state": {
           "celsius": "Celsius",
           "fahrenheit": "Fahrenheit"
+        }
+      },
+      "rinse_aid_setting_status": {
+        "name": "Klarsp\u00fcler",
+        "state": {
+          "tab": "TAB"
         }
       },
       "sand_timer_1_status_cmd": {
@@ -1443,6 +1467,32 @@
           "towels": "Handt\u00fccher",
           "wash_and_dry_49": "Waschen und Trocknen 49",
           "wool": "Wolle"
+        }
+      },
+      "selected_program_id_status": {
+        "name": "Programm",
+        "state": {
+          "auto": "Automatisch",
+          "clean": "Reinigung",
+          "eco": "Eco",
+          "glass": "Glas",
+          "hygiene": "Hygiene",
+          "intensive": "Intensiv",
+          "night": "Nacht",
+          "one_hour": "1 Stunde",
+          "quick_pro": "Quick pro",
+          "rinse_and_hold": "Sp\u00fclen & Warten",
+          "self_cleaning": "Selbstreinigung",
+          "time_program": "Zeitprogramm"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Programm Modus",
+        "state": {
+          "fast": "Schnell",
+          "night": "Nacht",
+          "normal": "Normal",
+          "speed": "Schnell"
         }
       },
       "softener": {
@@ -1643,6 +1693,12 @@
           "24h": "24h"
         }
       },
+      "time_program_set_duration_status": {
+        "name": "Zeitprogrammdauer",
+        "state": {
+          "not_set": "Nicht festgelegt"
+        }
+      },
       "volume": {
         "name": "Lautst\u00e4rke"
       },
@@ -1656,6 +1712,12 @@
       },
       "water_hardness": {
         "name": "Wasserh\u00e4rte"
+      },
+      "water_hardness_setting_status": {
+        "name": "Wasserh\u00e4rte",
+        "state": {
+          "not_set": "Nicht eingestellt"
+        }
       }
     },
     "sensor": {
@@ -1911,15 +1973,6 @@
       "fan_sequence_setting_status": {
         "name": "L\u00fcftersequenz"
       },
-      "feedback_volumen_setting_status": {
-        "name": "Feedback-Lautst\u00e4rke",
-        "state": {
-          "high": "Hoch",
-          "low": "Niedrig",
-          "mid": "Mittel",
-          "mute": "Stumm"
-        }
-      },
       "filter_state": {
         "name": "Filterzustand"
       },
@@ -2087,9 +2140,6 @@
       "night_mode_on_minute": {
         "name": "Nachtmodus Ein Minute"
       },
-      "notification_volumen_setting_status": {
-        "name": "Benachrichtigungslautst\u00e4rke"
-      },
       "order_time_minimum_hour": {
         "name": "Mindestbestellzeit in Stunden"
       },
@@ -2143,9 +2193,6 @@
       },
       "remaining_time_of_selected_program": {
         "name": "Verbleibende Zeit des gew\u00e4hlten Programms"
-      },
-      "rinse_aid_setting_status": {
-        "name": "Klarsp\u00fcler"
       },
       "rinsenum": {
         "name": "Anzahl der Sp\u00fclg\u00e4nge"
@@ -2279,25 +2326,17 @@
       "selected_program_id_status": {
         "name": "Programm",
         "state": {
-          "auto": "Automatisch",
           "baby": "Baby",
-          "clean": "Reinigung",
           "color": "Farbig",
           "down_feathers": "Daunenfedern",
           "draining": "Abpumpen",
           "drum_cleaning": "Trommelreinigung",
-          "eco": "Eco",
           "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra Hygiene",
           "fast_20": "Schnell 20'",
-          "glass": "Glas",
-          "hygiene": "Hygiene",
-          "intensive": "Intensiv",
           "intensive_59_32": "Intensiv 59'/32'",
           "mix_synthetic": "Mix/Synthetik",
-          "night": "Nacht",
           "no_program_selected": "Kein Programm ausgew\u00e4hlt",
-          "one_hour": "1 Stunde",
           "pet_hair_removal": "Tierhaarentfernung",
           "rinsing_softening": "Sp\u00fclen & Weichsp\u00fclen",
           "shirts": "Hemden",
@@ -2305,13 +2344,6 @@
           "sport": "Sport",
           "white_cotton": "Wei\u00dfe Baumwolle",
           "wool_manual": "Wolle & Manuell"
-        }
-      },
-      "selected_program_mode": {
-        "name": "Programm Modus",
-        "state": {
-          "fast": "Schnell",
-          "normal": "Normal"
         }
       },
       "selected_program_mode_status": {
@@ -3426,10 +3458,7 @@
         "name": "Wasserverbrauch im laufenden Programm"
       },
       "water_hardness_setting_status": {
-        "name": "Wasserh\u00e4rte",
-        "state": {
-          "not_set": "Nicht eingestellt"
-        }
+        "name": "Wasserh\u00e4rte"
       },
       "water_inlet_setting_status": {
         "name": "Wasserzulauf"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1393,6 +1393,15 @@
           "none": "None"
         }
       },
+      "feedback_volumen_setting_status": {
+        "name": "Feedback volume",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "mid": "Mid",
+          "mute": "Mute"
+        }
+      },
       "language_status": {
         "name": "Language",
         "state": {
@@ -1402,6 +1411,15 @@
       },
       "motorlevel": {
         "name": "Motor level"
+      },
+      "notification_volumen_setting_status": {
+        "name": "Notification volume",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "mid": "Mid",
+          "mute": "Mute"
+        }
       },
       "oven_temperature_unit": {
         "name": "Oven temperature unit",
@@ -1416,6 +1434,12 @@
           "level_1": "Level 1",
           "level_2": "Level 2",
           "none": "None"
+        }
+      },
+      "rinse_aid_setting_status": {
+        "name": "Rinse aid",
+        "state": {
+          "tab": "TAB"
         }
       },
       "sand_timer_1_status_cmd": {
@@ -1495,6 +1519,33 @@
           "towels": "Towels",
           "wash_and_dry_49": "Wash and dry 49",
           "wool": "Wool"
+        }
+      },
+      "selected_program_id_status": {
+        "name": "Program",
+        "state": {
+          "auto": "Auto",
+          "clean": "Clean",
+          "eco": "Eco",
+          "glass": "Glass",
+          "hygiene": "Hygiene",
+          "intensive": "Intensive",
+          "night": "Night",
+          "one_hour": "One hour",
+          "quick_pro": "Quick pro",
+          "rinse_and_hold": "Rinse and hold",
+          "self_cleaning": "Self cleaning",
+          "time_program": "Time program"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Mode",
+        "state": {
+          "fast": "Fast",
+          "night": "Night",
+          "normal": "Normal",
+          "not_available": "Not available",
+          "speed": "Speed"
         }
       },
       "softener": {
@@ -1702,6 +1753,20 @@
           "24h": "24h"
         }
       },
+      "time_program_set_duration_status": {
+        "name": "Time program duration",
+        "state": {
+          "15_min": "00:15",
+          "1_h": "01:00",
+          "1_h_30_min": "01:30",
+          "2_h": "02:00",
+          "2_h_30_min": "02:30",
+          "30_min": "00:30",
+          "45_min": "00:45",
+          "not_available": "Not available",
+          "not_set": "Not set"
+        }
+      },
       "volume": {
         "name": "Volume"
       },
@@ -1715,6 +1780,12 @@
       },
       "water_hardness": {
         "name": "Water hardness"
+      },
+      "water_hardness_setting_status": {
+        "name": "Water hardness setting status",
+        "state": {
+          "not_set": "Not set"
+        }
       }
     },
     "sensor": {
@@ -3122,15 +3193,6 @@
       "favour_program_id": {
         "name": "Favour program ID"
       },
-      "feedback_volumen_setting_status": {
-        "name": "Feedback volume",
-        "state": {
-          "high": "High",
-          "low": "Low",
-          "mid": "Mid",
-          "mute": "Mute"
-        }
-      },
       "filter_alarm_time": {
         "name": "Filter alarm time"
       },
@@ -3628,9 +3690,6 @@
       "notification_sounds_volume_setting": {
         "name": "Notification sounds volume setting"
       },
-      "notification_volumen_setting_status": {
-        "name": "Notification volume"
-      },
       "ntc_sensor_1": {
         "name": "NTC sensor 1"
       },
@@ -3955,9 +4014,6 @@
       "rgb_normal_mode_r_value": {
         "name": "RGB normal mode R value"
       },
-      "rinse_aid_setting_status": {
-        "name": "Rinse aid"
-      },
       "rinse_flag": {
         "name": "Rinse flag"
       },
@@ -4228,25 +4284,17 @@
       "selected_program_id_status": {
         "name": "Selected program",
         "state": {
-          "auto": "Auto",
           "baby": "Baby",
-          "clean": "Clean",
           "color": "Color",
           "down_feathers": "Down feathers",
           "draining": "Draining",
           "drum_cleaning": "Drum Cleaning",
-          "eco": "Eco",
           "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra Hygiene",
           "fast_20": "Fast 20'",
-          "glass": "Glass",
-          "hygiene": "Hygiene",
-          "intensive": "Intensive",
           "intensive_59_32": "Intensive 59'/32'",
           "mix_synthetic": "Mix/Synthetic",
-          "night": "Night",
           "no_program_selected": "No program selected",
-          "one_hour": "1 hour",
           "pet_hair_removal": "Pet hair removal",
           "rinsing_softening": "Rinsing & Softening",
           "shirts": "Shirts",
@@ -4266,11 +4314,7 @@
         "name": "Selected program lower wash function"
       },
       "selected_program_mode": {
-        "name": "Selected program mode",
-        "state": {
-          "fast": "Fast",
-          "normal": "Normal"
-        }
+        "name": "Selected program mode"
       },
       "selected_program_mode2_status": {
         "name": "Selected program mode 2 status"
@@ -5939,7 +5983,7 @@
         "name": "Time auto flag"
       },
       "time_program_set_duration_status": {
-        "name": "Time program set duration status"
+        "name": "Time program duration"
       },
       "time_program_set_time_status": {
         "name": "Time program set time status"
@@ -6287,10 +6331,7 @@
         "name": "Water hardness setting"
       },
       "water_hardness_setting_status": {
-        "name": "Water hardness",
-        "state": {
-          "not_set": "Not set"
-        }
+        "name": "Water hardness"
       },
       "water_heat_switch": {
         "name": "Water heat switch"
@@ -6470,7 +6511,7 @@
         "name": "Interior light"
       },
       "interior_light_at_power_off_setting_status": {
-        "name": "Interior light at power off setting status"
+        "name": "Interior light at power off"
       },
       "key_sound": {
         "name": "Key sound"
@@ -6515,7 +6556,7 @@
         "name": "Step pre bake status"
       },
       "super_rinse_setting_status": {
-        "name": "Super rinse setting status"
+        "name": "Super rinse"
       },
       "t_8heat": {
         "name": "Frost protection"
@@ -6548,7 +6589,7 @@
         "name": "AI"
       },
       "tab_setting_status": {
-        "name": "Tab setting status"
+        "name": "Detergent TAB"
       },
       "time_save": {
         "name": "Time save"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -678,6 +678,27 @@
           "wardrobe": "Armario"
         }
       },
+      "feedback_volumen_setting_status": {
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "mid": "Medio",
+          "mute": "Silenciar"
+        }
+      },
+      "notification_volumen_setting_status": {
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "mid": "Medio",
+          "mute": "Silenciar"
+        }
+      },
+      "rinse_aid_setting_status": {
+        "state": {
+          "tab": "TAB"
+        }
+      },
       "selected_program_id": {
         "name": "Programa seleccionado",
         "state": {
@@ -707,14 +728,35 @@
           "wool": "Lana"
         }
       },
+      "selected_program_id_status": {
+        "name": "Programa seleccionado",
+        "state": {
+          "auto": "Auto",
+          "clean": "Limpieza",
+          "eco": "Eco",
+          "glass": "Cristal",
+          "hygiene": "Higiene",
+          "intensive": "Intensivo",
+          "night": "Noche",
+          "one_hour": "1 hora",
+          "quick_pro": "Quick pro",
+          "rinse_and_hold": "Aclarar y esperar",
+          "self_cleaning": "Autolimpieza",
+          "time_program": "Programa temporizado"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Modo programa",
+        "state": {
+          "fast": "R\u00e1pido",
+          "night": "Noche",
+          "normal": "Normal",
+          "speed": "R\u00e1pido"
+        }
+      },
       "spin_speed_rpm": {
         "name": "Centrifugado",
         "state": {
-          "1000": "30",
-          "1200": "1200",
-          "1400": "1400",
-          "600": "60",
-          "800": "40",
           "none": "No centrifugar"
         }
       },
@@ -761,6 +803,12 @@
         "name": "Temperatura",
         "state": {
           "cold": "Frio"
+        }
+      },
+      "time_program_set_duration_status": {
+        "name": "Duraci\u00f3n del programa temporizado",
+        "state": {
+          "not_set": "Sin definir"
         }
       }
     },
@@ -907,14 +955,6 @@
       "f_votage": {
         "name": "Voltaje"
       },
-      "feedback_volumen_setting_status": {
-        "state": {
-          "high": "Alto",
-          "low": "Bajo",
-          "mid": "Medio",
-          "mute": "Silenciar"
-        }
-      },
       "freeze_real_temperature": {
         "name": "Temperatura real congelador"
       },
@@ -1039,23 +1079,7 @@
       },
       "selected_program_id_status": {
         "name": "Programa seleccionado",
-        "state": {
-          "auto": "Auto",
-          "clean": "Limpieza",
-          "eco": "Eco",
-          "glass": "Cristal",
-          "hygiene": "Higiene",
-          "intensive": "Intensivo",
-          "night": "Noche",
-          "one_hour": "1 hora"
-        }
-      },
-      "selected_program_mode": {
-        "name": "Modo programa",
-        "state": {
-          "fast": "R\u00e1pido",
-          "normal": "Normal"
-        }
+        "state": {}
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Tiempo restante programa seleccionado"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1354,7 +1354,6 @@
           "auto": "Automatisch",
           "less": "Minder",
           "more": "Meer",
-          "off": "Uit",
           "standard": "Standaard"
         }
       },
@@ -1382,7 +1381,6 @@
           "extra_dry": "Extra droog",
           "iron": "Strijken",
           "none": "Geen",
-          "off": "Uit",
           "pre-ironing": "Strijkdroog",
           "wardrobe": "Kastdroog"
         }
@@ -1391,6 +1389,15 @@
         "name": "Extra spoelen",
         "state": {
           "none": "Geen"
+        }
+      },
+      "feedback_volumen_setting_status": {
+        "name": "Feedback volume",
+        "state": {
+          "high": "Hoog",
+          "low": "Laag",
+          "mid": "Midden",
+          "mute": "Stil"
         }
       },
       "language_status": {
@@ -1402,6 +1409,15 @@
       },
       "motorlevel": {
         "name": "Motorniveau"
+      },
+      "notification_volumen_setting_status": {
+        "name": "Meldingsvolume",
+        "state": {
+          "high": "Hoog",
+          "low": "Laag",
+          "mid": "Midden",
+          "mute": "Stil"
+        }
       },
       "oven_temperature_unit": {
         "name": "Oventemperatuur eenheid",
@@ -1416,6 +1432,12 @@
           "level_1": "Level 1",
           "level_2": "Level 2",
           "none": "None"
+        }
+      },
+      "rinse_aid_setting_status": {
+        "name": "Glansspoelmiddel",
+        "state": {
+          "tab": "TAB"
         }
       },
       "sand_timer_1_status_cmd": {
@@ -1497,26 +1519,45 @@
           "wool": "Wol"
         }
       },
+      "selected_program_id_status": {
+        "name": "Geselecteerd programma",
+        "state": {
+          "auto": "Auto",
+          "clean": "Schoon",
+          "eco": "Eco",
+          "glass": "Glas",
+          "hygiene": "Hygi\u00ebne",
+          "intensive": "Intensief",
+          "night": "Nacht",
+          "one_hour": "1 uur",
+          "quick_pro": "Quick pro",
+          "rinse_and_hold": "Spoelen en wachten",
+          "self_cleaning": "Zelfreiniging",
+          "time_program": "Tijdprogramma"
+        }
+      },
+      "selected_program_mode": {
+        "name": "Geselecteerde programmamodus",
+        "state": {
+          "fast": "Snel",
+          "night": "Nacht",
+          "normal": "Normaal",
+          "speed": "Snel"
+        }
+      },
       "softener": {
         "name": "Wasverzachter",
         "state": {
           "auto": "Automatisch",
           "less": "Minder",
           "more": "Meer",
-          "off": "Uit",
           "standard": "Standaard"
         }
       },
       "spin_speed_rpm": {
         "name": "Centrifugeren",
         "state": {
-          "1000": "1000 toeren",
-          "1200": "1200 toeren",
-          "1400": "1400 toeren",
-          "600": "600 toeren",
-          "800": "800 toeren",
-          "none": "Geen",
-          "off": "Uit"
+          "none": "Geen"
         }
       },
       "steam_123": {
@@ -1702,6 +1743,12 @@
           "24h": "24-uurs"
         }
       },
+      "time_program_set_duration_status": {
+        "name": "Duur tijdprogramma",
+        "state": {
+          "not_set": "Niet ingesteld"
+        }
+      },
       "volume": {
         "name": "Volume"
       },
@@ -1715,6 +1762,12 @@
       },
       "water_hardness": {
         "name": "Waterhardheid"
+      },
+      "water_hardness_setting_status": {
+        "name": "Waterhardheid",
+        "state": {
+          "not_set": "Niet ingesteld"
+        }
       }
     },
     "sensor": {
@@ -1979,15 +2032,6 @@
       "fan_sequence_setting_status": {
         "name": "Ventilatorvolgorde"
       },
-      "feedback_volumen_setting_status": {
-        "name": "Feedback volume",
-        "state": {
-          "high": "Hoog",
-          "low": "Laag",
-          "mid": "Midden",
-          "mute": "Stil"
-        }
-      },
       "filter_state": {
         "name": "Filterstatus"
       },
@@ -2158,9 +2202,6 @@
       "night_mode_on_minute": {
         "name": "Nachtmodus aan Minuut"
       },
-      "notification_volumen_setting_status": {
-        "name": "Meldingsvolume"
-      },
       "order_time_minimum_hour": {
         "name": "Order time minimum (uur)"
       },
@@ -2214,9 +2255,6 @@
       },
       "remaining_time_of_selected_program": {
         "name": "Resterende tijd van geselecteerd programma"
-      },
-      "rinse_aid_setting_status": {
-        "name": "Glansspoelmiddel"
       },
       "rinsenum": {
         "name": "Aantal spoelbeurten"
@@ -2350,25 +2388,17 @@
       "selected_program_id_status": {
         "name": "Geselecteerd programma",
         "state": {
-          "auto": "Auto",
           "baby": "Baby",
-          "clean": "Schoon",
           "color": "Kleur",
           "down_feathers": "Donsveren",
           "draining": "Afpompen",
           "drum_cleaning": "Trommelreiniging",
-          "eco": "Eco",
           "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra hygi\u00ebne",
           "fast_20": "Snel 20'",
-          "glass": "Glas",
-          "hygiene": "Hygi\u00ebne",
-          "intensive": "Intensief",
           "intensive_59_32": "Intensief 59'/32'",
           "mix_synthetic": "Mix/Synthetisch",
-          "night": "Nacht",
           "no_program_selected": "Geen programma geselecteerd",
-          "one_hour": "1 uur",
           "pet_hair_removal": "Huisdierhaar verwijderen",
           "rinsing_softening": "Spoelen & verzachten",
           "shirts": "Shirts",
@@ -2376,13 +2406,6 @@
           "sport": "Sport",
           "white_cotton": "Wit katoen",
           "wool_manual": "Wol & Handmatig"
-        }
-      },
-      "selected_program_mode": {
-        "name": "Geselecteerde programmamodus",
-        "state": {
-          "fast": "Snel",
-          "normal": "Normaal"
         }
       },
       "selected_program_mode_status": {
@@ -3512,10 +3535,7 @@
         "name": "Waterverbruik in huidig programma"
       },
       "water_hardness_setting_status": {
-        "name": "Waterhardheid",
-        "state": {
-          "not_set": "Niet ingesteld"
-        }
+        "name": "Waterhardheid"
       },
       "water_inlet_setting_status": {
         "name": "Watertoevoer"


### PR DESCRIPTION
## Summary

Splits program and mode labels into per-model feature overlays so incompatible device variants don't share labels that don't apply to them.

Closes #287.

## Default (015.yaml)

- Convert `Feedback_volumen`, `Notification_volumen`, `Rinse_aid`, `Tab_setting`, and `Water_hardness_setting` to writable selects (`entity_category: config`).
- Fix `Remote_control_monitoring_set_commands_actions` binary sensor options mapping (1=off, 2=on per spec).
- Add `entity_category: config` to settings-like switches and selects.
- Drop `Selected_program_id_status` and `Selected_program_mode` option lists — overlays provide the labels.
- Fix typo in `Odor_control_setting` command override.

## Per-model overlays

- `015-000`, `015-dishwasher-60.2`, `015-dishwasher-60.3` — ASKO family: writable `Selected_program_id_status` (Eco/Auto/Intensive/Quick pro/Time program/Hygiene/Rinse and hold/Self cleaning), narrowed `Selected_program_mode` (Normal/Speed/Night), and `Time_program_set_duration_status` select with clock-format labels (00:15–02:30).
- `015-dishwasher-50.2f` (Gorenje GS673B60W), `015-dishwasher-50.2t` (Pelgrim GVWC330L), `015-1ux0s1005k15` (Hisense WD16-E722BXi) — writable selects with the 50.2-family labels (auto/eco/one_hour/intensive/glass/hygiene/night/clean).
   **Experimental:** labels confirmed via issue #173 (Gorenje) / PR #360 (Hisense), but converting sensor → writable select is speculative; command property pairs assumed same as ASKO family.

## Test plan

- [x] Confirmed writes on ASKO 60.2: `Selected_program_id_status`, `Selected_program_mode`, `Time_program_set_duration_status`, `Odor_control_setting`.
- [x] `validate_mappings` and `gen_strings` clean.
- [x] `Water_hardness_setting_status` write
- [ ] 60.3 / 1ux0s1005k15 / 50.2 variants: not tested; labels copied from matching family.