### PR TITLE
Add property inheritance in feature override files

### DIFF
--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -16,6 +16,59 @@ will just be ignored for feature variants that don't expose that property.
 
 **Note:** The top level `climate` section is not supported in the default mapping files.
 
+### Property inheritance in feature overrides
+
+Any field in a property can be overridden in a feature file; unspecified fields are inherited from the base
+type file. If the override changes the platform type (e.g., from `sensor:` to `select:`), the override's
+platform block replaces the base's. Top-level fields (`icon`, `hide`, `disable`, `entity_category`,
+`unavailable`, `combine`) always inherit.
+
+Collections (`options`, `combine`, `command`, dict-valued `min_value` / `max_value`) replace as a whole —
+there is no per-key merging inside them.
+
+Set a field to `null` to explicitly unset what the base specified — useful for opting a sensor out of
+long-term statistics with `state_class: null`, or dropping a `unit:` set in the base. To suppress an entity
+entirely, use `disable: true`.
+
+Example: the base specifies the full mapping, the feature override carries only the difference.
+
+```yaml
+# 009.yaml (base)
+- property: t_temp
+  climate:
+    target: target_temperature
+    min_value: 16
+    max_value: 32
+```
+
+```yaml
+# 009-120.yaml (feature override — caps at 30 °C, inherits target and min_value)
+- property: t_temp
+  climate:
+    max_value: 30
+```
+
+Example: a feature variant returns a property as a direct value where the base combines two sources.
+
+```yaml
+# 025.yaml (base — virtual sensor combining int and decimal source properties)
+- property: StandardElectricitConsumption
+  sensor:
+    device_class: energy
+    unit: kWh
+    state_class: total_increasing
+  combine:
+    - property: StandardElectricitConsumption_int
+    - property: StandardElectricitconsumption_decimal
+      multiplier: 0.01
+```
+
+```yaml
+# 025-{feature}.yaml (override — read the property directly, no combine)
+- property: StandardElectricitConsumption
+  combine: null
+```
+
 ## Create your own mapping file
 
 To map you device, create a file with the name `<deviceTypeCode>-<deviceFeatureCode>.yaml` in this directory. When done,

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -18,17 +18,30 @@ will just be ignored for feature variants that don't expose that property.
 
 ### Property inheritance in feature overrides
 
-Any field in a property can be overridden in a feature file; unspecified fields are inherited from the base
-type file. If the override changes the platform type (e.g., from `sensor:` to `select:`), the override's
-platform block replaces the base's. Top-level fields (`icon`, `hide`, `disable`, `entity_category`,
-`unavailable`, `combine`) always inherit.
+Any field in a property can be overridden in a feature file; unspecified fields are inherited from the
+base type file. If the override changes the platform type (e.g., from `sensor:` to `select:`), the
+override's platform block replaces the base's.
 
-Collections (`options`, `combine`, `command`, dict-valued `min_value` / `max_value`) replace as a whole —
-there is no per-key merging inside them.
+The following top-level fields always inherit, even across platform changes:
+
+- `icon`
+- `hide`
+- `disable`
+- `entity_category`
+- `unavailable`
+- `combine` — if you change the platform and want to drop the base's combine sources, clear it with
+  `combine: null`.
+
+Collections replace as a whole — there is no per-key merging inside them:
+
+- `options`
+- `combine`
+- `command`
+- dict-valued `min_value` / `max_value`
 
 Set a field to `null` to explicitly unset what the base specified — useful for opting a sensor out of
-long-term statistics with `state_class: null`, or dropping a `unit:` set in the base. To suppress an entity
-entirely, use `disable: true`.
+long-term statistics with `state_class: null`, or dropping a `unit:` set in the base. To suppress an
+entity entirely, use `disable: true`.
 
 Example: the base specifies the full mapping, the feature override carries only the difference.
 

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -53,7 +53,7 @@
           "type": "string"
         },
         "combine": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/$defs/CombineSource"
           },
@@ -84,9 +84,9 @@
           "$ref": "#/$defs/WaterHeater"
         },
         "icon": {
-          "type": "string",
+          "type": ["string", "null"],
           "title": "Icon",
-          "description": "Icon to use for the entity.",
+          "description": "Icon to use for the entity. Use null in a feature override to unset an icon set in the base.",
           "examples": [
             "mdi:alert",
             "mdi:dishwash-alert"
@@ -103,13 +103,14 @@
           "default": false
         },
         "unavailable": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "If the property has this value, it is not available on the device, and no entity is created."
         },
         "entity_category": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "https://developers.home-assistant.io/docs/core/entity/#registry-properties:~:text=automatic%20device%20registration.-,entity_category,-EntityCategory%20%7C%20None",
           "enum": [
+            null,
             "config",
             "diagnostic"
           ]
@@ -129,7 +130,7 @@
           "$ref": "#/$defs/BinarySensorDeviceClass"
         },
         "options": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "boolean"
           },
@@ -139,15 +140,15 @@
       "title": "BinarySensor"
     },
     "Command": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "name": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Use this property instead to change state."
         },
         "adjust": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "When changing state, adjust the request value by substracting this value. Used when the command values are offset from the property values.",
           "default": 0
         }
@@ -155,7 +156,7 @@
       "title": "Command"
     },
     "Climate": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "target": {
@@ -171,7 +172,7 @@
           "$ref": "#/$defs/IntegerOrTemperature"
         },
         "options": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           },
@@ -180,23 +181,23 @@
       }
     },
     "Humidifier": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "target": {
           "$ref": "#/$defs/HumidifierTarget"
         },
         "min_value": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "max_value": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "device_class": {
           "$ref": "#/$defs/HumidifierDeviceClass"
         },
         "options": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           },
@@ -205,14 +206,14 @@
       }
     },
     "Number": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "device_class": {
           "$ref": "#/$defs/NumberDeviceClass"
         },
         "unit": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Required if device_class is set, except not allowed when device_class is AQI or ph.",
           "examples": [
             "min",
@@ -221,7 +222,7 @@
           ]
         },
         "min_value": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "Minimum allowed value.",
           "examples": [
             -40,
@@ -229,7 +230,7 @@
           ]
         },
         "max_value": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "Maximum allowed value.",
           "examples": [
             20,
@@ -239,11 +240,11 @@
       }
     },
     "Select": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "options": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           },
@@ -252,10 +253,7 @@
         "command": {
           "$ref": "#/$defs/Command"
         }
-      },
-      "required": [
-        "options"
-      ]
+      }
     },
     "Sensor": {
       "type": ["object", "null" ],
@@ -270,7 +268,7 @@
           "default": false
         },
         "unit": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Required if device_class is set, except not allowed when device_class is aqi, enum or ph.",
           "examples": [
             "min",
@@ -282,7 +280,7 @@
           "$ref": "#/$defs/UnknownValue"
         },
         "options": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           },
@@ -292,7 +290,7 @@
           "$ref": "#/$defs/SensorStateClass"
         },
         "multiplier": {
-          "type": "number",
+          "type": ["number", "null"],
           "description": "Multiplier to be used if the native API value does not match a supportet unit in Home Assistant",
           "examples": [
             "0.1",
@@ -307,12 +305,12 @@
       "additionalProperties": false,
       "properties": {
         "off": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "Off value",
           "default": 0
         },
         "on": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "On value",
           "default": 1
         },
@@ -326,7 +324,7 @@
       "title": "BinarySensor"
     },
     "WaterHeater": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "properties": {
         "target": {
@@ -342,7 +340,7 @@
           "$ref": "#/$defs/IntegerOrTemperature"
         },
         "options": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": ["string", "boolean"]
           },
@@ -372,8 +370,9 @@
       ]
     },
     "BinarySensorDeviceClass": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "battery",
         "battery_charging",
         "carbon_monoxide",
@@ -407,8 +406,9 @@
       "description": "Name of any BinarySensorDeviceClass enum."
     },
     "ClimateTarget": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "current_humidity",
         "current_temperature",
         "fan_mode",
@@ -425,8 +425,9 @@
       "description": "Target property of ClimateEntity."
     },
     "HumidifierTarget": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "current_humidity",
         "mode",
         "target_humidity",
@@ -436,16 +437,18 @@
       "description": "Target property of HumidifierEntity."
     },
     "HumidifierDeviceClass": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "dehumidifier",
         "humidifier"
       ],
       "title": "Humidifier device class."
     },
     "SensorDeviceClass": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "date",
         "enum",
         "timestamp",
@@ -502,8 +505,9 @@
       "description": "Name of any SensorDeviceClass enum."
     },
     "NumberDeviceClass": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "apparent_power",
         "aqi",
         "atmospheric_pressure",
@@ -557,18 +561,20 @@
       "description": "Name of any SensorDeviceClass enum."
     },
     "SensorStateClass": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "measurement",
         "total",
         "total_increasing"
       ],
       "title": "State class",
-      "description": "Name of any SensorStateClass. Only allowed for integer properties, defaults to measurement."
+      "description": "Name of any SensorStateClass. Only allowed for integer properties. Set to null to suppress the integer-property auto-fallback to measurement (e.g. for state codes or setpoints where statistics aren't meaningful)."
     },
     "SwitchDeviceClass": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "outlet",
         "switch"
       ],
@@ -576,8 +582,9 @@
       "description": "Name of any SwitchDeviceClass enum."
     },
     "WaterHeaterTarget": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": [
+        null,
         "current_temperature",
         "current_operation",
         "is_on",
@@ -590,7 +597,7 @@
       "description": "Target property of WaterHeaterEntity."
     },
     "UnknownValue": {
-      "type": "integer",
+      "type": ["integer", "null"],
       "description": "The value used by the API to signal unknown value.",
       "examples": [
         255,
@@ -600,7 +607,8 @@
     "IntegerOrTemperature": {
       "type": [
         "integer",
-        "object"
+        "object",
+        "null"
       ],
       "additionalProperties": false,
       "properties": {

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 import logging
 import pkgutil
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from connectlife.appliance import ConnectLifeAppliance
 from homeassistant.const import Platform, EntityCategory
@@ -66,6 +66,18 @@ class CombineSource(_CombineSourceRequired, total=False):
     unknown_value: int
 
 
+def _val(d: dict, key: str, default: Any = None) -> Any:
+    """Return ``d[key]`` if the key is present with a non-None value, else ``default``.
+
+    Used by parsers to treat ``key: ~`` (explicit null in a feature override) the
+    same as the key being absent — except for ``state_class``, which tracks the
+    distinction explicitly to suppress the auto-fallback in sensor.py.
+    """
+    if key in d and d[key] is not None:
+        return d[key]
+    return default
+
+
 class BinarySensor:
     device_class: BinarySensorDeviceClass | None
     options: dict[int, bool] = {0: False, 1: False, 2: True}
@@ -73,13 +85,13 @@ class BinarySensor:
     def __init__(self, name: str, binary_sensor: dict | None):
         if binary_sensor is None:
             binary_sensor = {}
+        device_class = _val(binary_sensor, DEVICE_CLASS)
         self.device_class = (
-            BinarySensorDeviceClass(binary_sensor[DEVICE_CLASS])
-            if DEVICE_CLASS in binary_sensor
-            else None
+            BinarySensorDeviceClass(device_class) if device_class is not None else None
         )
-        if OPTIONS in binary_sensor:
-            self.options = binary_sensor[OPTIONS]
+        options = _val(binary_sensor, OPTIONS)
+        if options is not None:
+            self.options = options
 
 
 class Climate:
@@ -92,10 +104,10 @@ class Climate:
     def __init__(self, name: str, climate: dict | None):
         if climate is None:
             climate = {}
-        self.target = climate[TARGET] if TARGET in climate else None
+        self.target = _val(climate, TARGET)
         if self.target is None:
             _LOGGER.warning("Missing climate.target for for %s", name)
-        self.options = climate[OPTIONS] if OPTIONS in climate else {}
+        self.options = _val(climate, OPTIONS, {})
         if not self.options and self.target in [
             FAN_MODE,
             HVAC_ACTION,
@@ -109,8 +121,8 @@ class Climate:
             if UNKNOWN_VALUE in climate and climate[UNKNOWN_VALUE]
             else None
         )
-        self.min_value = climate[MIN_VALUE] if MIN_VALUE in climate else None
-        self.max_value = climate[MAX_VALUE] if MAX_VALUE in climate else None
+        self.min_value = _val(climate, MIN_VALUE)
+        self.max_value = _val(climate, MAX_VALUE)
 
 
 class Humidifier:
@@ -123,19 +135,18 @@ class Humidifier:
     def __init__(self, name: str, humidifier: dict | None):
         if humidifier is None:
             humidifier = {}
-        self.target = humidifier[TARGET] if TARGET in humidifier else None
+        self.target = _val(humidifier, TARGET)
         if self.target is None:
             _LOGGER.warning("Missing humidifier.target for for %s", name)
-        self.options = humidifier[OPTIONS] if OPTIONS in humidifier else {}
+        self.options = _val(humidifier, OPTIONS, {})
         if not self.options and self.target in [ACTION, MODE]:
             _LOGGER.warning("Missing humidifier.options for %s", name)
+        device_class = _val(humidifier, DEVICE_CLASS)
         self.device_class = (
-            HumidifierDeviceClass(humidifier[DEVICE_CLASS])
-            if DEVICE_CLASS in humidifier
-            else None
+            HumidifierDeviceClass(device_class) if device_class is not None else None
         )
-        self.min_value = humidifier[MIN_VALUE] if MIN_VALUE in humidifier else None
-        self.max_value = humidifier[MAX_VALUE] if MAX_VALUE in humidifier else None
+        self.min_value = _val(humidifier, MIN_VALUE)
+        self.max_value = _val(humidifier, MAX_VALUE)
 
 
 class Number:
@@ -145,17 +156,18 @@ class Number:
     device_class: NumberDeviceClass | None
     unit: str | None
 
-    def __init__(self, name: str, number: dict):
+    def __init__(self, name: str, number: dict | None):
         if number is None:
             number = {}
-        self.min_value = number[MIN_VALUE] if MIN_VALUE in number else None
-        self.max_value = number[MAX_VALUE] if MAX_VALUE in number else None
-        self.unit = number[UNIT] if UNIT in number and number[UNIT] else None
-        self.multiplier = number[MULTIPLIER] if MULTIPLIER in number else None
+        self.min_value = _val(number, MIN_VALUE)
+        self.max_value = _val(number, MAX_VALUE)
+        self.unit = _val(number, UNIT) or None
+        self.multiplier = _val(number, MULTIPLIER)
 
         device_class = None
-        if DEVICE_CLASS in number:
-            device_class = NumberDeviceClass(number[DEVICE_CLASS])
+        device_class_value = _val(number, DEVICE_CLASS)
+        if device_class_value is not None:
+            device_class = NumberDeviceClass(device_class_value)
             if (
                 device_class == NumberDeviceClass.PH
                 or device_class == NumberDeviceClass.AQI
@@ -179,24 +191,18 @@ class Select:
     command_name: str | None
     command_adjust: int = 0
 
-    def __init__(self, name: str, select: dict):
+    def __init__(self, name: str, select: dict | None):
         if select is None:
             select = {}
-        if OPTIONS not in select:
+        options = _val(select, OPTIONS)
+        if options is None:
             _LOGGER.warning("Select %s has no options", name)
             self.options = {}
         else:
-            self.options = select[OPTIONS]
-        self.command_name = (
-            select[COMMAND][NAME]
-            if COMMAND in select and NAME in select[COMMAND]
-            else None
-        )
-        self.command_adjust = (
-            select[COMMAND][ADJUST]
-            if COMMAND in select and ADJUST in select[COMMAND]
-            else 0
-        )
+            self.options = options
+        command = _val(select, COMMAND, {})
+        self.command_name = _val(command, NAME)
+        self.command_adjust = _val(command, ADJUST, 0)
 
 
 class Sensor:
@@ -206,11 +212,12 @@ class Sensor:
     multiplier: float | None
     read_only: bool | None
     state_class: SensorStateClass | None
+    state_class_explicit: bool
     device_class: SensorDeviceClass | None
     unit: str | None
     options: dict[int, str] | None
 
-    def __init__(self, name: str, sensor: dict):
+    def __init__(self, name: str, sensor: dict | None):
         if sensor is None:
             sensor = {}
         self.unknown_value = (
@@ -218,16 +225,19 @@ class Sensor:
             if UNKNOWN_VALUE in sensor and sensor[UNKNOWN_VALUE]
             else None
         )
-        self.read_only = sensor[READ_ONLY] if READ_ONLY in sensor else None
-        self.unit = sensor[UNIT] if UNIT in sensor and sensor[UNIT] else None
-        self.multiplier = sensor[MULTIPLIER] if MULTIPLIER in sensor else None
+        self.read_only = _val(sensor, READ_ONLY)
+        self.unit = _val(sensor, UNIT) or None
+        self.multiplier = _val(sensor, MULTIPLIER)
+        self.state_class_explicit = STATE_CLASS in sensor
+        state_class_value = _val(sensor, STATE_CLASS)
         self.state_class = (
-            SensorStateClass(sensor[STATE_CLASS]) if STATE_CLASS in sensor else None
+            SensorStateClass(state_class_value) if state_class_value is not None else None
         )
 
         device_class = None
-        if DEVICE_CLASS in sensor:
-            device_class = SensorDeviceClass(sensor[DEVICE_CLASS])
+        device_class_value = _val(sensor, DEVICE_CLASS)
+        if device_class_value is not None:
+            device_class = SensorDeviceClass(device_class_value)
             if device_class == SensorDeviceClass.ENUM:
                 if self.unit:
                     _LOGGER.warning("%s has device class enum, but has unit", name)
@@ -237,11 +247,12 @@ class Sensor:
                         "%s has device class enum, but has state_class", name
                     )
                     device_class = None
-                if device_class and "options" not in sensor:
+                options = _val(sensor, OPTIONS)
+                if device_class and options is None:
                     _LOGGER.warning("%s has device class enum, but no options", name)
                     device_class = None
                 else:
-                    self.options = sensor["options"]
+                    self.options = options
             elif device_class in [
                 SensorDeviceClass.AQI,
                 SensorDeviceClass.DATE,
@@ -269,24 +280,18 @@ class Switch:
     command_name: str | None
     command_adjust: int = 0
 
-    def __init__(self, name: str, switch: dict):
+    def __init__(self, name: str, switch: dict | None):
         if switch is None:
             switch = {}
+        device_class = _val(switch, DEVICE_CLASS)
         self.device_class = (
-            SwitchDeviceClass(switch[DEVICE_CLASS]) if DEVICE_CLASS in switch else None
+            SwitchDeviceClass(device_class) if device_class is not None else None
         )
-        self.off = switch[OFF] if OFF in switch else 0
-        self.on = switch[ON] if ON in switch else 1
-        self.command_name = (
-            switch[COMMAND][NAME]
-            if COMMAND in switch and NAME in switch[COMMAND]
-            else None
-        )
-        self.command_adjust = (
-            switch[COMMAND][ADJUST]
-            if COMMAND in switch and ADJUST in switch[COMMAND]
-            else 0
-        )
+        self.off = _val(switch, OFF, 0)
+        self.on = _val(switch, ON, 1)
+        command = _val(switch, COMMAND, {})
+        self.command_name = _val(command, NAME)
+        self.command_adjust = _val(command, ADJUST, 0)
 
 
 class WaterHeater:
@@ -299,10 +304,10 @@ class WaterHeater:
     def __init__(self, name: str, water_heater: dict | None):
         if water_heater is None:
             water_heater = {}
-        self.target = water_heater[TARGET] if TARGET in water_heater else None
+        self.target = _val(water_heater, TARGET)
         if self.target is None:
             _LOGGER.warning("Missing water_heater.target for for %s", name)
-        self.options = water_heater[OPTIONS] if OPTIONS in water_heater else {}
+        self.options = _val(water_heater, OPTIONS, {})
         if not self.options and self.target in [
             CURRENT_OPERATION,
             IS_AWAY_MODE_ON,
@@ -321,8 +326,8 @@ class WaterHeater:
             if UNKNOWN_VALUE in water_heater and water_heater[UNKNOWN_VALUE]
             else None
         )
-        self.min_value = water_heater[MIN_VALUE] if MIN_VALUE in water_heater else None
-        self.max_value = water_heater[MAX_VALUE] if MAX_VALUE in water_heater else None
+        self.min_value = _val(water_heater, MIN_VALUE)
+        self.max_value = _val(water_heater, MAX_VALUE)
 
 
 class Property:
@@ -344,18 +349,17 @@ class Property:
 
     def __init__(self, entry: dict):
         self.name = entry[PROPERTY]
-        self.icon = entry[ICON] if ICON in entry and entry[ICON] else None
+        self.icon = _val(entry, ICON) or None
         self.hide = entry[HIDE] == bool(entry[HIDE]) if HIDE in entry else False
         self.disable = (
             entry[DISABLE] == bool(entry[DISABLE]) if DISABLE in entry else False
         )
-        self.unavailable = entry[UNAVAILABLE] if UNAVAILABLE in entry else None
+        self.unavailable = _val(entry, UNAVAILABLE)
+        entity_category = _val(entry, ENTITY_CATEGORY)
         self.entity_category = (
-            EntityCategory[entry[ENTITY_CATEGORY].upper()]
-            if ENTITY_CATEGORY in entry
-            else None
+            EntityCategory[entity_category.upper()] if entity_category is not None else None
         )
-        self.combine = entry[COMBINE] if COMBINE in entry else None
+        self.combine = _val(entry, COMBINE)
 
         if Platform.BINARY_SENSOR in entry:
             self.binary_sensor = BinarySensor(self.name, entry[Platform.BINARY_SENSOR])
@@ -386,6 +390,87 @@ class Dictionary:
     properties: dict[str, Property]
 
 
+PLATFORM_KEYS = (
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.HUMIDIFIER,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.WATER_HEATER,
+)
+
+
+def _merge_property(base: dict | None, override: dict) -> dict:
+    """Merge ``override`` on top of ``base``.
+
+    Top-level fields and platform-block fields inherit field-by-field from the
+    base when the platform is unchanged. Collections (``options``, ``combine``,
+    dict-valued ``min_value``/``max_value``, ``command``) replace as a whole.
+    A field set to ``None`` in the override is preserved as ``None`` so parsers
+    can detect "explicitly unset" — meaningful for ``state_class``, equivalent
+    to absent for everything else.
+
+    A bare platform key in the override (``switch:`` with no value, parsed as
+    ``None``) is YAML shorthand for ``{}``: it means "this property uses the
+    given platform with no overrides", not "remove the platform from base".
+    To convert a property to a different platform, declare the new platform
+    key explicitly with the desired contents; to suppress an entity, use
+    ``disable: true``.
+    """
+    if base is None:
+        return dict(override)
+
+    result = dict(base)
+    base_plat = next((p for p in PLATFORM_KEYS if p in base), None)
+    override_plat = next((p for p in PLATFORM_KEYS if p in override), None)
+
+    for key, val in override.items():
+        if key in PLATFORM_KEYS:
+            continue
+        result[key] = val
+
+    if override_plat is None:
+        return result
+    override_val = override[override_plat]
+    if base_plat == override_plat:
+        inner_override = {} if override_val is None else override_val
+        result[override_plat] = _merge_platform_block(base[base_plat], inner_override)
+        return result
+    if base_plat is not None:
+        result.pop(base_plat, None)
+    result[override_plat] = override_val
+    return result
+
+
+def _merge_platform_block(base, override):
+    if override is None:
+        return None
+    if base is None:
+        return dict(override)
+    result = dict(base)
+    result.update(override)
+    return result
+
+
+def _load_yaml(path: str) -> tuple[bool, Any]:
+    """Return ``(found, parsed_yaml)``.
+
+    An empty file (a subtype file with only ``# Uses default mappings``) is
+    ``(True, None)`` — present, no overrides — distinct from a missing file
+    ``(False, None)``, so callers don't emit spurious "no data dictionary
+    found" warnings for placeholder subtype files.
+    """
+    try:
+        data = pkgutil.get_data(__name__, path)
+    except FileNotFoundError:
+        return False, None
+    if data is None:
+        return False, None
+    return True, yaml.safe_load(data)
+
+
 class Dictionaries:
 
     dictionaries: dict[str, Dictionary] = {}
@@ -395,36 +480,38 @@ class Dictionaries:
         key = f"{appliance.device_type_code}-{appliance.device_feature_code}"
         if key in cls.dictionaries:
             return cls.dictionaries[key]
+
         climate: dict | None = None
-        properties = defaultdict(lambda: Property({PROPERTY: "default", HIDE: True}))
-        try:
-            data = pkgutil.get_data(__name__, f"data_dictionaries/{appliance.device_type_code}.yaml")
-            if data is None:
-                raise FileNotFoundError
-            parsed = yaml.safe_load(data)
-            # TODO: Support default climate section
-            if parsed is not None and PROPERTIES in parsed and parsed[PROPERTIES] is not None:
-                for prop in parsed[PROPERTIES]:
-                    properties[prop[PROPERTY]] = Property(prop)
-        except FileNotFoundError:
-            pass
-        try:
-            data = pkgutil.get_data(__name__, f"data_dictionaries/{key}.yaml")
-            if data is None:
-                raise FileNotFoundError
-            parsed = yaml.safe_load(data)
-            if parsed is not None:
-                if Platform.CLIMATE in parsed:
-                    climate = (
-                        parsed[Platform.CLIMATE] if Platform.CLIMATE in parsed else None
-                    )
-                if PROPERTIES in parsed and parsed[PROPERTIES] is not None:
-                    for prop in parsed[PROPERTIES]:
-                        properties[prop[PROPERTY]] = Property(prop)
-        except FileNotFoundError:
+        raw_entries: dict[str, dict] = {}
+
+        # TODO: Support default climate section
+        _, base_data = _load_yaml(
+            f"data_dictionaries/{appliance.device_type_code}.yaml"
+        )
+        if base_data is not None and PROPERTIES in base_data and base_data[PROPERTIES] is not None:
+            for prop in base_data[PROPERTIES]:
+                raw_entries[prop[PROPERTY]] = prop
+
+        sub_found, sub_data = _load_yaml(f"data_dictionaries/{key}.yaml")
+        if not sub_found:
             _LOGGER.warning(
-                "No data dictionary found for %s (%s)", appliance.device_nickname, key
+                "No data dictionary found for %s (%s)",
+                appliance.device_nickname,
+                key,
             )
+        if sub_data is not None:
+            if Platform.CLIMATE in sub_data:
+                climate = sub_data[Platform.CLIMATE]
+            if PROPERTIES in sub_data and sub_data[PROPERTIES] is not None:
+                for prop in sub_data[PROPERTIES]:
+                    name = prop[PROPERTY]
+                    raw_entries[name] = _merge_property(raw_entries.get(name), prop)
+
+        properties: dict[str, Property] = defaultdict(
+            lambda: Property({PROPERTY: "default", HIDE: True})
+        )
+        for name, entry in raw_entries.items():
+            properties[name] = Property(entry)
 
         for prop in list(properties.values()):
             if prop.combine:

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -112,6 +112,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         state_class = dd_entry.sensor.state_class
         if (
             state_class is None
+            and not dd_entry.sensor.state_class_explicit
             and (isinstance(current_value, int) or self.combine)
             and device_class != SensorDeviceClass.ENUM
         ):

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -7,7 +7,44 @@ from os.path import isfile, join
 
 import yaml
 
+from custom_components.connectlife.dictionaries import _merge_property
 from scripts import check_translations, sort_translations
+
+
+def _is_base_file(filename: str) -> bool:
+    """True for ``009.yaml`` (base type), False for ``009-105.yaml`` (feature override)."""
+    return "-" not in filename.removesuffix(".yaml")
+
+
+def _load_base_properties(basedir: str, filenames: list[str]) -> dict[str, dict[str, dict]]:
+    """Pre-load base type YAMLs as ``{type_code: {prop_name: prop_dict}}``.
+
+    Used to merge feature-override entries with their base counterpart so
+    gen_strings sees the same merged Property the runtime sees, even when
+    a subtype is trimmed to only the differences from base.
+    """
+    bases: dict[str, dict[str, dict]] = {}
+    for filename in filenames:
+        if not _is_base_file(filename):
+            continue
+        type_code = filename.removesuffix(".yaml")
+        with open(f"{basedir}/data_dictionaries/{filename}") as f:
+            parsed = yaml.safe_load(f)
+        if not parsed or "properties" not in parsed or parsed["properties"] is None:
+            continue
+        bases[type_code] = {p["property"]: p for p in parsed["properties"]}
+    return bases
+
+
+def _merged_properties(filename: str, parsed_properties: list[dict], bases: dict[str, dict[str, dict]]):
+    """Yield each property in ``parsed_properties``, merged with its base entry for subtypes."""
+    if _is_base_file(filename):
+        yield from parsed_properties
+        return
+    type_code = filename.split("-", 1)[0]
+    base = bases.get(type_code, {})
+    for prop in parsed_properties:
+        yield _merge_property(base.get(prop["property"]), prop)
 
 HA_STRINGS_URL = "https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/strings.json"
 
@@ -21,13 +58,14 @@ def main(basedir):
 
     device_dir = f'{basedir}/data_dictionaries'
     filenames = list(filter(lambda f: f[-5:] == ".yaml", [f for f in listdir(device_dir) if isfile(join(device_dir, f))]))
+    bases = _load_base_properties(basedir, filenames)
     for filename in filenames:
         print(f"Generating strings from {filename}")
         with (open(f'{basedir}/data_dictionaries/{filename}') as f):
             appliance = yaml.safe_load(f)
         if appliance is not None:
             if "properties" in appliance and appliance["properties"] is not None:
-                for property in appliance["properties"]:
+                for property in _merged_properties(filename, appliance["properties"], bases):
                     if "climate" in property:
                         if property["climate"]["target"] == "fan_mode":
                             for option in property["climate"]["options"].values():

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -1,0 +1,254 @@
+"""Tests for the property inheritance merge in dictionaries.py."""
+
+from __future__ import annotations
+
+from custom_components.connectlife.dictionaries import (
+    Property,
+    Sensor,
+    _merge_property,
+)
+
+
+def test_override_with_no_platform_inherits_everything():
+    base = {
+        "property": "t_temp",
+        "icon": "mdi:thermometer",
+        "climate": {
+            "target": "target_temperature",
+            "min_value": 16,
+            "max_value": 32,
+        },
+    }
+    override = {"property": "t_temp"}
+
+    merged = _merge_property(base, override)
+
+    assert merged == base
+
+
+def test_same_platform_merges_field_by_field():
+    base = {
+        "property": "t_temp",
+        "climate": {
+            "target": "target_temperature",
+            "min_value": 16,
+            "max_value": 32,
+        },
+    }
+    override = {
+        "property": "t_temp",
+        "climate": {"max_value": 30},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged == {
+        "property": "t_temp",
+        "climate": {
+            "target": "target_temperature",
+            "min_value": 16,
+            "max_value": 30,
+        },
+    }
+
+
+def test_options_replace_as_whole():
+    base = {
+        "property": "t_work_mode",
+        "climate": {
+            "target": "hvac_mode",
+            "options": {0: "fan_only", 1: "heat", 2: "cool", 3: "dry", 4: "auto"},
+        },
+    }
+    override = {
+        "property": "t_work_mode",
+        "climate": {"options": {0: "fan_only", 2: "cool", 3: "dry", 4: "auto"}},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["climate"]["target"] == "hvac_mode"
+    assert merged["climate"]["options"] == {
+        0: "fan_only",
+        2: "cool",
+        3: "dry",
+        4: "auto",
+    }
+
+
+def test_combine_replaces_as_whole():
+    base = {
+        "property": "total_energy",
+        "combine": [{"property": "a"}, {"property": "b"}],
+    }
+    override = {
+        "property": "total_energy",
+        "combine": [{"property": "c"}],
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["combine"] == [{"property": "c"}]
+
+
+def test_dict_valued_min_max_replace_as_whole():
+    base = {
+        "property": "t_temp",
+        "climate": {
+            "target": "target_temperature",
+            "min_value": {"celsius": 16, "fahrenheit": 61},
+            "max_value": {"celsius": 32, "fahrenheit": 90},
+        },
+    }
+    override = {
+        "property": "t_temp",
+        "climate": {"min_value": {"celsius": 8, "fahrenheit": 46}},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["climate"]["min_value"] == {"celsius": 8, "fahrenheit": 46}
+    assert merged["climate"]["max_value"] == {"celsius": 32, "fahrenheit": 90}
+
+
+def test_different_platform_replaces_block_but_top_level_inherits():
+    base = {
+        "property": "p",
+        "icon": "mdi:eye",
+        "hide": True,
+        "sensor": {"device_class": "temperature", "unit": "°C"},
+    }
+    override = {
+        "property": "p",
+        "select": {"options": {0: "a", 1: "b"}},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["icon"] == "mdi:eye"
+    assert merged["hide"] is True
+    assert "sensor" not in merged
+    assert merged["select"] == {"options": {0: "a", 1: "b"}}
+
+
+def test_explicit_null_in_platform_unsets_base_field():
+    base = {
+        "property": "t_setpoint",
+        "sensor": {
+            "device_class": "temperature",
+            "unit": "°C",
+            "state_class": "measurement",
+        },
+    }
+    override = {
+        "property": "t_setpoint",
+        "sensor": {"state_class": None},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["sensor"]["device_class"] == "temperature"
+    assert merged["sensor"]["unit"] == "°C"
+    assert merged["sensor"]["state_class"] is None
+
+
+def test_explicit_null_at_top_level_unsets_field():
+    base = {
+        "property": "p",
+        "icon": "mdi:eye",
+        "sensor": {"device_class": "temperature", "unit": "°C"},
+    }
+    override = {
+        "property": "p",
+        "icon": None,
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["icon"] is None
+    assert merged["sensor"] == {"device_class": "temperature", "unit": "°C"}
+
+
+def test_bare_platform_in_subtype_inherits_base_block():
+    """A subtype writing ``switch:`` (parsed as None) is YAML shorthand for
+    ``switch: {}`` — "this property is a switch with no overrides" — and
+    should inherit the base's switch block, not unset the platform."""
+    base = {
+        "property": "AntiCrease",
+        "icon": "mdi:iron",
+        "switch": {"on": 1, "off": 0},
+    }
+    override = {
+        "property": "AntiCrease",
+        "icon": "mdi:iron",
+        "switch": None,
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["switch"] == {"on": 1, "off": 0}
+
+
+def test_bare_platform_in_subtype_with_no_base_platform():
+    """When base has no platform key, a subtype's bare ``switch:`` adds the
+    platform; the value flows through as None and the parser handles it as
+    "switch entity with defaults"."""
+    base = {"property": "p"}
+    override = {"property": "p", "switch": None}
+
+    merged = _merge_property(base, override)
+
+    assert "switch" in merged
+    assert merged["switch"] is None
+
+
+def test_no_base_returns_override_copy():
+    override = {"property": "p", "sensor": {"unit": "kWh"}}
+
+    merged = _merge_property(None, override)
+
+    assert merged == override
+    assert merged is not override
+
+
+def test_property_constructed_from_merged_dict():
+    base = {
+        "property": "t_temp",
+        "climate": {
+            "target": "target_temperature",
+            "max_value": 32,
+            "min_value": 16,
+        },
+    }
+    override = {
+        "property": "t_temp",
+        "climate": {"max_value": 30},
+    }
+
+    merged = _merge_property(base, override)
+    prop = Property(merged)
+
+    assert prop.climate.target == "target_temperature"
+    assert prop.climate.max_value == 30
+    assert prop.climate.min_value == 16
+
+
+def test_state_class_explicit_null_suppresses_auto_fallback_signal():
+    sensor = Sensor("t_setpoint", {"state_class": None})
+
+    assert sensor.state_class is None
+    assert sensor.state_class_explicit is True
+
+
+def test_state_class_absent_does_not_set_explicit_flag():
+    sensor = Sensor("t_setpoint", {})
+
+    assert sensor.state_class is None
+    assert sensor.state_class_explicit is False
+
+
+def test_state_class_explicit_value_sets_flag():
+    sensor = Sensor("t_setpoint", {"state_class": "measurement"})
+
+    assert sensor.state_class is not None
+    assert sensor.state_class_explicit is True


### PR DESCRIPTION
## Summary

Feature override files (`<type>-<feature>.yaml`) now inherit unspecified fields from the same-named property in the base type file (`<type>.yaml`). Author intent stays explicit — only the differences from base are declared — and overrides automatically pick up new fields the base gains over time.

The merge rule, in short:
- Any field in a property can be overridden in a feature file; unspecified fields are inherited from the base.
- If the override changes the platform (`sensor:` → `select:`), the override's platform block replaces the base's. Top-level fields (`icon`, `hide`, `disable`, `entity_category`, `unavailable`, `combine`) always inherit.
- Collections (`options`, `combine`, `command`, dict-valued `min_value` / `max_value`) replace as a whole — there is no per-key merging inside them.
- Set a field to `null` to explicitly unset what the base specified (e.g. `state_class: null` opts a sensor out of long-term statistics, `combine: null` converts a virtual combine sensor into a direct property reading).

Documented in `data_dictionaries/README.md` with worked examples (009 `t_temp` cap, 025 `StandardElectricitConsumption` direct-vs-combined).

This PR adds the machinery only — no YAML files are trimmed. Existing overrides keep working unchanged. Trim PRs by device family can follow.

### Side fix

The "No data dictionary found" warning previously fired for *placeholder* subtype files — files containing only a comment like `# Uses default mappings`. The warning now treats an empty subtype file as the explicit "base mapping is sufficient" marker and stays silent. A genuinely missing subtype file still warns as before.

## Implementation

- `Dictionaries.get_dictionary` reads base + subtype as raw dicts and merges per `_merge_property` before constructing `Property` objects.
- All parsers handle `key: null` (explicit null in YAML) gracefully — no more `EnumCls(None)` crashes.
- New `Sensor.state_class_explicit` flag makes `state_class: null` actually opt out of the integer/combine auto-fallback to `measurement` in `sensor.py`.
- `properties-schema.json` accepts `null` on inheritable fields. Booleans (`hide`, `disable`, `read_only`) stay as plain booleans — `false` is the unset value.
- `scripts/gen_strings.py` is now inheritance-aware: it pre-loads base files and merges each subtype property with its base counterpart before processing, so trimmed subtypes won't be misclassified or have legitimate translations pruned.

## Test plan

- [x] `uv run pytest tests/` — 19 passed (15 new tests in `test_dictionaries.py` covering same-platform field merge, top-level inheritance across platform changes, collection-replace-whole semantics, explicit-null at top level and inside platform blocks, bare-platform-key inheritance, and `state_class_explicit` tracking).
- [x] `uv run pyright` — 0 errors, 0 warnings.
- [x] `uv run python -m scripts.validate_mappings` — clean across all 102 YAML files.
- [x] `uv run python -m scripts.gen_strings` — zero diff in `strings.json` / `translations/en.json` against current YAMLs (the regression gate from the verification plan).
- [x] Tested in HA dev mode against ~30 dump devices — no behavioral regressions; only pre-existing warnings remain (a few truly-missing-YAML, plus dump-data oddities).

## Out of scope

- **YAML cleanup pass.** Trimming existing overrides to take advantage of inheritance is a separate effort, best done per device family in focused PRs.