### PR TITLE
Trim redundant fields from feature override files

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006-200.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-200.yaml
@@ -2,7 +2,6 @@
 properties:
 - property: t_work_mode
   climate:
-    target: hvac_mode
     options:
       0: fan_only
       2: cool

--- a/custom_components/connectlife/data_dictionaries/006-201.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-201.yaml
@@ -1,11 +1,1 @@
-# Portable air conditioner
-properties:
-- property: t_work_mode
-  climate:
-    target: hvac_mode
-    options:
-      0: fan_only
-      1: heat
-      2: cool
-      3: dry
-      4: auto
+# Portable air conditioner — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/007-400.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-400.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     humidifier:
-      target: mode
       options:
         0: continuous
         1: manual

--- a/custom_components/connectlife/data_dictionaries/007-406.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-406.yaml
@@ -1,9 +1,1 @@
-properties:
-  - property: t_work_mode
-    humidifier:
-      target: mode
-      options:
-        0: continuous
-        1: manual
-        2: auto
-        3: clothes_dry
+# Dehumidifier — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/008-301.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-301.yaml
@@ -2,17 +2,12 @@
 properties:
   - property: t_fan_speed
     climate:
-      target: fan_mode
       options:
         2: low
         3: medium
         4: high
   - property: t_temp
     climate:
-      target: target_temperature
-      min_value:
-        celsius: 16
-        fahrenheit: 61
       max_value:
         celsius: 30
         fahrenheit: 86

--- a/custom_components/connectlife/data_dictionaries/008-399.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-399.yaml
@@ -2,7 +2,6 @@
 properties:
   - property: t_fan_speed
     climate:
-      target: fan_mode
       options:
         0: auto
         5: low
@@ -10,10 +9,6 @@ properties:
         9: high
   - property: t_temp
     climate:
-      target: target_temperature
-      min_value:
-        celsius: 16
-        fahrenheit: 61
       max_value:
         celsius: 30
         fahrenheit: 86

--- a/custom_components/connectlife/data_dictionaries/009-101.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-101.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-103.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-103.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -75,6 +75,5 @@ properties:
     sensor:
       device_class: power
       state_class: measurement
-      read_only: true
       unit: kW
       multiplier: 0.1

--- a/custom_components/connectlife/data_dictionaries/009-105.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-105.yaml
@@ -74,7 +74,6 @@ climate:
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-107.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-107.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-108.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-108.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-110.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-110.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-112.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-112.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-114.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-114.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-116.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-116.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-118.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-118.yaml
@@ -1,7 +1,6 @@
 properties:
   - property: t_work_mode
     climate:
-      target: hvac_mode
       options:
         0: fan_only
         2: cool

--- a/custom_components/connectlife/data_dictionaries/009-120.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-120.yaml
@@ -1,10 +1,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
       max_value:
         celsius: 30
         fahrenheit: 86
-      min_value:
-        celsius: 16
-        fahrenheit: 61

--- a/custom_components/connectlife/data_dictionaries/009-121.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-121.yaml
@@ -2,10 +2,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/009-122.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-122.yaml
@@ -2,10 +2,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/009-123.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-123.yaml
@@ -2,10 +2,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/009-124.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-124.yaml
@@ -2,10 +2,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/009-125.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-125.yaml
@@ -2,10 +2,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/009-126.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-126.yaml
@@ -2,10 +2,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/009-127.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-127.yaml
@@ -1,10 +1,6 @@
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
       max_value:
         celsius: 30
         fahrenheit: 86
-      min_value:
-        celsius: 16
-        fahrenheit: 61

--- a/custom_components/connectlife/data_dictionaries/009-129.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-129.yaml
@@ -11,10 +11,6 @@ climate:
 properties:
   - property: t_temp
     climate:
-      target: target_temperature
-      max_value:
-        celsius: 32
-        fahrenheit: 90
       min_value:
         celsius: 8
         fahrenheit: 46

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -16,7 +16,6 @@ properties:
         7: self_cleaning
       command:
         name: Selected_program_id
-    icon: mdi:clipboard-list
   - property: Selected_program_mode
     select:
       options:
@@ -27,7 +26,6 @@ properties:
       command:
         name: Program_mode
         adjust: 1
-    icon: mdi:cube-outline
   - property: Time_program_set_duration_status
     select:
       options:

--- a/custom_components/connectlife/data_dictionaries/015-1ux0s1005k15.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-1ux0s1005k15.yaml
@@ -13,7 +13,6 @@ properties:
         7: clean
       command:
         name: Selected_program_id
-    icon: mdi:clipboard-list
   - property: Selected_program_mode
     select:
       options:
@@ -25,4 +24,3 @@ properties:
       command:
         name: Program_mode
         adjust: 1
-    icon: mdi:cube-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2f.yaml
@@ -13,7 +13,6 @@ properties:
         7: clean
       command:
         name: Selected_program_id
-    icon: mdi:clipboard-list
   - property: Selected_program_mode
     select:
       options:
@@ -25,4 +24,3 @@ properties:
       command:
         name: Program_mode
         adjust: 1
-    icon: mdi:cube-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
@@ -13,7 +13,6 @@ properties:
         7: clean
       command:
         name: Selected_program_id
-    icon: mdi:clipboard-list
   - property: Selected_program_mode
     select:
       options:
@@ -25,4 +24,3 @@ properties:
       command:
         name: Program_mode
         adjust: 1
-    icon: mdi:cube-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -22,7 +22,6 @@ properties:
         7: self_cleaning
       command:
         name: Selected_program_id
-    icon: mdi:clipboard-list
   - property: Selected_program_mode
     select:
       options:
@@ -33,7 +32,6 @@ properties:
       command:
         name: Program_mode
         adjust: 1
-    icon: mdi:cube-outline
   - property: Time_program_set_duration_status
     select:
       options:

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
@@ -13,7 +13,6 @@ properties:
         7: self_cleaning
       command:
         name: Selected_program_id
-    icon: mdi:clipboard-list
   - property: Selected_program_mode
     select:
       options:
@@ -24,7 +23,6 @@ properties:
       command:
         name: Program_mode
         adjust: 1
-    icon: mdi:cube-outline
   - property: Time_program_set_duration_status
     select:
       options:

--- a/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
@@ -1,7 +1,6 @@
 # WashingMachine
 properties:
   - property: Current_program_phase
-    icon: mdi:state-machine
     sensor:
       device_class: enum
       options:
@@ -13,23 +12,8 @@ properties:
         7: spin-dry
         8: drying
         10: finished
-      read_only: true
-  - property: Detergent_display
-    icon: mdi:spray
-    binary_sensor:
-      options:
-        0: false
-        1: true
-  - property: Energy_estimate
-    icon: mdi:lightning-bolt
-    sensor:
-      read_only: true
-      state_class: total
-      device_class: energy
-      unit: kWh
   - property: ExtraRinseNum
     icon: mdi:tray-plus
-    entity_category: diagnostic
     select:
       options:
         0: "0"
@@ -37,7 +21,6 @@ properties:
         2: "2"
         3: "3"
   - property: RinseNum
-    icon: mdi:reload
     sensor:
       device_class: enum
       options:
@@ -64,42 +47,7 @@ properties:
         22: "clean_dry_60"
         41: "power49"
         42: "auto"
-  - property: Selected_program_remaining_time_in_minutes
-    icon: mdi:update
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true
-  - property: Selected_program_total_time_in_minutes
-    icon: mdi:timer
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true
-  - property: Selected_program_total_running_time_in_minutes
-    icon: mdi:timer
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true
-  - property: Softer_display
-    icon: mdi:water
-    binary_sensor:
-      options:
-        0: false
-        1: true
-  - property: temperature
-    icon: mdi:thermometer-lines
-    select:
-      options:
-        0: "cold"
-        2: "20"
-        3: "30"
-        4: "40"
-        6: "60"
-        9: "90"
   - property: Spin_speed_rpm
-    icon: mdi:rotate-3d-variant
     select:
       options:
         14: "1400"
@@ -108,9 +56,3 @@ properties:
         80: "800"
         60: "600"
         0: "none"
-  - property: spintime_index
-    icon: mdi:timer-sand
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj090728v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090728v0w.yaml
@@ -1,9 +1,7 @@
 # Washing Machine WF5S9045BW
 properties:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -31,23 +29,3 @@ properties:
       24: "shirts"
       41: "power49"
       42: "auto"
-- property: Spin_speed_rpm
-  icon: mdi:rotate-3d-variant
-  select:
-    options:
-      14: "1400"
-      12: "1200"
-      10: "1000"
-      8: "800"
-      6: "600"
-      0: "none"
-- property: temperature
-  icon: mdi:thermometer-lines
-  select:
-    options:
-      0: "cold"
-      2: "20"
-      3: "30"
-      4: "40"
-      6: "60"
-      9: "90"

--- a/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
@@ -9,10 +9,7 @@ properties:
       1: "not_granted"
       3: "granted"
   icon: 'mdi:shield-check'
-  entity_category: diagnostic
-
 - property: Child_lock
-  icon: mdi:lock
   # 1 = active, 0 = inactive
   switch:
     device_class: switch
@@ -20,9 +17,7 @@ properties:
 
 - property: Current_program_phase
   # Machine falls back to the first option from the selected program after machine is completed. Usually option 3 for washing program. 7 for spin-dry only program. 8 for drying only program. Dont know why.
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -35,9 +30,7 @@ properties:
       10: finished
 
 - property: DefaultSpinSpeed
-  icon: mdi:speedometer
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: "off"
@@ -48,7 +41,6 @@ properties:
       14: "1400"
 
 - property: DelayEndTime
-  icon: mdi:clock-outline
   select:
     options:
       0: "none"
@@ -92,10 +84,8 @@ properties:
       14: "1400"
 
 - property: Energy_estimate
-  icon: mdi:lightning-bolt
   # Estimates power consumption (0%-100%) for the selected program and options in 10 percentage steps, based on selected program options.
   sensor:
-    read_only: true
     device_class: power_factor
 #    unit: '%'
 
@@ -130,21 +120,6 @@ properties:
       41: "power49"
       42: "auto"
 
-- property: Selected_program_total_running_time_in_minutes
-  icon: mdi:timer
-  # Sample value: 49
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-
-- property: Selected_program_total_time_in_minutes
-  icon: mdi:timer
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-
 - property: Sound_setting
   # Sample value: 3 
   sensor:
@@ -153,7 +128,6 @@ properties:
 
 - property: Spin_speed_rpm
   # Sample value: 12 (1200 rpm)
-  icon: 'mdi:rotate-3d-variant'
   select:
     options:
       0: "off"
@@ -165,7 +139,6 @@ properties:
 
 - property: Steam
   # Sample value: 0
-  icon: mdi:heat-wave
   switch:
     device_class: switch
 
@@ -184,22 +157,4 @@ properties:
       120: "120_min"
       180: "180_min"
       240: "240_min"
-
-- property: spin_time
-  icon: mdi:timer-sand
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-
-- property: temperature
-  icon: mdi:thermometer-lines
-  select:
-    options:
-      0: "cold"
-      2: "20"
-      3: "30"
-      4: "40"
-      6: "60"
-      9: "90"
 

--- a/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
@@ -1,9 +1,7 @@
 # WF3S1014-SVW002-000
 properties:
   - property: Current_program_phase
-    icon: mdi:state-machine
     sensor:
-      read_only: true
       device_class: enum
       options:
         0: not_available
@@ -48,7 +46,6 @@ properties:
         1: level_1
         2: level_2
   - property: DelayEndTime
-    icon: mdi:clock-outline
     number:
       min_value: 4
       max_value: 24
@@ -56,7 +53,6 @@ properties:
       unit: h
   - property: ApplicationPermissions
     icon: mdi:cellphone-wireless
-    entity_category: diagnostic
     sensor:
       read_only: true
       device_class: enum

--- a/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
@@ -5,9 +5,7 @@ properties:
     read_only: true
   icon: 'mdi:shield-check'
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -27,28 +25,15 @@ properties:
       14: delay
       15: finished
 - property: Electricit_consumption
-  icon: mdi:lightning-bolt
-  sensor:
-    read_only: true
-    device_class: energy
-    unit: kWh
   combine:
     - property: Electricit_consumption_decimal
-- property: Energy_estimate
-  icon: mdi:lightning-bolt
-  sensor:
-    read_only: true
-    device_class: energy
-    unit: kWh
 - property: FlexibleSpinTime_Flag
   sensor:
     read_only: true
   icon: 'mdi:timer-cog'
 - property: RinseNum
   sensor:
-    read_only: true
     unit: times
-  icon: 'mdi:reload'
 - property: Selected_program_ID
   icon: mdi:playlist-check
   sensor:
@@ -86,15 +71,3 @@ properties:
     device_class: temperature
     unit: °C
   icon: 'mdi:thermometer'
-- property: Temperature_Default_DefaultMainWashTime
-  icon: mdi:clock-outline
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-- property: DryOpen_DefaultSpinSpeed
-  hide: true
-- property: ExtraRinseNum
-  hide: true
-- property: dry_time
-  hide: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj100722v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100722v0w.yaml
@@ -1,9 +1,7 @@
 # Washing machine WF3S1043BW3
 properties:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -44,9 +42,3 @@ properties:
       14: remote
       15: none
   icon: 'mdi:playlist-check'
-- property: Selected_program_remaining_time_in_minutes
-  icon: mdi:update
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min

--- a/custom_components/connectlife/data_dictionaries/025-1wj100923v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100923v0f.yaml
@@ -1,12 +1,6 @@
 #WashingMachine 025-1wj100923v0f
 properties:
-  - property: AutoTubClean
-    switch:
-  - property: Child_lock
-    icon: mdi:lock
-    switch:
   - property: Current_program_phase
-    icon: mdi:state-machine
     sensor:
       device_class: enum
       options:
@@ -16,16 +10,8 @@ properties:
         3: wash
         4: rinse
         7: spin-dry
-      read_only: true
-  - property: Detergent_display
-    icon: mdi:spray
-    binary_sensor:
-      options:
-        0: false
-        1: true
   - property: ExtraRinseNum
     icon: mdi:tray-plus
-    entity_category: diagnostic
     select:
       options:
         0: "0"
@@ -33,7 +19,6 @@ properties:
         2: "2"
         3: "3"
   - property: RinseNum
-    icon: mdi:reload
     sensor:
       device_class: enum
       options:
@@ -60,45 +45,7 @@ properties:
         22: "clean_dry_60"
         41: "power49"
         42: "auto"
-  - property: Selected_program_remaining_time_in_minutes
-    icon: mdi:update
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true
-  - property: Selected_program_total_time_in_minutes
-    icon: mdi:timer
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true
-  - property: Selected_program_total_running_time_in_minutes
-    icon: mdi:timer
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true
-  - property: Softer_display
-    icon: mdi:water
-    binary_sensor:
-      options:
-        0: false
-        1: true
-  - property: Steam
-    icon: mdi:heat-wave
-    switch:
-  - property: temperature
-    icon: mdi:thermometer-lines
-    select:
-      options:
-        0: "cold"
-        2: "20"
-        3: "30"
-        4: "40"
-        6: "60"
-        9: "90"
   - property: Spin_speed_rpm
-    icon: mdi:rotate-3d-variant
     select:
       options:
         14: "1400"
@@ -107,9 +54,3 @@ properties:
         80: "800"
         60: "600"
         0: "none"
-  - property: spintime_index
-    icon: mdi:timer-sand
-    sensor:
-      device_class: duration
-      unit: min
-      read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj105050v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105050v0w.yaml
@@ -1,9 +1,7 @@
 # Washing Machine
 properties:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -39,23 +37,3 @@ properties:
       42: "auto"
       44: "bed_linen"
       45: "jeans"
-- property: Spin_speed_rpm
-  icon: mdi:rotate-3d-variant
-  select:
-    options:
-      14: "1400"
-      12: "1200"
-      10: "1000"
-      8: "800"
-      6: "600"
-      0: "none"
-- property: temperature
-  icon: mdi:thermometer-lines
-  select:
-    options:
-      0: "cold"
-      2: "20"
-      3: "30"
-      4: "40"
-      6: "60"
-      9: "90"

--- a/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
@@ -1,9 +1,7 @@
 # Washing Machine WFSE1114-LVW002
 properties:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -24,10 +22,7 @@ properties:
       15: finished
 - property: DefaultSpinSpeed
   sensor:
-    read_only: true
-    unit: rpm
     multiplier: 100
-  icon: 'mdi:speedometer'
 - property: DryOpen_DefaultSpinSpeed
   # Sample value: 14
   sensor:
@@ -36,26 +31,15 @@ properties:
     multiplier: 100
   icon: 'mdi:speedometer'
 - property: Electricit_consumption
-  icon: mdi:lightning-bolt
   sensor:
-    read_only: true
-    device_class: energy
     state_class: total
-    unit: kWh
   combine:
     - property: Electricit_consumption_decimal
 - property: Program_end_to_shutdown_time_in_minutes
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-  icon: 'mdi:timer'
   hide: true
 - property: RinseNum
   sensor: # Sample value: 2
-    read_only: true
     unit: times
-  icon: 'mdi:reload'
 - property: Selected_program_ID
   sensor: # Sample value: 9
     read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
@@ -5,9 +5,7 @@ properties:
     read_only: true
   icon: 'mdi:shield-check'
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -32,9 +30,7 @@ properties:
   icon: 'mdi:timer-cog'
 - property: RinseNum
   sensor:
-    read_only: true
     unit: times
-  icon: 'mdi:reload'
 - property: Selected_program_ID
   sensor:
     read_only: true
@@ -72,22 +68,5 @@ properties:
     device_class: temperature
     unit: °C
   icon: 'mdi:thermometer'
-- property: Temperature_Default_DefaultMainWashTime
-  icon: mdi:clock-outline
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-- property: DryOpen_DefaultSpinSpeed
-  hide: true
-- property: ExtraRinseNum
-  hide: true
 - property: Program_end_to_shutdown_time_in_minutes
-  sensor:
-    read_only: true
-    device_class: duration
-    unit: min
-  icon: 'mdi:timer'
-  hide: true
-- property: dry_time
   hide: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj105418v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105418v0t.yaml
@@ -1,9 +1,7 @@
 # Washing Machine
 properties:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -16,7 +14,6 @@ properties:
       10: finished
 - property: ExtraRinseNum
   icon: mdi:tray-plus
-  entity_category: diagnostic
   select:
     options:
       0: "0"
@@ -43,23 +40,3 @@ properties:
       22: "clean_dry_60"
       41: "power49"
       42: "auto"
-- property: Spin_speed_rpm
-  icon: mdi:rotate-3d-variant
-  select:
-    options:
-      14: "1400"
-      12: "1200"
-      10: "1000"
-      8: "800"
-      6: "600"
-      0: "none"
-- property: temperature
-  icon: mdi:thermometer-lines
-  select:
-    options:
-      0: "cold"
-      2: "20"
-      3: "30"
-      4: "40"
-      6: "60"
-      9: "90"

--- a/custom_components/connectlife/data_dictionaries/025-1wj105552v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105552v0w.yaml
@@ -1,26 +1,14 @@
 # Washing Machine
 properties:
-- property: AntiCrease
-  icon: mdi:iron
-  switch:
-- property: AutoDose
-  icon: mdi:tray-arrow-up
-  switch:
 - property: AutoDose_flag
-  hide: true
   icon: mdi:tray-arrow-up
   sensor:
     device_class: enum
     options:
       0: "unavailable"
       1: "available"
-- property: Child_lock
-  icon: mdi:lock
-  switch:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -34,7 +22,6 @@ properties:
       11: delay
 - property: ExtraRinseNum
   icon: mdi:tray-plus
-  entity_category: diagnostic
   select:
     options:
       0: "0"
@@ -68,28 +55,11 @@ properties:
       52: "power_30"
       56: "pets"
       57: "full_load_49"
-- property: Selected_program_remaining_time_in_minutes
-  icon: mdi:update
-  sensor:
-    device_class: duration
-    unit: min
-    read_only: true
 - property: Selected_program_total_time_in_minutes
-  icon: mdi:timer
   hide: true
-  sensor:
-    device_class: duration
-    unit: min
-    read_only: true
 - property: Selected_program_total_running_time_in_minutes
-  icon: mdi:timer
   hide: true
-  sensor:
-    device_class: duration
-    unit: min
-    read_only: true
 - property: Spin_speed_rpm
-  icon: mdi:rotate-3d-variant
   select:
     options:
       14: "1400"
@@ -98,9 +68,6 @@ properties:
       80: "800"
       60: "600"
       0: "none"
-- property: Steam
-  icon: mdi:heat-wave
-  switch:
 - property: dry_time
   icon: mdi:tumble-dryer
   select:
@@ -116,14 +83,3 @@ properties:
       120: "120"
       180: "180"
       240: "240"
-- property: temperature
-  icon: mdi:thermometer-lines
-  select:
-    options:
-      0: "cold"
-      2: "20"
-      3: "30"
-      4: "40"
-      6: "60"
-      9: "90"
-

--- a/custom_components/connectlife/data_dictionaries/025-1wj120238v0b.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120238v0b.yaml
@@ -22,30 +22,8 @@ properties:
         42: auto
         44: bedding
         45: jeans
-  - property: Spin_speed_rpm
-    icon: mdi:rotate-3d-variant
-    select:
-      options:
-        0: none
-        6: "600"
-        8: "800"
-        10: "1000"
-        12: "1200"
-        14: "1400"
-  - property: temperature
-    icon: mdi:thermometer-lines
-    select:
-      options:
-        0: cold
-        2: "20"
-        3: "30"
-        4: "40"
-        6: "60"
-        9: "90"
   - property: Current_program_phase
-    icon: mdi:state-machine
     sensor:
-      read_only: true
       device_class: enum
       options:
         0: not_available

--- a/custom_components/connectlife/data_dictionaries/025-1wj120261v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120261v0w.yaml
@@ -1,10 +1,8 @@
 # Washing Machine
 properties:
 - property: Door_status
-  unavailable: 0
   binary_sensor:
     device_class: door
     options:
       1: off
       2: on
-  icon: mdi:door

--- a/custom_components/connectlife/data_dictionaries/025-1wj120389v0b.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120389v0b.yaml
@@ -1,10 +1,8 @@
 # Washing Machine
 properties:
 - property: Door_status
-  unavailable: 0
   binary_sensor:
     device_class: door
     options:
       1: off
       2: on
-  icon: mdi:door

--- a/custom_components/connectlife/data_dictionaries/025-1wj120514v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120514v0t.yaml
@@ -1,9 +1,7 @@
 # Washing Machine
 properties:
 - property: Current_program_phase
-  icon: mdi:state-machine
   sensor:
-    read_only: true
     device_class: enum
     options:
       0: not_available
@@ -53,23 +51,3 @@ properties:
       44: "bed_linen"
       45: "jeans"
       55: "hand_wash"
-- property: Spin_speed_rpm
-  icon: mdi:rotate-3d-variant
-  select:
-    options:
-      14: "1400"
-      12: "1200"
-      10: "1000"
-      8: "800"
-      6: "600"
-      0: "none"
-- property: temperature
-  icon: mdi:thermometer-lines
-  select:
-    options:
-      0: "cold"
-      2: "20"
-      3: "30"
-      4: "40"
-      6: "60"
-      9: "90"

--- a/custom_components/connectlife/data_dictionaries/026-1b0330z0079j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0330z0079j.yaml
@@ -1,13 +1,8 @@
 properties:
   - property: freeze_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: -24
       max_value: -14
   - property: refrigerator_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: 2
-      max_value: 8

--- a/custom_components/connectlife/data_dictionaries/026-1b0470z0026j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0470z0026j.yaml
@@ -2,19 +2,12 @@
 properties:
   - property: freeze_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: -18
       max_value: -14
   - property: refrigerator_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: 2
-      max_value: 8
   - property: variation_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: -18
       max_value: -14

--- a/custom_components/connectlife/data_dictionaries/026-1b0628z0075j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0628z0075j.yaml
@@ -1,17 +1,12 @@
 properties:
   - property: freeze_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: -24
       max_value: -14
   - property: ice_making_state
     switch: {}
   - property: refrigerator_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: 2
-      max_value: 8
   - property: sf_sr_mutex_mode
     switch: {}

--- a/custom_components/connectlife/data_dictionaries/026-1b0628z0146j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0628z0146j.yaml
@@ -2,13 +2,8 @@
 properties:
   - property: freeze_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: -24
       max_value: -14
   - property: refrigerator_temperature
     number:
-      device_class: temperature
-      unit: °C
       min_value: 2
-      max_value: 8

--- a/custom_components/connectlife/data_dictionaries/030-1wk080027e0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk080027e0w.yaml
@@ -1,7 +1,6 @@
 # Tumble dryer model DHSE80-BEW001
 properties:
   - property: Selected_program_ID
-    icon: mdi:selection-ellipse-arrow-inside
     select:
       options:
         1: auto

--- a/custom_components/connectlife/data_dictionaries/030-1wk080140v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk080140v0w.yaml
@@ -1,6 +1,5 @@
 properties:
   - property: Selected_program_ID
-    icon: mdi:selection-ellipse-arrow-inside
     select:
       options:
         1: auto
@@ -19,7 +18,6 @@ properties:
         19: down
         28: eco
   - property: dry_time
-    icon: mdi:timer
     select:
       options:
         1: wardrobe

--- a/custom_components/connectlife/data_dictionaries/030-1wk100266v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk100266v0f.yaml
@@ -1,7 +1,6 @@
 # Tumble Dryer
 properties:
   - property: Selected_program_ID
-    icon: mdi:selection-ellipse-arrow-inside
     select:
       options:
         1: auto


### PR DESCRIPTION
## Summary

With property inheritance in place (#471), feature override files no longer need to redeclare fields that match their base type. This pass removes **512 net lines across 55 files**:

- **50 fully-redundant property entries** deleted (subtype declared a property identical to base).
- **96 partial overrides** trimmed to only the fields that actually differ from base.
- **Two fully-redundant subtype files** (\`006-201.yaml\`, \`007-406.yaml\`) converted to comment-only markers, matching the convention used by \`016-502.yaml\` and \`032-000.yaml\`.

Comments, quote style, and file-specific indentation preserved across all files.

## Test plan
- [x] \`uv run python -m scripts.validate_mappings\` — clean across all 102 YAMLs
- [x] \`uv run python -m scripts.gen_strings\` — **zero diff** to \`strings.json\` / \`translations/en.json\` (no behavior change for any device)
- [x] \`uv run pytest tests/\` — 22 passed
- [x] Started HA in dev mode against test server with all ~30 dump devices — no errors, no warnings

## Out of scope (future PRs per \`local/todo.md\`)

- Quote consistency across mapping files
- Consistent icon usage (e.g. \`mdi:temp\` is not a valid MDI icon)
- Consistent indentation across mapping files
- Unify option keys
- Clean up spin speed properties