### PR TITLE
Fix state_class on cumulative consumption sensors

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -568,22 +568,22 @@ properties:
     hide: true
   - property: Total_energy_consumption
     sensor:
-      state_class: total
+      state_class: total_increasing
       device_class: energy
       unit: kWh
     icon: mdi:lightning-bolt
   - property: Total_number_of_cycles
     sensor:
-      state_class: total
+      state_class: total_increasing
   - property: Total_run_time
     sensor:
-      state_class: total
+      state_class: total_increasing
       device_class: duration
       unit: h
     icon: mdi:timer-sand-full
   - property: Total_water_consumption
     sensor:
-      state_class: total
+      state_class: total_increasing
       device_class: water
       unit: L
     icon: mdi:water

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -603,6 +603,7 @@ properties:
       device_class: energy
       unit: kWh
       read_only: true
+      state_class: total_increasing
     combine:
       - property: StandardElectricitConsumption_int
       - property: StandardElectricitconsumption_decimal
@@ -614,6 +615,7 @@ properties:
       device_class: water
       unit: L
       read_only: true
+      state_class: total_increasing
     combine:
       - property: StandardWaterConsumption_int
       - property: StandardWaterConsumption_decimal

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -240,6 +240,7 @@ properties:
       device_class: energy
       unit: kWh
       read_only: true
+      state_class: total_increasing
     combine:
       - property: StandardElectricitConsumption_int
       - property: StandardElectricitconsumption_decimal


### PR DESCRIPTION
## Summary

- `StandardElectricitConsumption` / `StandardWaterConsumption` in `025.yaml` and `030.yaml` had `device_class: energy` / `water` but no `state_class`, so the integer/combine auto-fallback in `sensor.py` applied `measurement`. Home Assistant rejects that combination — those device classes require `total` or `total_increasing`. The "state class 'measurement' is impossible considering device class 'energy'" warning fires for ~11 entities across these device variants.
- The four `Total_*` sensors in `015.yaml` (`Total_energy_consumption`, `Total_water_consumption`, `Total_run_time`, `Total_number_of_cycles`) were set to `state_class: total`. `total` allows the value to decrease and is meant for net meters; appliance lifetime counters only ever increase, with possible factory-reset to 0, which `total_increasing` describes accurately and lets HA detect resets correctly.

## Test plan
- [x] \`uv run python -m scripts.validate_mappings\` passes
- [x] Verified in dev mode against test-server dumps: the 11 "state class measurement is impossible" warnings disappear after this change
- [x] Reviewer: confirm no Statistics repair is required for existing `015` users — `total` ↔ `total_increasing` use the same stats type (sum), so HA transitions silently