### PR TITLE
Expand split AC (009) mappings with new variants and properties

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -9,13 +9,37 @@
 |                      | Air conditioner          | 008              | 304                    |
 | AWUS1225TW           | Air conditioner          | 008              | 399                    |
 |                      | Air conditioner          | 009              | 100                    |
+|                      | Air conditioner          | 009              | 101                    |
+|                      | Air conditioner          | 009              | 102                    |
+|                      | Air conditioner          | 009              | 103                    |
 |                      | Air conditioner          | 009              | 104                    |
 | AS-09TW2RLDTT00      | Air conditioner          | 009              | 105                    |
 |                      | Air conditioner          | 009              | 106                    |
+|                      | Air conditioner          | 009              | 107                    |
+|                      | Air conditioner          | 009              | 108                    |
 |                      | Air conditioner          | 009              | 109                    |
+|                      | Air conditioner          | 009              | 110                    |
+|                      | Air conditioner          | 009              | 111                    |
+|                      | Air conditioner          | 009              | 112                    |
+|                      | Air conditioner          | 009              | 113                    |
+|                      | Air conditioner          | 009              | 114                    |
+|                      | Air conditioner          | 009              | 115                    |
+|                      | Air conditioner          | 009              | 116                    |
 |                      | Air conditioner          | 009              | 117                    |
+|                      | Air conditioner          | 009              | 118                    |
+|                      | Air conditioner          | 009              | 119                    |
+|                      | Air conditioner          | 009              | 120                    |
+|                      | Air conditioner          | 009              | 121                    |
+|                      | Air conditioner          | 009              | 122                    |
+|                      | Air conditioner          | 009              | 123                    |
+|                      | Air conditioner          | 009              | 124                    |
+|                      | Air conditioner          | 009              | 125                    |
+|                      | Air conditioner          | 009              | 126                    |
+|                      | Air conditioner          | 009              | 127                    |
 |                      | Air conditioner          | 009              | 128                    |
 |                      | Air conditioner          | 009              | 129                    |
+|                      | Air conditioner          | 009              | 199                    |
+|                      | Air conditioner          | 009              | 19901                  |
 |                      | Hood                     | 012              | 000                    |
 |                      | Oven                     | 013              | 000                    |
 | Bio21                | Oven                     | 013              | oven-bio21-iconledplus |

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -21,7 +21,7 @@ properties:
     state_class: measurement
   icon: mdi:flash
 - property: f_temp_in
-  icon: mdi:temp
+  icon: mdi:thermometer
   climate:
     target: current_temperature
 - property: t_eco

--- a/custom_components/connectlife/data_dictionaries/009-101.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-101.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-102.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-102.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009-103.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-103.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-107.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-107.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-108.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-108.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-110.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-110.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-111.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-111.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009-112.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-112.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-113.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-113.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009-114.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-114.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-115.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-115.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009-116.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-116.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-118.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-118.yaml
@@ -1,0 +1,9 @@
+properties:
+  - property: t_work_mode
+    climate:
+      target: hvac_mode
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/009-119.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-119.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009-120.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-120.yaml
@@ -1,0 +1,10 @@
+properties:
+  - property: t_temp
+    climate:
+      target: target_temperature
+      max_value:
+        celsius: 30
+        fahrenheit: 86
+      min_value:
+        celsius: 16
+        fahrenheit: 61

--- a/custom_components/connectlife/data_dictionaries/009-121.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-121.yaml
@@ -1,13 +1,4 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
-climate:
-  presets:
-    - t_eco: 1
-      t_fan_speed: 0 # auto
-      t_power: 1
-      preset: eco
-    - t_power: 1
-      t_tms: 1
-      preset: ai
 properties:
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-122.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-122.yaml
@@ -1,13 +1,4 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
-climate:
-  presets:
-    - t_eco: 1
-      t_fan_speed: 0 # auto
-      t_power: 1
-      preset: eco
-    - t_power: 1
-      t_tms: 1
-      preset: ai
 properties:
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-123.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-123.yaml
@@ -1,13 +1,4 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
-climate:
-  presets:
-    - t_eco: 1
-      t_fan_speed: 0 # auto
-      t_power: 1
-      preset: eco
-    - t_power: 1
-      t_tms: 1
-      preset: ai
 properties:
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-124.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-124.yaml
@@ -1,13 +1,4 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
-climate:
-  presets:
-    - t_eco: 1
-      t_fan_speed: 0 # auto
-      t_power: 1
-      preset: eco
-    - t_power: 1
-      t_tms: 1
-      preset: ai
 properties:
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-125.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-125.yaml
@@ -1,13 +1,4 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
-climate:
-  presets:
-    - t_eco: 1
-      t_fan_speed: 0 # auto
-      t_power: 1
-      preset: eco
-    - t_power: 1
-      t_tms: 1
-      preset: ai
 properties:
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-126.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-126.yaml
@@ -1,13 +1,4 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
-climate:
-  presets:
-    - t_eco: 1
-      t_fan_speed: 0 # auto
-      t_power: 1
-      preset: eco
-    - t_power: 1
-      t_tms: 1
-      preset: ai
 properties:
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-127.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-127.yaml
@@ -1,0 +1,10 @@
+properties:
+  - property: t_temp
+    climate:
+      target: target_temperature
+      max_value:
+        celsius: 30
+        fahrenheit: 86
+      min_value:
+        celsius: 16
+        fahrenheit: 61

--- a/custom_components/connectlife/data_dictionaries/009-199.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-199.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009-19901.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-19901.yaml
@@ -1,0 +1,1 @@
+# No overrides needed; all properties covered by default 009.yaml.

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -1,4 +1,76 @@
 properties:
+  - property: aus_zone1_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone1_power
+    switch:
+      device_class: switch
+  - property: aus_zone2_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone2_power
+    switch:
+      device_class: switch
+  - property: aus_zone3_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone3_power
+    switch:
+      device_class: switch
+  - property: aus_zone4_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone4_power
+    switch:
+      device_class: switch
+  - property: aus_zone5_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone5_power
+    switch:
+      device_class: switch
+  - property: aus_zone6_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone6_power
+    switch:
+      device_class: switch
+  - property: aus_zone7_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone7_power
+    switch:
+      device_class: switch
+  - property: aus_zone8_opencontrol
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:valve
+  - property: aus_zone8_power
+    switch:
+      device_class: switch
   - property: f_cool_qvalue
     sensor:
       unit: BTU/h
@@ -11,6 +83,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_incoiltemp
     binary_sensor:
       device_class: problem
@@ -18,6 +91,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_incom
     binary_sensor:
       device_class: problem
@@ -25,6 +99,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_indisplay
     binary_sensor:
       device_class: problem
@@ -32,6 +107,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_ineeprom
     binary_sensor:
       device_class: problem
@@ -39,6 +115,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_inele
     binary_sensor:
       device_class: problem
@@ -46,6 +123,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_infanmotor
     binary_sensor:
       device_class: problem
@@ -53,6 +131,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_inhumidity
     binary_sensor:
       device_class: problem
@@ -60,6 +139,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_inkeys
     binary_sensor:
       device_class: problem
@@ -67,6 +147,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_intemp
     binary_sensor:
       device_class: problem
@@ -74,6 +155,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_invzero
     binary_sensor:
       device_class: problem
@@ -81,6 +163,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_inwifi
     binary_sensor:
       device_class: problem
@@ -88,6 +171,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_outcoiltemp
     binary_sensor:
       device_class: problem
@@ -95,6 +179,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_outeeprom
     binary_sensor:
       device_class: problem
@@ -102,6 +187,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_outgastemp
     binary_sensor:
       device_class: problem
@@ -109,6 +195,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_outtemp
     binary_sensor:
       device_class: problem
@@ -116,6 +203,7 @@ properties:
         0: false
         1: true
     hide: true
+    entity_category: diagnostic
   - property: f_e_push
     disable: true
   - property: f_ecm
@@ -157,6 +245,9 @@ properties:
       device_class: voltage
       unit: V
     hide: true
+    entity_category: diagnostic
+  - property: oem_host_version
+    disable: true
   - property: t_8heat
     switch:
       device_class: switch
@@ -167,6 +258,16 @@ properties:
         0: off
         1: on
     hide: true
+    entity_category: diagnostic
+  - property: t_device_info
+    disable: true
+  - property: t_dimmer
+    switch:
+      device_class: switch
+      "on": 0
+      "off": 1
+    icon: mdi:lightbulb-on
+    entity_category: config
   - property: t_eco
     switch:
       device_class: switch
@@ -187,6 +288,20 @@ properties:
         9: high
   - property: t_fan_speed_s
     disable: true
+  - property: t_fanspeedCV
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:fan
+  - property: t_fresh_air
+    switch:
+      device_class: switch
+    icon: mdi:weather-windy
+  - property: t_left_right
+    switch:
+      device_class: switch
+    icon: mdi:arrow-left-right
   - property: t_power
     climate:
       target: is_on
@@ -202,7 +317,7 @@ properties:
         2: for_old
         3: for_young
         4: for_kid
-    icon: mdi:sleep
+    icon: mdi:power-sleep
   - property: t_super
     switch:
       device_class: switch
@@ -232,8 +347,8 @@ properties:
       options:
         0: forward
         1: right
-        2: swing
-        3: both_sides
+        2: both_sides
+        3: swing
         4: left
   - property: t_up_down
     climate:
@@ -250,6 +365,28 @@ properties:
       min_value:
         celsius: 16
         fahrenheit: 61
+  - property: t_temp_compensate
+    # Signed 4-bit encoding: 0..7 = 0..+7 °C, 9..15 = -7..-1 °C (value 8 / -8 unused).
+    # Full range applies in non-AI modes; AI mode (t_tms=1) limits effective offset to ±3 °C.
+    select:
+      options:
+        9: "offset_minus_7"
+        10: "offset_minus_6"
+        11: "offset_minus_5"
+        12: "offset_minus_4"
+        13: "offset_minus_3"
+        14: "offset_minus_2"
+        15: "offset_minus_1"
+        0: "offset_0"
+        1: "offset_plus_1"
+        2: "offset_plus_2"
+        3: "offset_plus_3"
+        4: "offset_plus_4"
+        5: "offset_plus_5"
+        6: "offset_plus_6"
+        7: "offset_plus_7"
+    icon: mdi:thermometer-plus
+    entity_category: config
   - property: t_temp_type
     climate:
       target: temperature_unit

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1234,6 +1234,30 @@
       }
     },
     "number": {
+      "aus_zone1_opencontrol": {
+        "name": "Zone 1 opening"
+      },
+      "aus_zone2_opencontrol": {
+        "name": "Zone 2 opening"
+      },
+      "aus_zone3_opencontrol": {
+        "name": "Zone 3 opening"
+      },
+      "aus_zone4_opencontrol": {
+        "name": "Zone 4 opening"
+      },
+      "aus_zone5_opencontrol": {
+        "name": "Zone 5 opening"
+      },
+      "aus_zone6_opencontrol": {
+        "name": "Zone 6 opening"
+      },
+      "aus_zone7_opencontrol": {
+        "name": "Zone 7 opening"
+      },
+      "aus_zone8_opencontrol": {
+        "name": "Zone 8 opening"
+      },
       "delayendtime": {
         "name": "Delay end time"
       },
@@ -1269,6 +1293,9 @@
       },
       "refrigerator_temperature": {
         "name": "Refrigerator temperature"
+      },
+      "t_fanspeedcv": {
+        "name": "Variable fan speed"
       },
       "variation_max_temperature": {
         "name": "Variation max temperature"
@@ -1731,6 +1758,26 @@
           "follow": "Follow",
           "not_follow": "Not Follow",
           "off": "Off"
+        }
+      },
+      "t_temp_compensate": {
+        "name": "Temperature offset",
+        "state": {
+          "offset_0": "0 \u00b0C",
+          "offset_minus_1": "-1 \u00b0C",
+          "offset_minus_2": "-2 \u00b0C",
+          "offset_minus_3": "-3 \u00b0C",
+          "offset_minus_4": "-4 \u00b0C",
+          "offset_minus_5": "-5 \u00b0C",
+          "offset_minus_6": "-6 \u00b0C",
+          "offset_minus_7": "-7 \u00b0C",
+          "offset_plus_1": "+1 \u00b0C",
+          "offset_plus_2": "+2 \u00b0C",
+          "offset_plus_3": "+3 \u00b0C",
+          "offset_plus_4": "+4 \u00b0C",
+          "offset_plus_5": "+5 \u00b0C",
+          "offset_plus_6": "+6 \u00b0C",
+          "offset_plus_7": "+7 \u00b0C"
         }
       },
       "temperature": {
@@ -6464,6 +6511,30 @@
       "anticrease": {
         "name": "Anti-crease"
       },
+      "aus_zone1_power": {
+        "name": "Zone 1"
+      },
+      "aus_zone2_power": {
+        "name": "Zone 2"
+      },
+      "aus_zone3_power": {
+        "name": "Zone 3"
+      },
+      "aus_zone4_power": {
+        "name": "Zone 4"
+      },
+      "aus_zone5_power": {
+        "name": "Zone 5"
+      },
+      "aus_zone6_power": {
+        "name": "Zone 6"
+      },
+      "aus_zone7_power": {
+        "name": "Zone 7"
+      },
+      "aus_zone8_power": {
+        "name": "Zone 8"
+      },
       "auto_dose_setting_status": {
         "name": "Auto-dose"
       },
@@ -6577,6 +6648,12 @@
       },
       "t_fan_mute": {
         "name": "Fan mute"
+      },
+      "t_fresh_air": {
+        "name": "Fresh air"
+      },
+      "t_left_right": {
+        "name": "Horizontal swing"
       },
       "t_purify": {
         "name": "Purifier"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1234,6 +1234,30 @@
       }
     },
     "number": {
+      "aus_zone1_opencontrol": {
+        "name": "Zone 1 opening"
+      },
+      "aus_zone2_opencontrol": {
+        "name": "Zone 2 opening"
+      },
+      "aus_zone3_opencontrol": {
+        "name": "Zone 3 opening"
+      },
+      "aus_zone4_opencontrol": {
+        "name": "Zone 4 opening"
+      },
+      "aus_zone5_opencontrol": {
+        "name": "Zone 5 opening"
+      },
+      "aus_zone6_opencontrol": {
+        "name": "Zone 6 opening"
+      },
+      "aus_zone7_opencontrol": {
+        "name": "Zone 7 opening"
+      },
+      "aus_zone8_opencontrol": {
+        "name": "Zone 8 opening"
+      },
       "delayendtime": {
         "name": "Delay end time"
       },
@@ -1269,6 +1293,9 @@
       },
       "refrigerator_temperature": {
         "name": "Refrigerator temperature"
+      },
+      "t_fanspeedcv": {
+        "name": "Variable fan speed"
       },
       "variation_max_temperature": {
         "name": "Variation max temperature"
@@ -1731,6 +1758,26 @@
           "follow": "Follow",
           "not_follow": "Not Follow",
           "off": "Off"
+        }
+      },
+      "t_temp_compensate": {
+        "name": "Temperature offset",
+        "state": {
+          "offset_0": "0 \u00b0C",
+          "offset_minus_1": "-1 \u00b0C",
+          "offset_minus_2": "-2 \u00b0C",
+          "offset_minus_3": "-3 \u00b0C",
+          "offset_minus_4": "-4 \u00b0C",
+          "offset_minus_5": "-5 \u00b0C",
+          "offset_minus_6": "-6 \u00b0C",
+          "offset_minus_7": "-7 \u00b0C",
+          "offset_plus_1": "+1 \u00b0C",
+          "offset_plus_2": "+2 \u00b0C",
+          "offset_plus_3": "+3 \u00b0C",
+          "offset_plus_4": "+4 \u00b0C",
+          "offset_plus_5": "+5 \u00b0C",
+          "offset_plus_6": "+6 \u00b0C",
+          "offset_plus_7": "+7 \u00b0C"
         }
       },
       "temperature": {
@@ -6464,6 +6511,30 @@
       "anticrease": {
         "name": "Anti-crease"
       },
+      "aus_zone1_power": {
+        "name": "Zone 1"
+      },
+      "aus_zone2_power": {
+        "name": "Zone 2"
+      },
+      "aus_zone3_power": {
+        "name": "Zone 3"
+      },
+      "aus_zone4_power": {
+        "name": "Zone 4"
+      },
+      "aus_zone5_power": {
+        "name": "Zone 5"
+      },
+      "aus_zone6_power": {
+        "name": "Zone 6"
+      },
+      "aus_zone7_power": {
+        "name": "Zone 7"
+      },
+      "aus_zone8_power": {
+        "name": "Zone 8"
+      },
       "auto_dose_setting_status": {
         "name": "Auto-dose"
       },
@@ -6577,6 +6648,12 @@
       },
       "t_fan_mute": {
         "name": "Fan mute"
+      },
+      "t_fresh_air": {
+        "name": "Fresh air"
+      },
+      "t_left_right": {
+        "name": "Horizontal swing"
       },
       "t_purify": {
         "name": "Purifier"


### PR DESCRIPTION
## Summary
- Adds mapping coverage for 24 additional 009 (split AC) feature codes: 101-103, 107-108, 110-127, 199, 19901.
- Extends default `009.yaml` with 8-zone damper control, fresh air, horizontal swing, display dimmer, variable fan speed, temperature offset (±7 °C).
- Adds feature overrides for cool-only work mode (9 variants), smaller `t_temp` range (120, 127), and extended `t_temp` range covering 8° heat mode (121-126, 129).
- Fixes a couple of shared AC-family issues: swapped `t_swing_direction` option labels, inverted `t_dimmer` switch mapping, missing `entity_category: diagnostic` on error sensors, `mdi:temp` (invalid MDI icon) in 006.yaml, and `t_sleep` icon alignment across 006/008/009.

Fixes #453.

## Test plan
- [x] `uv run python -m scripts.validate_mappings` passes
- [x] `uv run python -m scripts.gen_strings` produces no unexpected drift
- [x] `uv run pyright` clean
- [ ] Verify a 009-199 / 009-19901 device exposes the zone switches, fresh air switch, horizontal swing, variable fan speed, and temperature offset entities with correct labels
- [ ] Verify the `t_dimmer` switch on 009-199 reflects the actual display state (toggle ON = display lit)
- [ ] Verify existing 009 devices (100, 104, 105, 106, 109, 117, 128, 129) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)