### PR TITLE
Consolidate icon choices and hoist shared icons to base files

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -19,7 +19,7 @@ properties:
     unit: W
     read_only: true
     state_class: measurement
-  icon: mdi:flash
+  icon: mdi:lightning-bolt
 - property: f_temp_in
   icon: mdi:thermometer
   climate:

--- a/custom_components/connectlife/data_dictionaries/007.yaml
+++ b/custom_components/connectlife/data_dictionaries/007.yaml
@@ -42,7 +42,7 @@ properties:
       unit: W
       read_only: true
       state_class: measurement
-    icon: mdi:flash
+    icon: mdi:lightning-bolt
   - property: t_fan_speed
     icon: mdi:fan
     select:

--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -211,7 +211,7 @@ properties:
   - property: t_fan_mute
     switch:
       device_class: switch
-    icon: mdi:volume-variant-off
+    icon: mdi:volume-off
   - property: t_fan_speed
     climate:
       target: fan_mode

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -236,7 +236,7 @@ properties:
       unit: W
       read_only: true
       state_class: measurement
-    icon: mdi:flash
+    icon: mdi:lightning-bolt
   - property: f_temp_in
     climate:
       target: current_temperature

--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -41,4 +41,3 @@ properties:
       command:
         name: Time_program_set_duration
         adjust: 1
-    icon: mdi:timer-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -47,4 +47,3 @@ properties:
       command:
         name: Time_program_set_duration
         adjust: 1
-    icon: mdi:timer-outline

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
@@ -38,4 +38,3 @@ properties:
       command:
         name: Time_program_set_duration
         adjust: 1
-    icon: mdi:timer-outline

--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -222,7 +222,7 @@ properties:
       options:
         1: off
         2: on
-    icon: mdi:folder-open-outline
+    icon: mdi:door
   - property: Energy_consumption_in_running_program
     sensor:
       state_class: total_increasing
@@ -396,7 +396,7 @@ properties:
       command:
         name: Feedback_volumen_setting
         adjust: 1
-    icon: mdi:volume-low
+    icon: mdi:volume-high
   - property: Fill_salt
     binary_sensor:
       device_class: problem
@@ -448,7 +448,7 @@ properties:
       command:
         name: Notification_volumen_setting
         adjust: 1
-    icon: mdi:volume-low
+    icon: mdi:volume-high
   - property: Odor_control_setting
     entity_category: config
     unavailable: 0
@@ -500,7 +500,7 @@ properties:
   - property: Selected_program_auto_door_open_function
     binary_sensor:
       device_class: door
-    icon: mdi:folder-open-outline
+    icon: mdi:door
     hide: true
   - property: Selected_program_dry_function
     hide: true
@@ -565,6 +565,7 @@ properties:
   - property: Temperature_unit_status
     hide: true
   - property: Time_program_set_duration_status
+    icon: mdi:timer
   - property: Total_energy_consumption
     sensor:
       state_class: total_increasing

--- a/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090660v0w.yaml
@@ -13,7 +13,6 @@ properties:
         8: drying
         10: finished
   - property: ExtraRinseNum
-    icon: mdi:tray-plus
     select:
       options:
         0: "0"
@@ -28,7 +27,6 @@ properties:
         2: "2"
         3: "3"
   - property: Selected_program_ID
-    icon: mdi:tshirt-crew
     select:
       options:
         1: "cotton_dry"

--- a/custom_components/connectlife/data_dictionaries/025-1wj090728v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090728v0w.yaml
@@ -13,7 +13,6 @@ properties:
       8: drying
       10: finished
 - property: Selected_program_ID
-  icon: mdi:tshirt-crew
   select:
     options:
       6: "drum_cleaning"

--- a/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090913v0f.yaml
@@ -9,12 +9,10 @@ properties:
     options:
       1: "not_granted"
       3: "granted"
-  icon: 'mdi:shield-check'
 - property: Child_lock
   # 1 = active, 0 = inactive
   switch:
     device_class: switch
-  #icon_on: 'mdi:account-lock'
 
 - property: Current_program_phase
   # Machine falls back to the first option from the selected program after machine is completed. Usually option 3 for washing program. 7 for spin-dry only program. 8 for drying only program. Dont know why.
@@ -72,7 +70,6 @@ properties:
 
 - property: DryOpen_DefaultSpinSpeed
   # Sample value: 14
-  icon: 'mdi:rotate-3d-variant'
   sensor:
     read_only: true
     device_class: enum
@@ -91,7 +88,6 @@ properties:
 #    unit: '%'
 
 - property: ExtraRinseNum
-  icon: mdi:tray-plus
   select:
     options:
       0: "none"
@@ -101,7 +97,6 @@ properties:
 
 - property: Selected_program_ID
   # Sample value: 41 (Power 49')
-  icon: 'mdi:washing-machine'
   select:
     options:
       1: "cotton_dry"
@@ -139,7 +134,6 @@ properties:
 
 - property: dry_time
   # Sample value: 3
-  icon: 'mdi:tumble-dryer'
   select:
     options:
       0: "off"

--- a/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100404v0w.yaml
@@ -14,7 +14,6 @@ properties:
         10: finished
         11: delay_start_waiting
   - property: Selected_program_ID
-    icon: mdi:playlist-check
     select:
       options:
         1: cotton_dry
@@ -39,7 +38,6 @@ properties:
         55: hand_wash
         90: auto
   - property: QuickerMode
-    icon: mdi:clock-fast
     select:
       options:
         0: none
@@ -53,7 +51,6 @@ properties:
       unit: h
   - property: ApplicationPermissions
     hide: false
-    icon: mdi:cellphone-wireless
     sensor:
       read_only: true
       device_class: enum

--- a/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100649v0t.yaml
@@ -4,7 +4,6 @@ properties:
   hide: false
   sensor:
     read_only: true
-  icon: 'mdi:shield-check'
 - property: Current_program_phase
   sensor:
     device_class: enum
@@ -32,7 +31,6 @@ properties:
   sensor:
     unit: times
 - property: Selected_program_ID
-  icon: mdi:playlist-check
   sensor:
     read_only: true
     device_class: enum
@@ -57,10 +55,8 @@ properties:
   sensor:
     read_only: true
     unit: rpm
-  icon: 'mdi:speedometer'
 - property: temperature
   sensor:
     read_only: true
     device_class: temperature
     unit: °C
-  icon: 'mdi:thermometer'

--- a/custom_components/connectlife/data_dictionaries/025-1wj100722v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100722v0w.yaml
@@ -41,4 +41,3 @@ properties:
       13: extra_hygiene
       14: remote
       15: none
-  icon: 'mdi:playlist-check'

--- a/custom_components/connectlife/data_dictionaries/025-1wj100923v0f.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj100923v0f.yaml
@@ -11,7 +11,6 @@ properties:
         4: rinse
         7: spin-dry
   - property: ExtraRinseNum
-    icon: mdi:tray-plus
     select:
       options:
         0: "0"
@@ -26,7 +25,6 @@ properties:
         2: "2"
         3: "3"
   - property: Selected_program_ID
-    icon: mdi:tshirt-crew
     select:
       options:
         1: "cotton_dry"

--- a/custom_components/connectlife/data_dictionaries/025-1wj105050v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105050v0w.yaml
@@ -13,7 +13,6 @@ properties:
       8: drying
       10: finished
 - property: Selected_program_ID
-  icon: mdi:tshirt-crew
   select:
     options:
       1: "cotton_dry"

--- a/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105219v0w.yaml
@@ -29,7 +29,6 @@ properties:
     read_only: true
     unit: rpm
     multiplier: 100
-  icon: 'mdi:speedometer'
 - property: Electricit_consumption
   sensor:
     state_class: total
@@ -61,17 +60,14 @@ properties:
       13: extra_hygiene
       14: remote
       15: none
-  icon: 'mdi:playlist-check'
 - property: Spin_speed_rpm
   sensor: # Sample value: 10
     read_only: true
     unit: rpm
     multiplier: 100
-  icon: 'mdi:speedometer'
 - property: temperature
   sensor:   # Sample value: 2
     read_only: true
     device_class: temperature
     unit: °C
     multiplier: 10
-  icon: 'mdi:thermometer'

--- a/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105246v0w.yaml
@@ -4,7 +4,6 @@ properties:
   hide: false
   sensor:
     read_only: true
-  icon: 'mdi:shield-check'
 - property: Current_program_phase
   sensor:
     device_class: enum
@@ -49,17 +48,14 @@ properties:
       13: extra_hygiene
       14: remote
       15: none
-  icon: 'mdi:playlist-check'
 - property: Spin_speed_rpm
   sensor:
     read_only: true
     unit: rpm
-  icon: 'mdi:speedometer'
 - property: temperature
   sensor:
     read_only: true
     device_class: temperature
     unit: °C
-  icon: 'mdi:thermometer'
 - property: Program_end_to_shutdown_time_in_minutes
   hide: true

--- a/custom_components/connectlife/data_dictionaries/025-1wj105418v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105418v0t.yaml
@@ -13,7 +13,6 @@ properties:
       8: drying
       10: finished
 - property: ExtraRinseNum
-  icon: mdi:tray-plus
   select:
     options:
       0: "0"
@@ -21,7 +20,6 @@ properties:
       2: "2"
       3: "3"
 - property: Selected_program_ID
-  icon: mdi:tshirt-crew
   select:
     options:
       1: "cotton_dry"

--- a/custom_components/connectlife/data_dictionaries/025-1wj105552v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105552v0w.yaml
@@ -14,7 +14,6 @@ properties:
       10: finished
       11: delay
 - property: ExtraRinseNum
-  icon: mdi:tray-plus
   select:
     options:
       0: "0"
@@ -24,7 +23,6 @@ properties:
       4: "4"
       5: "5"
 - property: Selected_program_ID
-  icon: mdi:tshirt-crew
   select:
     options:
       1: "cotton_dry"
@@ -62,7 +60,6 @@ properties:
       60: "600"
       0: "none"
 - property: dry_time
-  icon: mdi:tumble-dryer
   select:
     options:
       1: "iron"

--- a/custom_components/connectlife/data_dictionaries/025-1wj120238v0b.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120238v0b.yaml
@@ -1,7 +1,6 @@
 # Washing Machine
 properties:
   - property: Selected_program_ID
-    icon: mdi:tshirt-crew
     select:
       options:
         6: drum_clean

--- a/custom_components/connectlife/data_dictionaries/025-1wj120514v0t.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj120514v0t.yaml
@@ -14,7 +14,6 @@ properties:
       10: finished
       11: delay_start_waiting
 - property: dry_time
-  icon: mdi:tumble-dryer
   select:
     options:
       0: "none"
@@ -28,7 +27,6 @@ properties:
       180: "180"
       240: "240"
 - property: Selected_program_ID
-  icon: mdi:tshirt-crew
   select:
     options:
       1: "cotton_dry"

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -48,13 +48,13 @@ properties:
         0: false
         1: true
   - property: Selected_program_remaining_time_in_minutes
-    icon: mdi:update
+    icon: mdi:clock-end
     sensor:
       device_class: duration
       unit: min
       read_only: true
   - property: Remaining_time_of_selected_program
-    icon: mdi:update
+    icon: mdi:clock-end
     sensor:
       device_class: duration
       unit: min
@@ -127,7 +127,7 @@ properties:
       unit: min
       read_only: true
   - property: MainWashTimeUseIndex
-    icon: mdi:clock
+    icon: mdi:clock-outline
     entity_category: diagnostic
     sensor:
       read_only: true
@@ -177,7 +177,7 @@ properties:
       read_only: true
       unit: rpm
   - property: DefaultSpinSpeed
-    icon: mdi:speedometer
+    icon: mdi:sync
     entity_category: diagnostic
     sensor:
       read_only: true
@@ -204,7 +204,7 @@ properties:
     entity_category: config
     switch: {}
   - property: mute
-    icon: mdi:volume-variant-off
+    icon: mdi:volume-off
     entity_category: config
     switch:
       device_class: switch
@@ -219,7 +219,7 @@ properties:
     icon: mdi:iron
     switch: {}
   - property: AutoDose
-    icon: mdi:tray-arrow-up
+    icon: mdi:car-coolant-level
     entity_category: config
     switch: {}
   - property: AutoTubClean
@@ -245,7 +245,7 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: AutoDose_flag
-    icon: mdi:tray-arrow-up
+    icon: mdi:car-coolant-level
     entity_category: diagnostic
     sensor:
       device_class: enum
@@ -527,6 +527,7 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: QuickerMode
+    icon: mdi:clock-fast
   - property: Quiet_model
     hide: true
     entity_category: diagnostic
@@ -929,6 +930,7 @@ properties:
     entity_category: diagnostic
   - property: ApplicationPermissions
     hide: true
+    icon: mdi:cellphone-wireless
   - property: BathingWaterPump_Flag
     hide: true
     entity_category: diagnostic
@@ -957,6 +959,7 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: DryOpen_DefaultSpinSpeed
+    icon: mdi:sync
   - property: FlexibleSpinTime_Flag
     sensor:
       read_only: true
@@ -1126,6 +1129,7 @@ properties:
     sensor:
       read_only: true
   - property: ExtraRinseNum
+    icon: mdi:tray-plus
   - property: Filterclean_washCound
     hide: true
     entity_category: diagnostic
@@ -1136,8 +1140,9 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: Selected_program_ID
+    icon: mdi:tshirt-crew
   - property: Spin_speed_rpm
-    icon: mdi:rotate-3d-variant
+    icon: mdi:sync
     select:
       options:
         0: none
@@ -1147,11 +1152,12 @@ properties:
         12: "1200"
         14: "1400"
   - property: dry_time
+    icon: mdi:tumble-dryer
   - property: once_strong_step_time
     hide: true
     entity_category: diagnostic
   - property: temperature
-    icon: mdi:thermometer-lines
+    icon: mdi:thermometer
     select:
       options:
         0: cold

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -55,7 +55,7 @@ properties:
 - property: Selected_program_entry_steam_status
   binary_sensor: {}
 - property: Selected_program_id_status
-  icon: 'mdi:playlist-check'
+  icon: 'mdi:tshirt-crew'
   sensor:
     read_only: true
     device_class: enum
@@ -80,7 +80,7 @@ properties:
       16: rinsing_softening
       17: down_feathers
 - property: Selected_program_mode_status
-  icon: 'mdi:playlist-check'
+  icon: 'mdi:tshirt-crew'
   sensor:
     read_only: true
     device_class: enum
@@ -92,7 +92,7 @@ properties:
 - property: Selected_program_prewash_status
   binary_sensor: {}
 - property: Selected_program_remaining_time_in_minutes
-  icon: 'mdi:update'
+  icon: 'mdi:clock-end'
   sensor:
     read_only: true
     device_class: duration

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -50,12 +50,12 @@ properties:
       options:
         1: off
         2: on
-    icon: mdi:square-circle
+    icon: mdi:door
   - property: DownLight_LightTime
     # Sample value: 0
     hide: true
   - property: Drum_Light
-    icon: mdi:lightbulb-on
+    icon: mdi:lightbulb
     entity_category: config
     switch:
   - property: Dry_Level
@@ -158,16 +158,17 @@ properties:
   - property: Language
     # Sample value: 0
   - property: Natural_Dry
-    icon: mdi:hair-dryer
+    icon: mdi:tumble-dryer
     switch:
   - property: Night_Dry
     # Sample value: 0
   - property: Pause_AntiCrease_flag
     # Sample value: 0
   - property: QuickerMode
+    icon: mdi:clock-fast
     # Sample value: 0
   - property: Remaining_time_of_selected_program
-    icon: mdi:update
+    icon: mdi:clock-end
     sensor:
       device_class: duration
       unit: min
@@ -199,7 +200,7 @@ properties:
       device_class: duration
       unit: min
       read_only: true
-    icon: mdi:timer
+    icon: mdi:clock-end
   - property: Selected_program_total_running_time
     icon: mdi:timer
     sensor:
@@ -315,7 +316,7 @@ properties:
         2: running
       read_only: true
   - property: mute
-    icon: mdi:volume-mute
+    icon: mdi:volume-off
     entity_category: config
     switch:
   - property: parse_lib_ver

--- a/custom_components/connectlife/data_dictionaries/032.yaml
+++ b/custom_components/connectlife/data_dictionaries/032.yaml
@@ -118,7 +118,7 @@ properties:
   - property: Door_status
     unavailable: 0
     hide: true
-    icon: mdi:square
+    icon: mdi:door
     binary_sensor:
       device_class: door
       options:


### PR DESCRIPTION
## Summary

Two related cleanup passes on the data dictionary icons:

1. **Icon normalization** — reduce icon variety and align with HA core integration conventions (miele, home_connect, smartthings) where applicable.
2. **Hoisting** — move icons from subtype files to base files where every subtype agreed (uses the inheritance machinery from #471).

No entity behavior change — only icon visuals.

## Icon normalizations

Concept consolidations:

| Property | Old | New | Rationale |
|---|---|---|---|
| Spin speed (`Spin_speed_rpm`, `DefaultSpinSpeed`) | `mdi:speedometer` / `mdi:rotate-3d-variant` | `mdi:sync` | matches miele; conveys rotation, not a car gauge |
| `Door_status` (015/025/027/030/032) | `mdi:folder-open-outline` / `mdi:square-circle` / `mdi:square` | `mdi:door` | matches home_connect |
| `AutoDose`, `AutoDose_flag` | `mdi:tray-arrow-up` | `mdi:car-coolant-level` | matches smartthings `detergent_amount`, miele `twin_dos_level` |
| Remaining time (025/027/030) | `mdi:update` / `mdi:timer` | `mdi:clock-end` | matches miele `remaining_time`; `mdi:update` looked like "refresh" |
| `Selected_program_ID` (025/027) | `mdi:playlist-check` / `mdi:washing-machine` / `mdi:shield-check` | `mdi:tshirt-crew` | washer-specific; 030/032 keep `mdi:selection-ellipse-arrow-inside` (matches miele `program_id`) |
| `ApplicationPermissions` | `mdi:shield-check` | `mdi:cellphone-wireless` | matches miele `mobile_start` |
| `Natural_Dry` (030) | `mdi:hair-dryer` | `mdi:tumble-dryer` | hair-dryer was wrong |
| `mute` / `t_fan_mute` | `mdi:volume-variant-off` | `mdi:volume-off` | visually clearer |

Stylistic duplicates also collapsed: `mdi:flash` → `mdi:lightning-bolt`, plus `mdi:thermometer-lines` / `mdi:clock` / `mdi:timer-outline` / `mdi:volume-low` merged into single canonical variants.

## Hoisting to base files

PR #471 added field-level inheritance from base to subtype. Where every subtype overriding a property used the same icon, the icon now lives at the base and the subtype overrides are removed:

| Base | Property | # subtypes |
|---|---|---|
| `025.yaml` | `Selected_program_ID` | 14 |
| `025.yaml` | `ExtraRinseNum` | 5 |
| `025.yaml` | `ApplicationPermissions` | 4 |
| `025.yaml` | `dry_time` | 3 |
| `025.yaml` | `DryOpen_DefaultSpinSpeed` | 2 |
| `025.yaml` | `QuickerMode` | 1 (also applied to 030.yaml base) |
| `015.yaml` | `Time_program_set_duration_status` | 3 |

Net effect: 6 base entries gain icons, ~31 redundant subtype lines removed.

## Intentionally not aligned

- `LightBrightness` / `LightColorTemperature` — different concepts; merging would lose visual distinction.
- `Rinse_aid_setting_status` / `Rinse_aid_refill` — current icons match the sun/flare symbols on dishwasher control panels.
- `Current_program_phase` — miele uses `mdi:tray-full` for this slot, but `mdi:state-machine` is a defensible generic and the change felt pedantic.

## Test plan

- [x] `uv run python -m scripts.validate_mappings` passes
- [x] `uv run python -m scripts.gen_strings` produces zero diff (no behavior change)
- [x] Visual spot-check entities in HA after install