### PR TITLE
Expose device firmware version via DeviceInfo.sw_version

### DIFF
--- a/custom_components/connectlife/const.py
+++ b/custom_components/connectlife/const.py
@@ -27,3 +27,5 @@ SWING_HORIZONTAL_MODE = "swing_horizontal_mode"
 TARGET_HUMIDITY = "target_humidity"
 TARGET_TEMPERATURE = "target_temperature"
 TEMPERATURE_UNIT = "temperature_unit"
+
+SW_VERSION_PROPERTY = "oem_host_version"

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -246,8 +246,6 @@ properties:
       unit: V
     hide: true
     entity_category: diagnostic
-  - property: oem_host_version
-    disable: true
   - property: t_8heat
     switch:
       device_class: switch

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_DEVICES,
     CONF_DISABLE_BEEP,
     DOMAIN,
+    SW_VERSION_PROPERTY,
 )
 from .coordinator import ConnectLifeCoordinator
 
@@ -43,12 +44,14 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
         self.device_id = appliance.device_id
         self.nickname = appliance.device_nickname
         self._attr_unique_id = f'{appliance.device_id}-{entity_name}'
+        sw_version = appliance.status_list.get(SW_VERSION_PROPERTY)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, appliance.device_id)},
             model=appliance.device_feature_name,
             hw_version=f'{appliance.device_type_code}-{appliance.device_feature_code}',
             name=appliance.device_nickname,
             suggested_area=appliance.room_name,
+            sw_version=sw_version if isinstance(sw_version, str) else None,
         )
         coordinator.add_entity(self._attr_unique_id, platform)
         if config_entry and CONF_DEVICES in config_entry.options:

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, SW_VERSION_PROPERTY
 from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
@@ -46,7 +46,8 @@ async def async_setup_entry(
                 coordinator, appliance, s, dictionary.properties[s], dictionary
             )
             for s in appliance.status_list
-            if is_entity(
+            if s != SW_VERSION_PROPERTY
+            and is_entity(
                 Platform.SENSOR,
                 dictionary.properties[s],
                 appliance.status_list[s],


### PR DESCRIPTION
## Summary
- Maps `oem_host_version` from the appliance status list to `DeviceInfo.sw_version`, so the firmware version shows in HA's device info panel instead of being a hidden sensor.
- Filters the property out of the sensor platform and drops the `disable: true` stub in `009.yaml` that was previously needed to prevent a string sensor with `state_class=measurement`.
- Centralized via a new `SW_VERSION_PROPERTY` constant, so new device types picking up the property get firmware in DeviceInfo automatically — no per-YAML stub.

## Test plan
- [x] `uv run python -m scripts.validate_mappings` — passes
- [x] `uv run pyright` — 0 errors
- [x] Verified using test server with 016-502 dump: HA device info shows `Firmware: S1798.6.01.06.RB`, `Hardware: 016-502`

🤖 Generated with [Claude Code](https://claude.com/claude-code)