### PR TITLE
Update bump-version and release-notes skills

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -10,8 +10,20 @@ Bump the version of this ConnectLife Home Assistant integration.
 ## Steps
 
 1. Determine the new version:
-   - `$ARGUMENTS` is required and must be a valid semver version (e.g., `0.31.0`)
-   - If not provided, read the current version from `custom_components/connectlife/manifest.json` and ask the user what the new version should be
+   - If `$ARGUMENTS` is provided, it must be a valid semver version (e.g., `0.31.0`). Use it as the new version.
+   - If not provided, determine the next version via semver by analyzing commits since the last release:
+     1. Read the current version from `custom_components/connectlife/manifest.json`.
+     2. List commits since the last version bump:
+        ```
+        git log --oneline "$(git log --grep='^Version ' -n 1 --format=%H)..HEAD"
+        ```
+        (Falls back to `git log --oneline -n 20` if no prior version commit is found.)
+     3. Classify the bump based on the commit subjects and diffs. **Note:** this project is on `0.x.y`, where per semver the public API is considered unstable — breaking changes do **not** trigger a `1.0.0` release on their own, they bump MINOR. Reserve a MAJOR bump for a deliberate, user-driven `1.0.0` graduation.
+        - **MAJOR** (`X.0.0`): only when the user explicitly asks to graduate to `1.0.0` (or beyond). Do not infer this from commit contents alone while on `0.x.y`.
+        - **MINOR** (`0.X.0`): new functionality **or** breaking changes — new device mappings/registrations, new properties, new platforms, new entities, additive API changes, removed/renamed entities or options, incompatible config flow changes, minimum HA version raised.
+        - **PATCH** (`0.0.X`): backwards-compatible fixes only — bug fixes, translation-only changes, doc/readme tweaks, internal refactors with no user-visible change.
+        When in doubt between MINOR and PATCH, pick MINOR.
+     4. Compute the next version and show the user: the current version, the classification (major/minor/patch) with a one-line justification referencing the commits, and the proposed new version. Ask for confirmation before proceeding.
 
 2. Verify the working tree is clean:
    ```

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -47,14 +47,15 @@ Generate release notes for this ConnectLife Home Assistant integration release.
 
 7. Come up with a cool release name.
 
-8. Format the release notes following this template:
+8. Format the release notes following this template. Do NOT include a `v` prefix on the version in the title line.
 
 ```markdown
-# <release version> <release name>
+<version> <release name>
 
 ## Highlights
 
 <2-4 bullet summary of the most notable changes in this release>
+- Do NOT include PR references (#123) or contributor mentions in Highlights — those belong in the detail sections below.
 
 ## New devices
 
@@ -105,4 +106,7 @@ The following have contributed to changes in this release — thank you very muc
 - Quote property names and field names in backticks (e.g., `DelayEndTime`, `state_class`)
 - Keep descriptions concise — one line per item
 - The Highlights section should give a quick overview: count of new devices, key fixes, notable features
+- Always read the PR body (via `gh pr view <num> --json body --jq '.body'`)
+- When a PR body calls out a breaking change is experimental, note that in the entry (e.g., "breaking changes ...")
+- When a PR body calls out that a change is experimental, speculative, or untested for certain models/devices, note that in the entry (e.g., "experimental for ...")
 - Present the final release notes as a single markdown code block so it can be easily copied


### PR DESCRIPTION
## Summary
- **bump-version**: when no version argument is given, infer the next version via semver by analyzing commits since the last release. Accounts for the `0.x.y` phase where breaking changes bump MINOR, not MAJOR.
- **release-notes**: drop the `v` prefix from the title, exclude PR references and contributor mentions from Highlights, and require reading PR bodies so experimental/breaking notes surface in individual entries.

## Test plan
- [ ] Run the bump-version skill without an argument and verify it proposes a sensible next version with justification
- [ ] Run the release-notes skill and verify the generated notes follow the updated template