### PR TITLE
Climate: include current work mode when turning on

### DIFF
--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -292,7 +292,13 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
     async def async_turn_on(self):
         """Turn the entity on."""
         # TODO: Support value mapping
-        await self.async_update_device(self.add_target_temperature({self.target_map[IS_ON]: 1}))
+        request = {self.target_map[IS_ON]: 1}
+        if HVAC_MODE in self.target_map:
+            status = self.target_map[HVAC_MODE]
+            status_list = self.coordinator.data[self.device_id].status_list
+            if status in status_list:
+                request[status] = int(status_list[status])
+        await self.async_update_device(self.add_target_temperature(request))
 
     async def async_turn_off(self):
         """Turn the entity off."""


### PR DESCRIPTION
## Summary

- Include the cached `t_work_mode` value in the `async_turn_on` payload so devices receive `{t_power: 1, t_work_mode: <cached>, t_temp: <cached>}` together, matching how `async_set_hvac_mode` already constructs its payload.
- Motivated by #448: a 006-200 portable AC user reports the unit turning itself off within a minute of HA sending power-on. The server accepts the bare `{t_power: 1, t_temp: 70}` command and returns a commandId, but the next successful poll shows `t_power: 0`, i.e. the device never actually powered on. HA's entity then flips on→off, appearing as a spontaneous off. The official Hisense plugin's fallback path also sends `{t_power, t_work_mode}` together when powering on from an off state, suggesting the combined payload is what some devices require.
- Keeps the #117 fix (`t_temp` included on turn-on) intact.

## Test plan

- [ ] Verify HA climate entity turn-on still works for 009-* split AC variants (regression check for #117).
- [ ] Ask reporter on #448 to retest turn-on from HA on 006-200 and confirm the AC stays on.
- [ ] Verify behaviour when `t_work_mode` is not in `target_map` (e.g., devices without mode mapping) — turn-on payload falls back to previous `{t_power, t_temp}` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)