### PR TITLE
Add error codes and translations for washing machine faults

### DIFF
--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -830,6 +830,20 @@ properties:
       read_only: true
       options:
         0: none
+        1: error_f01
+        3: error_f03
+        4: error_f04
+        5: error_f05
+        6: error_f06
+        7: error_f07
+        13: error_f13
+        14: error_f14
+        15: error_f15
+        16: error_f16
+        17: error_f17
+        18: error_f18
+        23: error_f23
+        24: error_f24
         100: unbalance_alarm
   - property: hottime
     hide: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -3087,6 +3087,20 @@
       "error_code": {
         "name": "Error code",
         "state": {
+          "error_f01": "F01 - Water inflow fault",
+          "error_f03": "F03 - Water drain fault",
+          "error_f04": "F04 - Electronic module fault",
+          "error_f05": "F05 - Electronic module fault",
+          "error_f06": "F06 - Electronic module fault",
+          "error_f07": "F07 - Electronic module fault",
+          "error_f13": "F13 - Door lock fault",
+          "error_f14": "F14 - Door unlock fault",
+          "error_f15": "F15 - Abnormal drying",
+          "error_f16": "F16 - Abnormal drying",
+          "error_f17": "F17 - Abnormal drying",
+          "error_f18": "F18 - Abnormal drying",
+          "error_f23": "F23 - Electronic module fault",
+          "error_f24": "F24 - Water level overflow",
           "none": "None",
           "unbalance_alarm": "Unbalance alarm"
         }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -3087,6 +3087,20 @@
       "error_code": {
         "name": "Error code",
         "state": {
+          "error_f01": "F01 - Water inflow fault",
+          "error_f03": "F03 - Water drain fault",
+          "error_f04": "F04 - Electronic module fault",
+          "error_f05": "F05 - Electronic module fault",
+          "error_f06": "F06 - Electronic module fault",
+          "error_f07": "F07 - Electronic module fault",
+          "error_f13": "F13 - Door lock fault",
+          "error_f14": "F14 - Door unlock fault",
+          "error_f15": "F15 - Abnormal drying",
+          "error_f16": "F16 - Abnormal drying",
+          "error_f17": "F17 - Abnormal drying",
+          "error_f18": "F18 - Abnormal drying",
+          "error_f23": "F23 - Electronic module fault",
+          "error_f24": "F24 - Water level overflow",
           "none": "None",
           "unbalance_alarm": "Unbalance alarm"
         }

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1995,20 +1995,20 @@
         "state": {
           "error_f01": "F01 - Watertoevoer fout",
           "error_f03": "F03 - Waterafvoer fout",
-          "error_f04": "F04 - Electronische module fout",
-          "error_f05": "F05 - Electronische module fout",
-          "error_f06": "F06 - Electronische module fout",
-          "error_f07": "F07 - Electronische module fout",
+          "error_f04": "F04 - Fout elektrische module",
+          "error_f05": "F05 - Fout elektrische module",
+          "error_f06": "F06 - Fout elektrische module",
+          "error_f07": "F07 - Fout elektrische module",
           "error_f13": "F13 - Deurvergrendeling fout",
           "error_f14": "F14 - Deurontgrendeling fout",
           "error_f15": "F15 - Abnormaal drogen",
           "error_f16": "F16 - Abnormaal drogen",
           "error_f17": "F17 - Abnormaal drogen",
           "error_f18": "F18 - Abnormaal drogen",
-          "error_f23": "F23 - Electronische module fout",
-          "error_f24": "F24 - Water overloop pleil",
+          "error_f23": "F23 - Fout elektrische module",
+          "error_f24": "F24 - Wateroverlooppeil bereikt",
           "none": "Geen",
-          "unbalance_alarm": "Onbalans alarm"
+          "unbalance_alarm": "Onbalansalarm"
         }
       },
       "error_read_out_1_code": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1993,6 +1993,20 @@
       "error_code": {
         "name": "Foutmelding",
         "state": {
+          "error_f01": "F01 - Watertoevoer fout",
+          "error_f03": "F03 - Waterafvoer fout",
+          "error_f04": "F04 - Electronische module fout",
+          "error_f05": "F05 - Electronische module fout",
+          "error_f06": "F06 - Electronische module fout",
+          "error_f07": "F07 - Electronische module fout",
+          "error_f13": "F13 - Deurvergrendeling fout",
+          "error_f14": "F14 - Deurontgrendeling fout",
+          "error_f15": "F15 - Abnormaal drogen",
+          "error_f16": "F16 - Abnormaal drogen",
+          "error_f17": "F17 - Abnormaal drogen",
+          "error_f18": "F18 - Abnormaal drogen",
+          "error_f23": "F23 - Electronische module fout",
+          "error_f24": "F24 - Water overloop pleil",
           "none": "Geen",
           "unbalance_alarm": "Onbalans alarm"
         }


### PR DESCRIPTION
# Summary
-Following up on #456, I remembered that I had already looked up a number of error codes for washing machines. I’ve added the ones that were missing, based on [this manual](https://partners.gorenje.com/fts/GetDigitDoc.aspx?sifra=20014422&jezik=en&tipVsebine=1&docName=wd3s9043bb3-um-en.pdf).

# Tests

## Tested on machine WD3S9043BB3

- [x] error_f01: F01 - Water inflow fault 
- [ ] error_f03: F03 - Water drain fault 
- [ ] error_f04: F04 - Electronic module fault 
- [ ] error_f05: F05 - Electronic module fault 
- [ ] error_f06: F06 - Electronic module fault 
- [ ] error_f07: F07 - Electronic module fault 
- [x] error_f13: F13 - Door lock fault 
- [ ] error_f14: F14 - Door unlock fault 
- [ ] error_f15: F15 - Abnormal drying 
- [ ] error_f16: F16 - Abnormal drying 
- [ ] error_f17: F17 - Abnormal drying 
- [ ] error_f18: F18 - Abnormal drying 
- [ ] error_f23: F23 - Electronic module fault 
- [ ] error_f24: F24 - Water level overflow 

# Test plan

- [x] `uv run python -m scripts.gen_strings`
- [x] `uv run python -m scripts.validate_mappings`
- [x] Add translated keys in nl.json
