### PR TITLE
Register 025-1wj105091v0t washing machine

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -36,6 +36,7 @@
 | WF3S1043BW3          | Washing machine          | 025              | 1wj100722v0w           |
 | HWFS1015AB           | Washing machine          | 025              | 1wj100923v0f           |
 |                      | Washing machine          | 025              | 1wj105050v0w           |
+|                      | Washing machine          | 025              | 1wj105091v0t           |
 | WFSE1114-LVW002      | Washing machine          | 025              | 1wj105219v0w           |
 | WF3S1114-LVW004      | Washing machine          | 025              | 1wj105246v0w           |
 |                      | Washing machine          | 025              | 1wj105418v0t           |

--- a/custom_components/connectlife/data_dictionaries/025-1wj105091v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105091v0t.yaml
@@ -1,0 +1,1 @@
+# Uses default mappings


### PR DESCRIPTION
## Summary

- Add empty feature-overlay file `025-1wj105091v0t.yaml` (uses default 025 mappings)
- Add DEVICES.md row

Closes #206

## Test plan

- [x] `uv run python -m scripts.validate_mappings` passes
- [ ] Reporter confirms entities are created from the generic 025 default

🤖 Generated with [Claude Code](https://claude.com/claude-code)