### PR TITLE
Honor unknown_value: 0 in scalar parsers

### DIFF
--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -116,11 +116,7 @@ class Climate:
             TEMPERATURE_UNIT,
         ]:
             _LOGGER.warning("Missing climate.options for %s", name)
-        self.unknown_value = (
-            climate[UNKNOWN_VALUE]
-            if UNKNOWN_VALUE in climate and climate[UNKNOWN_VALUE]
-            else None
-        )
+        self.unknown_value = _val(climate, UNKNOWN_VALUE)
         self.min_value = _val(climate, MIN_VALUE)
         self.max_value = _val(climate, MAX_VALUE)
 
@@ -220,11 +216,7 @@ class Sensor:
     def __init__(self, name: str, sensor: dict | None):
         if sensor is None:
             sensor = {}
-        self.unknown_value = (
-            sensor[UNKNOWN_VALUE]
-            if UNKNOWN_VALUE in sensor and sensor[UNKNOWN_VALUE]
-            else None
-        )
+        self.unknown_value = _val(sensor, UNKNOWN_VALUE)
         self.read_only = _val(sensor, READ_ONLY)
         self.unit = _val(sensor, UNIT) or None
         self.multiplier = _val(sensor, MULTIPLIER)
@@ -321,11 +313,7 @@ class WaterHeater:
             _LOGGER.warning(
                 "Require at least 2 valid states in water_heater.options for %s", name
             )
-        self.unknown_value = (
-            water_heater[UNKNOWN_VALUE]
-            if UNKNOWN_VALUE in water_heater and water_heater[UNKNOWN_VALUE]
-            else None
-        )
+        self.unknown_value = _val(water_heater, UNKNOWN_VALUE)
         self.min_value = _val(water_heater, MIN_VALUE)
         self.max_value = _val(water_heater, MAX_VALUE)
 

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -252,3 +252,21 @@ def test_state_class_explicit_value_sets_flag():
 
     assert sensor.state_class is not None
     assert sensor.state_class_explicit is True
+
+
+def test_unknown_value_zero_is_honored():
+    """`unknown_value: 0` should be preserved as 0, not silently dropped.
+    A device reporting 0 (e.g., probe removed, sensor off) means "unknown",
+    and the YAML author signals that with the explicit 0 sentinel."""
+    sensor = Sensor("oven_temperature", {"unknown_value": 0})
+    assert sensor.unknown_value == 0
+
+
+def test_unknown_value_null_is_none():
+    sensor = Sensor("p", {"unknown_value": None})
+    assert sensor.unknown_value is None
+
+
+def test_unknown_value_absent_is_none():
+    sensor = Sensor("p", {})
+    assert sensor.unknown_value is None


### PR DESCRIPTION
## Summary

`unknown_value` parsing in `Climate`, `Sensor`, and `WaterHeater` used a truthy check (\`if X in d and d[X]\`) that silently dropped \`unknown_value: 0\` entries. Three properties in \`023.yaml\` are affected:

- \`Meat_probe_measured_temperature\`
- \`Meat_probe_set_temperature\`
- \`Oven_temperature\`

All three declare \`unknown_value: 0\`, signalling "0 means probe removed / oven off". The truthy check ignored the 0, so the entities reported 0 °C instead of "Unknown" in those states.

Switch the parsers to \`_val()\` (added in #471), which only treats \`null\`/\`absent\` as "no value" — preserving 0 as a valid sentinel.

Verified using the test server on a 023 oven (\`023-295608422d362be1\`): meat probe entities now report "Unknown" when the probe isn't inserted.

## Test plan
- [x] \`uv run pytest tests/\` — 22 passed (3 new tests covering \`unknown_value: 0\`, \`null\`, and absent)
- [x] \`uv run python -m scripts.validate_mappings\` — clean
- [x] Tested using the test server on a 023 oven (Meat probe sensors now show "Ukjent"/"Unknown" instead of 0 °C)