### PR TITLE
Fix inheritance issues

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -565,7 +565,6 @@ properties:
   - property: Temperature_unit_status
     hide: true
   - property: Time_program_set_duration_status
-    hide: true
   - property: Total_energy_consumption
     sensor:
       state_class: total_increasing

--- a/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
@@ -2,6 +2,7 @@
 properties:
 - property: ApplicationPermissions
   # 1 = not granted (No remote control allowed), 3 = granted (Remote control allowed) ?
+  hide: false
   sensor:
     read_only: true
     device_class: enum
@@ -120,12 +121,6 @@ properties:
       41: "power49"
       42: "auto"
 
-- property: Sound_setting
-  # Sample value: 3 
-  sensor:
-    read_only: true
-  icon: 'mdi:volume-high'
-
 - property: Spin_speed_rpm
   # Sample value: 12 (1200 rpm)
   select:
@@ -157,4 +152,3 @@ properties:
       120: "120_min"
       180: "180_min"
       240: "240_min"
-

--- a/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
@@ -52,6 +52,7 @@ properties:
       device_class: duration
       unit: h
   - property: ApplicationPermissions
+    hide: false
     icon: mdi:cellphone-wireless
     sensor:
       read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
@@ -1,6 +1,7 @@
 # Washing machine WFQR1014
 properties:
 - property: ApplicationPermissions
+  hide: false
   sensor:
     read_only: true
   icon: 'mdi:shield-check'
@@ -27,10 +28,6 @@ properties:
 - property: Electricit_consumption
   combine:
     - property: Electricit_consumption_decimal
-- property: FlexibleSpinTime_Flag
-  sensor:
-    read_only: true
-  icon: 'mdi:timer-cog'
 - property: RinseNum
   sensor:
     unit: times
@@ -56,10 +53,6 @@ properties:
       13: extra_hygiene
       14: remote
       15: none
-- property: Sound_setting
-  sensor:
-    read_only: true
-  icon: 'mdi:volume-high'
 - property: Spin_speed_rpm
   sensor:
     read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
@@ -1,6 +1,7 @@
 # Washing machine WF3S1043BW3
 properties:
 - property: ApplicationPermissions
+  hide: false
   sensor:
     read_only: true
   icon: 'mdi:shield-check'
@@ -24,10 +25,6 @@ properties:
       13: anti_crease
       14: delay
       15: finished
-- property: FlexibleSpinTime_Flag
-  sensor:
-    read_only: true
-  icon: 'mdi:timer-cog'
 - property: RinseNum
   sensor:
     unit: times
@@ -53,10 +50,6 @@ properties:
       14: remote
       15: none
   icon: 'mdi:playlist-check'
-- property: Sound_setting
-  sensor:
-    read_only: true
-  icon: 'mdi:volume-high'
 - property: Spin_speed_rpm
   sensor:
     read_only: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj105552v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105552v0w.yaml
@@ -1,12 +1,5 @@
 # Washing Machine
 properties:
-- property: AutoDose_flag
-  icon: mdi:tray-arrow-up
-  sensor:
-    device_class: enum
-    options:
-      0: "unavailable"
-      1: "available"
 - property: Current_program_phase
   sensor:
     device_class: enum

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -245,8 +245,14 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: AutoDose_flag
-    hide: true
+    icon: mdi:tray-arrow-up
     entity_category: diagnostic
+    sensor:
+      device_class: enum
+      options:
+        0: unavailable
+        1: available
+      read_only: true
   - property: BathingWaterPumpState
     hide: true
     entity_category: diagnostic
@@ -521,8 +527,6 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: QuickerMode
-    hide: true
-    entity_category: diagnostic
   - property: Quiet_model
     hide: true
     entity_category: diagnostic
@@ -925,7 +929,6 @@ properties:
     entity_category: diagnostic
   - property: ApplicationPermissions
     hide: true
-    entity_category: diagnostic
   - property: BathingWaterPump_Flag
     hide: true
     entity_category: diagnostic
@@ -954,10 +957,10 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: DryOpen_DefaultSpinSpeed
-    hide: true
-    entity_category: diagnostic
   - property: FlexibleSpinTime_Flag
-    hide: true
+    sensor:
+      read_only: true
+    icon: 'mdi:timer-cog'
     entity_category: diagnostic
   - property: Fluffysoft_flag
     hide: true
@@ -1022,6 +1025,9 @@ properties:
   - property: Sound_setting
     hide: true
     entity_category: diagnostic
+    sensor:
+      read_only: true
+    icon: 'mdi:volume-high'
   - property: SpinRange
     hide: true
     entity_category: diagnostic
@@ -1120,8 +1126,6 @@ properties:
     sensor:
       read_only: true
   - property: ExtraRinseNum
-    hide: true
-    entity_category: diagnostic
   - property: Filterclean_washCound
     hide: true
     entity_category: diagnostic
@@ -1132,8 +1136,6 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: Selected_program_ID
-    hide: true
-    entity_category: diagnostic
   - property: Spin_speed_rpm
     icon: mdi:rotate-3d-variant
     select:
@@ -1145,8 +1147,6 @@ properties:
         12: "1200"
         14: "1400"
   - property: dry_time
-    hide: true
-    entity_category: diagnostic
   - property: once_strong_step_time
     hide: true
     entity_category: diagnostic

--- a/custom_components/connectlife/data_dictionaries/026-1b0628z0075j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0628z0075j.yaml
@@ -10,3 +10,5 @@ properties:
       min_value: 2
   - property: sf_sr_mutex_mode
     switch: {}
+    hide: false
+    entity_category: config

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -338,10 +338,8 @@ class Property:
     def __init__(self, entry: dict):
         self.name = entry[PROPERTY]
         self.icon = _val(entry, ICON) or None
-        self.hide = entry[HIDE] == bool(entry[HIDE]) if HIDE in entry else False
-        self.disable = (
-            entry[DISABLE] == bool(entry[DISABLE]) if DISABLE in entry else False
-        )
+        self.hide = bool(entry[HIDE]) if HIDE in entry else False
+        self.disable = bool(entry[DISABLE]) if DISABLE in entry else False
         self.unavailable = _val(entry, UNAVAILABLE)
         entity_category = _val(entry, ENTITY_CATEGORY)
         self.entity_category = (

--- a/scripts/validate_mappings.py
+++ b/scripts/validate_mappings.py
@@ -1,13 +1,47 @@
 import pprint
+import sys
 from os import listdir
 from os.path import isfile, join
 
 from jschon import create_catalog, JSON, JSONSchema
 import yaml
 
+from custom_components.connectlife.dictionaries import _merge_property
+
+PLATFORMS = ('binary_sensor', 'climate', 'humidifier', 'number', 'select',
+             'sensor', 'switch', 'water_heater')
+
+
 def my_construct_mapping(self, node, deep=False):
     data = self.construct_mapping_org(node, deep)
     return {(str(key) if isinstance(key, int) else key): data[key] for key in data}
+
+
+def _is_sensor_platform(entry):
+    """Return True if the merged property entry resolves to a sensor entity.
+
+    A property is a sensor when it has an explicit ``sensor:`` key, or no
+    platform key at all (default sensor)."""
+    explicit = next((p for p in PLATFORMS if p in entry), None)
+    return explicit == 'sensor' or explicit is None
+
+
+def _check_entity_category_config_on_sensor(filename, merged_entry):
+    """HA rejects sensors with ``entity_category: config`` — that category is
+    reserved for entities the user can change directly (numbers, selects,
+    switches). Catch the combination at validation time so it fails the PR
+    rather than the integration setup."""
+    if merged_entry.get('entity_category') != 'config':
+        return None
+    if not _is_sensor_platform(merged_entry):
+        return None
+    return (
+        f"{filename}: property '{merged_entry['property']}' resolves to a "
+        f"sensor with entity_category=config. HA only allows config on "
+        f"writable entities (number/select/switch); use diagnostic or "
+        f"omit the category for sensors."
+    )
+
 
 def main(basedir):
     yaml.SafeLoader.construct_mapping_org = yaml.SafeLoader.construct_mapping
@@ -21,17 +55,47 @@ def main(basedir):
 
     filenames = list(filter(lambda f: f[-5:] == ".yaml", [f for f in listdir(device_dir) if isfile(join(device_dir, f))]))
     filenames.sort()
+
+    # Pre-load base files so we can merge subtype entries before checking
+    # cross-cutting rules like "no config on sensors".
+    bases = {}
+    for filename in filenames:
+        if '-' in filename.removesuffix('.yaml'):
+            continue
+        type_code = filename.removesuffix('.yaml')
+        with open(f"{device_dir}/{filename}") as f:
+            doc = yaml.safe_load(f) or {}
+        bases[type_code] = {p['property']: p for p in (doc.get('properties') or [])}
+
+    errors = []
     for filename in filenames:
         print(f"Validating {filename}")
         with open(f"{device_dir}/{filename}", "r") as f:
             mappings_yaml = yaml.safe_load(f)
         if mappings_yaml is None:
             print("Empty mapping file")
-        else:
-            mappings_json = JSON(mappings_yaml)
-            result = schema.evaluate(mappings_json)
-            if not result.valid:
-                pprint.pp(result.output("basic")["errors"])
+            continue
+        mappings_json = JSON(mappings_yaml)
+        result = schema.evaluate(mappings_json)
+        if not result.valid:
+            pprint.pp(result.output("basic")["errors"])
+            errors.append(filename)
+
+        # Cross-cutting rule checks on merged property entries
+        is_subtype = '-' in filename.removesuffix('.yaml')
+        type_code = filename.split('-')[0] if is_subtype else filename.removesuffix('.yaml')
+        base_props = bases.get(type_code, {}) if is_subtype else {}
+        for prop in (mappings_yaml.get('properties') or []):
+            name = prop['property']
+            merged = _merge_property(base_props.get(name), prop) if is_subtype else prop
+            err = _check_entity_category_config_on_sensor(filename, merged)
+            if err:
+                print(err)
+                errors.append(filename)
+
+    if errors:
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main("custom_components/connectlife")

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -270,3 +270,19 @@ def test_unknown_value_null_is_none():
 def test_unknown_value_absent_is_none():
     sensor = Sensor("p", {})
     assert sensor.unknown_value is None
+
+
+def test_hide_false_actually_disables_hiding():
+    """Regression: the parser used `entry[HIDE] == bool(entry[HIDE])`, which
+    evaluates True for any boolean — so `hide: false` previously set
+    `self.hide = True`. With inheritance, that broke the only way for a
+    subtype to clear an inherited `hide: true` from a base placeholder."""
+    assert Property({"property": "p", "hide": False}).hide is False
+    assert Property({"property": "p", "hide": True}).hide is True
+    assert Property({"property": "p"}).hide is False
+
+
+def test_disable_false_actually_disables_disabling():
+    assert Property({"property": "p", "disable": False}).disable is False
+    assert Property({"property": "p", "disable": True}).disable is True
+    assert Property({"property": "p"}).disable is False


### PR DESCRIPTION
## Summary

Property inheritance from #471 silently regressed visibility for ~20 entities: base placeholder entries with `hide: true` and `entity_category: diagnostic` propagated to subtypes that upgraded the property to a real entity. The intended visible/operational entity ended up hidden in the diagnostic section.

This PR fixes the regression at three levels.

### 1. Parser bug fix

`Property.__init__` had:

```python
self.hide = entry[HIDE] == bool(entry[HIDE]) if HIDE in entry else False
```

The expression `False == bool(False)` is `True`, so `hide: false` previously set `self.hide = True` — the exact opposite of intent. Same buggy pattern for `disable`. Latent until inheritance made `hide: false` overrides meaningful (before #471, you'd just omit the field). Replaced with `bool(entry[HIDE])` and added regression tests.

### 2. Per-property cleanup of affected base placeholders

11 base placeholder properties were upgraded by 1+ subtypes, propagating `hide: true` to those subtypes. Each fixed per its semantics:

- **Promoted to real base entry** (read-only sensors with consistent shape across subtypes — safe to promote because non-overriding variants get a benign read-only sensor): `Sound_setting`, `FlexibleSpinTime_Flag`, `AutoDose_flag`. Subtypes drop their now-redundant overrides via inheritance.
- **Stripped placeholder `hide`/`entity_category`** (writable platforms can't be safely promoted — non-overriding variants might not support the write): `Time_program_set_duration_status`, `Selected_program_ID`, `DryOpen_DefaultSpinSpeed`, `ExtraRinseNum`, `dry_time`, `QuickerMode`.
- **Kept as `hide: true` placeholder, with explicit `hide: false` in upgrading subtype** (and `entity_category: config` where the override is a writable user setting): `ApplicationPermissions`, `sf_sr_mutex_mode`. Drops `entity_category: diagnostic` from these placeholders — diagnostic implies *meaningful* read-only info, but an unmapped property is just unmapped.

### 3. Validation check

`scripts/validate_mappings.py` gains a cross-cutting rule that catches sensors with `entity_category: config` — HA rejects that combination at runtime (`config` is reserved for writable entities). The check runs against **merged** base+subtype properties so it catches the inheritance-propagation case where a base placeholder's `entity_category: config` would silently apply to a subtype's sensor.

## Principle

An override is the author's signal that the property is important for that variant — base placeholder UI flags shouldn't silently propagate. When an override needs to flip an inherited flag, the YAML now lets it (`hide: false` works, `entity_category: null` clears the inherited category).

## Test plan

- [x] `uv run pytest tests/` — 24 passed (2 new regression tests for the parser bug)
- [x] `uv run pyright` — 0 errors
- [x] `uv run python -m scripts.validate_mappings` — clean (the new check fires correctly when a sensor + config combo is introduced; verified with hand-crafted inputs)
- [x] `uv run python -m scripts.gen_strings` — zero diff in `strings.json`/`translations/en.json`
- [x] HA dev mode against ~30 dump devices — no errors, no warnings (was previously `HomeAssistantError: Entity ... cannot be added as the entity category is set to config` on multiple entities)