### PR TITLE
Add mapping for device type 010 (ATAG induction hob)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -40,6 +40,7 @@
 |                      | Air conditioner          | 009              | 129                    |
 |                      | Air conditioner          | 009              | 199                    |
 |                      | Air conditioner          | 009              | 19901                  |
+| HI21472SV            | Induction hob            | 010              | hob-pind               |
 |                      | Hood                     | 012              | 000                    |
 |                      | Oven                     | 013              | 000                    |
 | Bio21                | Oven                     | 013              | oven-bio21-iconledplus |

--- a/custom_components/connectlife/data_dictionaries/010-hob-pind.yaml
+++ b/custom_components/connectlife/data_dictionaries/010-hob-pind.yaml
@@ -1,0 +1,2 @@
+# ATAG induction hob model HI21472SV
+# Uses default mappings

--- a/custom_components/connectlife/data_dictionaries/010.yaml
+++ b/custom_components/connectlife/data_dictionaries/010.yaml
@@ -1,0 +1,778 @@
+# Induction hob
+properties:
+  - property: Alarm_Hob_Hood_Started
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_NTC_TC
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_NTC_coil_overheating
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_NTC_power
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_auto_program_ended
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_voltage
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Child_lock
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Device_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: idle
+        1: service
+        2: production
+        3: demo_mode
+        4: iq
+        5: running
+        6: failure
+        7: stand_by
+        8: pause_mode
+        9: locked
+  - property: Demo_mode
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Test_mode
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: ECO_mode
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Auto_timer
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Auto_bridge
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Auto_boost
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Chef_mode
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Permanent_pot_detection
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Remote_controlmode
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Recovery
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Hard_pairing_unpair_all_set_flag
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: HardPairingStatus
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: HardPairingUnpairAll
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: FOTA_status
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: FOTA_set
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: FOTA_set_flag
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Total_time_of_cooking_in_minute
+    sensor:
+      state_class: total
+      unit: min
+  - property: SL1_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL2_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL3_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL4_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL1_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL2_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL3_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL4_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL1_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL2_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL3_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL4_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL1_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Power_level
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
+        6: "6"
+        7: "7"
+        8: "8"
+        9: "9"
+        10: "10"
+        11: "11"
+        12: "12"
+        13: boost
+  - property: SL2_Power_level
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
+        6: "6"
+        7: "7"
+        8: "8"
+        9: "9"
+        10: "10"
+        11: "11"
+        12: "12"
+        13: boost
+  - property: SL3_Power_level
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
+        6: "6"
+        7: "7"
+        8: "8"
+        9: "9"
+        10: "10"
+        11: "11"
+        12: "12"
+        13: boost
+  - property: SL4_Power_level
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
+        6: "6"
+        7: "7"
+        8: "8"
+        9: "9"
+        10: "10"
+        11: "11"
+        12: "12"
+        13: boost
+  - property: SL1_Function_status
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL2_Function_status
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL3_Function_status
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL4_Function_status
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL1_Cooking_method
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL2_Cooking_method
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL3_Cooking_method
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL4_Cooking_method
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL1_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: keep_warm_and_fry
+  - property: SL2_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: keep_warm_and_fry
+  - property: SL3_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: keep_warm_and_fry
+  - property: SL4_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: keep_warm_and_fry
+  - property: SL1_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL1_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL1_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL1_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C

--- a/custom_components/connectlife/data_dictionaries/010.yaml
+++ b/custom_components/connectlife/data_dictionaries/010.yaml
@@ -192,6 +192,18 @@ properties:
       options:
         0: off
         1: on
+  - property: SL5_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL1_Sand_timer_status
     hide: true
     sensor:
@@ -223,6 +235,26 @@ properties:
         3: ended
         4: inactive
   - property: SL4_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL5_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL6_Sand_timer_status
     hide: true
     sensor:
       device_class: enum
@@ -268,6 +300,24 @@ properties:
         1: active
         2: paused
         3: inactive
+  - property: SL5_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL6_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
   - property: SL1_Residual_heat_signal
     hide: true
     binary_sensor:
@@ -287,6 +337,18 @@ properties:
         0: off
         1: on
   - property: SL4_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Residual_heat_signal
     hide: true
     binary_sensor:
       options:
@@ -316,6 +378,18 @@ properties:
       options:
         0: off
         1: on
+  - property: SL5_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL1_Alarm_automatic_switch_off_zone
     hide: true
     binary_sensor:
@@ -340,6 +414,18 @@ properties:
       options:
         0: off
         1: on
+  - property: SL5_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL1_Alarm_timer_ended
     hide: true
     binary_sensor:
@@ -359,6 +445,18 @@ properties:
         0: off
         1: on
   - property: SL4_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_timer_ended
     hide: true
     binary_sensor:
       options:
@@ -396,6 +494,22 @@ properties:
         0: inactive
         1: stopwatch
         2: timer
+  - property: SL5_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL6_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
   - property: SL1_Alarm_zone_turned_off
     hide: true
     binary_sensor:
@@ -415,6 +529,18 @@ properties:
         0: off
         1: on
   - property: SL4_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_zone_turned_off
     hide: true
     binary_sensor:
       options:
@@ -444,6 +570,18 @@ properties:
       options:
         0: off
         1: on
+  - property: SL5_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL1_Bridge_function_active
     hide: true
     binary_sensor:
@@ -468,6 +606,18 @@ properties:
       options:
         0: off
         1: on
+  - property: SL5_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL1_Pot_detected
     hide: true
     binary_sensor:
@@ -487,6 +637,18 @@ properties:
         0: off
         1: on
   - property: SL4_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Pot_detected
     hide: true
     binary_sensor:
       options:
@@ -564,7 +726,44 @@ properties:
         11: "11"
         12: "12"
         13: boost
+  - property: SL5_Power_level
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
+        6: "6"
+        7: "7"
+        8: "8"
+        9: "9"
+        10: "10"
+        11: "11"
+        12: "12"
+        13: boost
+  - property: SL6_Power_level
+    sensor:
+      device_class: enum
+      options:
+        0: "off"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
+        6: "6"
+        7: "7"
+        8: "8"
+        9: "9"
+        10: "10"
+        11: "11"
+        12: "12"
+        13: boost
   - property: SL1_Function_status
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -572,6 +771,7 @@ properties:
         1: function_1
         2: function_2
   - property: SL2_Function_status
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -579,6 +779,7 @@ properties:
         1: function_1
         2: function_2
   - property: SL3_Function_status
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -586,6 +787,23 @@ properties:
         1: function_1
         2: function_2
   - property: SL4_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL5_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL6_Function_status
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -593,6 +811,7 @@ properties:
         1: function_1
         2: function_2
   - property: SL1_Cooking_method
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -600,6 +819,7 @@ properties:
         1: method_1
         2: method_2
   - property: SL2_Cooking_method
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -607,6 +827,7 @@ properties:
         1: method_1
         2: method_2
   - property: SL3_Cooking_method
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -614,6 +835,23 @@ properties:
         1: method_1
         2: method_2
   - property: SL4_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL5_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL6_Cooking_method
+    hide: true
     sensor:
       device_class: enum
       options:
@@ -625,45 +863,67 @@ properties:
       device_class: enum
       options:
         0: none
-        1: keep_warm
+        1: keep_warm_and_heat_up
         2: fry
         3: grill
         4: slow_cook
         5: boil
-        6: keep_warm_and_fry
+        6: heat_up_and_fry
   - property: SL2_Functions
     sensor:
       device_class: enum
       options:
         0: none
-        1: keep_warm
+        1: keep_warm_and_heat_up
         2: fry
         3: grill
         4: slow_cook
         5: boil
-        6: keep_warm_and_fry
+        6: heat_up_and_fry
   - property: SL3_Functions
     sensor:
       device_class: enum
       options:
         0: none
-        1: keep_warm
+        1: keep_warm_and_heat_up
         2: fry
         3: grill
         4: slow_cook
         5: boil
-        6: keep_warm_and_fry
+        6: heat_up_and_fry
   - property: SL4_Functions
     sensor:
       device_class: enum
       options:
         0: none
-        1: keep_warm
+        1: keep_warm_and_heat_up
         2: fry
         3: grill
         4: slow_cook
         5: boil
-        6: keep_warm_and_fry
+        6: heat_up_and_fry
+  - property: SL5_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL6_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
   - property: SL1_Temperature
     hide: true
     sensor:
@@ -686,6 +946,20 @@ properties:
       device_class: temperature
       unit: °C
   - property: SL4_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL5_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_Temperature
     hide: true
     sensor:
       read_only: true
@@ -720,6 +994,20 @@ properties:
       state_class: measurement
       device_class: temperature
       unit: °C
+  - property: SL5_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
   - property: SL1_Hestan_Cue_Set_Temperature
     hide: true
     sensor:
@@ -748,6 +1036,20 @@ properties:
       state_class: measurement
       device_class: temperature
       unit: °C
+  - property: SL5_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
   - property: SL1_Hestan_Cue_Temperature
     hide: true
     sensor:
@@ -770,6 +1072,20 @@ properties:
       device_class: temperature
       unit: °C
   - property: SL4_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL5_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_Hestan_Cue_Temperature
     hide: true
     sensor:
       read_only: true

--- a/custom_components/connectlife/data_dictionaries/010.yaml
+++ b/custom_components/connectlife/data_dictionaries/010.yaml
@@ -4,6 +4,7 @@ properties:
     hide: true
   - property: Alarm_Grease_filter
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
       options:
@@ -11,6 +12,7 @@ properties:
         1: on
   - property: Alarm_NTC_TC
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
       options:
@@ -18,6 +20,7 @@ properties:
         1: on
   - property: Alarm_NTC_coil_overheating
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
       options:
@@ -25,6 +28,7 @@ properties:
         1: on
   - property: Alarm_NTC_power
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
       options:
@@ -32,6 +36,7 @@ properties:
         1: on
   - property: Alarm_Recirculation_filter_1
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
       options:
@@ -39,34 +44,35 @@ properties:
         1: on
   - property: Alarm_auto_program_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
-      device_class: problem
       options:
         0: off
         1: on
   - property: Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
-      device_class: problem
       options:
         0: off
         1: on
   - property: Alarm_hob_hood_started
     hide: true
+    entity_category: diagnostic
     binary_sensor:
-      device_class: problem
       options:
         0: off
         1: on
   - property: Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
-      device_class: problem
       options:
         0: off
         1: on
   - property: Alarm_voltage
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       device_class: problem
       options:
@@ -74,13 +80,14 @@ properties:
         1: on
   - property: Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
-      device_class: problem
       options:
         0: off
         1: on
   - property: Auto_Grease_filter_indication
     hide: true
+    entity_category: diagnostic
   - property: Auto_Tower_Up
     hide: true
   - property: Auto_boost
@@ -117,6 +124,7 @@ properties:
     disable: true
   - property: Control_Response_Level
     hide: true
+    entity_category: diagnostic
   - property: Demo_mode
     binary_sensor:
       options:
@@ -239,69 +247,73 @@ properties:
         0: off
         1: on
   - property: FOTA_set
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: FOTA_set_flag
-    binary_sensor:
-      options:
-        0: off
-        1: on
+    disable: true
   - property: FOTA_status
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: Grease_Filter_saturation
     hide: true
+    entity_category: diagnostic
   - property: Grease_filter_cleaning_interval_in_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
   - property: Grease_filter_reset_counter
     hide: true
+    entity_category: diagnostic
   - property: Grease_filter_reset_counter_set_flag
     disable: true
   - property: Grease_filter_set_lifetime_in_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
   - property: Grease_filter_set_lifetime_in_hours_set_flag
     disable: true
   - property: Grease_filter_status
     hide: true
+    entity_category: diagnostic
   - property: Grease_filter_timer_active
     hide: true
+    entity_category: diagnostic
   - property: Grease_filter_timer_active_set_flag
     disable: true
   - property: Grease_filter_used_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
+      state_class: total_increasing
   - property: HardPairingStatus
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: HardPairingUnpairAll
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: Hard_pairing_unpair_all_set_flag
-    binary_sensor:
-      options:
-        0: off
-        1: on
+    disable: true
   - property: Hood_connected_via_RF
     hide: true
+    entity_category: diagnostic
   - property: Hood_fan_speed
     hide: true
   - property: Hood_light
@@ -310,14 +322,17 @@ properties:
     hide: true
   - property: Hood_total_used_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
+      state_class: total_increasing
   - property: Key_sensitivity_level
     hide: true
+    entity_category: diagnostic
   - property: Key_sound_level
     hide: true
+    entity_category: diagnostic
   - property: Motor
     hide: true
   - property: Motor_level
@@ -331,40 +346,46 @@ properties:
     hide: true
   - property: Recirculation_filter_1_lifetime_in_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
   - property: Recirculation_filter_1_reset_counter
     hide: true
+    entity_category: diagnostic
   - property: Recirculation_filter_1_reset_counter_set_flag
     disable: true
   - property: Recirculation_filter_1_set_lifetime_in_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
   - property: Recirculation_filter_1_set_lifetime_in_hours_set_flag
     disable: true
   - property: Recirculation_filter_1_set_type
     hide: true
+    entity_category: diagnostic
   - property: Recirculation_filter_1_set_type_set_flag
     disable: true
   - property: Recirculation_filter_1_status
     hide: true
+    entity_category: diagnostic
   - property: Recirculation_filter_1_timer_active
     hide: true
+    entity_category: diagnostic
   - property: Recirculation_filter_1_timer_active_set_flag
     disable: true
   - property: Recirculation_filter_1_type
     hide: true
+    entity_category: diagnostic
   - property: Recirculation_filter_1_used_hours
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: h
-      state_class: measurement
+      state_class: total_increasing
   - property: Recovery
     binary_sensor:
       options:
@@ -385,30 +406,36 @@ properties:
         2: timer
   - property: SL1_Alarm_NTC_coil
     hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
   - property: SL1_Alarm_auto_program_notification
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL1_Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL1_Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL1_Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
@@ -468,6 +495,7 @@ properties:
     hide: true
   - property: SL1_NTC_sensor
     hide: true
+    entity_category: diagnostic
     sensor:
       read_only: true
       state_class: measurement
@@ -505,12 +533,16 @@ properties:
         1: on
   - property: SL1_Sand_timer_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL1_Sand_timer_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL1_Sand_timer_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL1_Sand_timer_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -533,12 +565,16 @@ properties:
         1: on
   - property: SL1_Stopwatch_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL1_Stopwatch_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL1_Stopwatch_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL1_Stopwatch_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -561,16 +597,22 @@ properties:
       unit: °C
   - property: SL1_Timer_UTC_end_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL1_Timer_UTC_end_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL1_Timer_UTC_end_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL1_Timer_UTC_paused_hours
     hide: true
+    entity_category: diagnostic
   - property: SL1_Timer_UTC_paused_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL1_Timer_UTC_paused_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL1_error_1
     hide: true
     entity_category: diagnostic
@@ -717,30 +759,36 @@ properties:
         2: timer
   - property: SL2_Alarm_NTC_coil
     hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
   - property: SL2_Alarm_auto_program_notification
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL2_Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL2_Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL2_Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
@@ -800,6 +848,7 @@ properties:
     hide: true
   - property: SL2_NTC_sensor
     hide: true
+    entity_category: diagnostic
     sensor:
       read_only: true
       state_class: measurement
@@ -837,12 +886,16 @@ properties:
         1: on
   - property: SL2_Sand_timer_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL2_Sand_timer_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL2_Sand_timer_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL2_Sand_timer_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -865,12 +918,16 @@ properties:
         1: on
   - property: SL2_Stopwatch_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL2_Stopwatch_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL2_Stopwatch_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL2_Stopwatch_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -893,16 +950,22 @@ properties:
       unit: °C
   - property: SL2_Timer_UTC_end_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL2_Timer_UTC_end_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL2_Timer_UTC_end_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL2_Timer_UTC_paused_hours
     hide: true
+    entity_category: diagnostic
   - property: SL2_Timer_UTC_paused_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL2_Timer_UTC_paused_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL2_error_1
     hide: true
     entity_category: diagnostic
@@ -1049,30 +1112,36 @@ properties:
         2: timer
   - property: SL3_Alarm_NTC_coil
     hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
   - property: SL3_Alarm_auto_program_notification
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL3_Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL3_Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL3_Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
@@ -1132,6 +1201,7 @@ properties:
     hide: true
   - property: SL3_NTC_sensor
     hide: true
+    entity_category: diagnostic
     sensor:
       read_only: true
       state_class: measurement
@@ -1169,12 +1239,16 @@ properties:
         1: on
   - property: SL3_Sand_timer_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL3_Sand_timer_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL3_Sand_timer_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL3_Sand_timer_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -1197,12 +1271,16 @@ properties:
         1: on
   - property: SL3_Stopwatch_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL3_Stopwatch_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL3_Stopwatch_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL3_Stopwatch_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -1225,16 +1303,22 @@ properties:
       unit: °C
   - property: SL3_Timer_UTC_end_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL3_Timer_UTC_end_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL3_Timer_UTC_end_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL3_Timer_UTC_paused_hours
     hide: true
+    entity_category: diagnostic
   - property: SL3_Timer_UTC_paused_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL3_Timer_UTC_paused_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL3_error_1
     hide: true
     entity_category: diagnostic
@@ -1381,30 +1465,36 @@ properties:
         2: timer
   - property: SL4_Alarm_NTC_coil
     hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
   - property: SL4_Alarm_auto_program_notification
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL4_Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL4_Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL4_Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
@@ -1464,6 +1554,7 @@ properties:
     hide: true
   - property: SL4_NTC_sensor
     hide: true
+    entity_category: diagnostic
     sensor:
       read_only: true
       state_class: measurement
@@ -1501,12 +1592,16 @@ properties:
         1: on
   - property: SL4_Sand_timer_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL4_Sand_timer_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL4_Sand_timer_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL4_Sand_timer_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -1529,12 +1624,16 @@ properties:
         1: on
   - property: SL4_Stopwatch_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL4_Stopwatch_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL4_Stopwatch_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL4_Stopwatch_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -1557,16 +1656,22 @@ properties:
       unit: °C
   - property: SL4_Timer_UTC_end_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL4_Timer_UTC_end_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL4_Timer_UTC_end_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL4_Timer_UTC_paused_hours
     hide: true
+    entity_category: diagnostic
   - property: SL4_Timer_UTC_paused_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL4_Timer_UTC_paused_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL4_error_1
     hide: true
     entity_category: diagnostic
@@ -1713,30 +1818,36 @@ properties:
         2: timer
   - property: SL5_Alarm_NTC_coil
     hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
   - property: SL5_Alarm_auto_program_notification
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL5_Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL5_Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL5_Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
@@ -1796,6 +1907,7 @@ properties:
     hide: true
   - property: SL5_NTC_sensor
     hide: true
+    entity_category: diagnostic
     sensor:
       read_only: true
       state_class: measurement
@@ -1833,12 +1945,16 @@ properties:
         1: on
   - property: SL5_Sand_timer_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL5_Sand_timer_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL5_Sand_timer_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL5_Sand_timer_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -1861,12 +1977,16 @@ properties:
         1: on
   - property: SL5_Stopwatch_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL5_Stopwatch_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL5_Stopwatch_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL5_Stopwatch_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -1889,16 +2009,22 @@ properties:
       unit: °C
   - property: SL5_Timer_UTC_end_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL5_Timer_UTC_end_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL5_Timer_UTC_end_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL5_Timer_UTC_paused_hours
     hide: true
+    entity_category: diagnostic
   - property: SL5_Timer_UTC_paused_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL5_Timer_UTC_paused_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL5_error_1
     hide: true
     entity_category: diagnostic
@@ -2045,30 +2171,36 @@ properties:
         2: timer
   - property: SL6_Alarm_NTC_coil
     hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
   - property: SL6_Alarm_auto_program_notification
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL6_Alarm_automatic_switch_off_zone
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL6_Alarm_timer_ended
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
         1: on
   - property: SL6_Alarm_zone_turned_off
     hide: true
+    entity_category: diagnostic
     binary_sensor:
       options:
         0: off
@@ -2128,6 +2260,7 @@ properties:
     hide: true
   - property: SL6_NTC_sensor
     hide: true
+    entity_category: diagnostic
     sensor:
       read_only: true
       state_class: measurement
@@ -2165,12 +2298,16 @@ properties:
         1: on
   - property: SL6_Sand_timer_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL6_Sand_timer_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL6_Sand_timer_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL6_Sand_timer_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -2193,12 +2330,16 @@ properties:
         1: on
   - property: SL6_Stopwatch_UTC_start_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL6_Stopwatch_UTC_start_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL6_Stopwatch_UTC_start_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL6_Stopwatch_paused_total_seconds
     hide: true
+    entity_category: diagnostic
     sensor:
       device_class: duration
       unit: s
@@ -2221,16 +2362,22 @@ properties:
       unit: °C
   - property: SL6_Timer_UTC_end_time_hours
     hide: true
+    entity_category: diagnostic
   - property: SL6_Timer_UTC_end_time_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL6_Timer_UTC_end_time_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL6_Timer_UTC_paused_hours
     hide: true
+    entity_category: diagnostic
   - property: SL6_Timer_UTC_paused_minutes
     hide: true
+    entity_category: diagnostic
   - property: SL6_Timer_UTC_paused_seconds
     hide: true
+    entity_category: diagnostic
   - property: SL6_error_1
     hide: true
     entity_category: diagnostic
@@ -2369,10 +2516,13 @@ properties:
         1: on
   - property: Stand_by_time
     hide: true
+    entity_category: diagnostic
   - property: Synchro_Start_Level
     hide: true
+    entity_category: diagnostic
   - property: Synchro_Stop_Level
     hide: true
+    entity_category: diagnostic
   - property: Test_mode
     binary_sensor:
       options:
@@ -2380,12 +2530,9 @@ properties:
         1: on
   - property: Total_time_of_cooking_in_minute
     sensor:
-      state_class: total
+      device_class: duration
       unit: min
+      state_class: total_increasing
   - property: Window_status
     hide: true
-  - property: daily_energy_kwh
-    sensor:
-      device_class: energy
-      unit: kWh
-      state_class: total_increasing
+    entity_category: diagnostic

--- a/custom_components/connectlife/data_dictionaries/010.yaml
+++ b/custom_components/connectlife/data_dictionaries/010.yaml
@@ -1,6 +1,8 @@
 # Induction hob
 properties:
-  - property: Alarm_Hob_Hood_Started
+  - property: Air_dry_function
+    hide: true
+  - property: Alarm_Grease_filter
     hide: true
     binary_sensor:
       device_class: problem
@@ -28,6 +30,13 @@ properties:
       options:
         0: off
         1: on
+  - property: Alarm_Recirculation_filter_1
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
   - property: Alarm_auto_program_ended
     hide: true
     binary_sensor:
@@ -36,6 +45,13 @@ properties:
         0: off
         1: on
   - property: Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Alarm_hob_hood_started
     hide: true
     binary_sensor:
       device_class: problem
@@ -63,8 +79,45 @@ properties:
       options:
         0: off
         1: on
+  - property: Auto_Grease_filter_indication
+    hide: true
+  - property: Auto_Tower_Up
+    hide: true
+  - property: Auto_boost
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Auto_bridge
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Auto_timer
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: BuiltIn_Hood_status
+    hide: true
+  - property: Chef_mode
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: Child_lock
     hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Circulation_mode
+    hide: true
+  - property: Circulation_mode__set_flag
+    disable: true
+  - property: Control_Response_Level
+    hide: true
+  - property: Demo_mode
     binary_sensor:
       options:
         0: off
@@ -84,73 +137,104 @@ properties:
         7: stand_by
         8: pause_mode
         9: locked
-  - property: Demo_mode
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: Test_mode
-    binary_sensor:
-      options:
-        0: off
-        1: on
   - property: ECO_mode
     binary_sensor:
       options:
         0: off
         1: on
-  - property: Auto_timer
+  - property: Error_1
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Auto_bridge
+  - property: Error_10
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Auto_boost
+  - property: Error_11
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Chef_mode
+  - property: Error_12
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Permanent_pot_detection
+  - property: Error_2
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Remote_controlmode
+  - property: Error_3
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Recovery
+  - property: Error_4
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: Hard_pairing_unpair_all_set_flag
+  - property: Error_5
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: HardPairingStatus
+  - property: Error_6
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: HardPairingUnpairAll
+  - property: Error_7
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
-  - property: FOTA_status
+  - property: Error_8
+    hide: true
+    entity_category: diagnostic
     binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
       options:
         0: off
         1: on
@@ -164,300 +248,129 @@ properties:
       options:
         0: off
         1: on
-  - property: Total_time_of_cooking_in_minute
-    sensor:
-      state_class: total
-      unit: min
-  - property: SL1_Status
-    hide: true
+  - property: FOTA_status
     binary_sensor:
       options:
         0: off
         1: on
-  - property: SL2_Status
+  - property: Grease_Filter_saturation
     hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Status
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Status
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Status
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Status
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL1_Sand_timer_status
+  - property: Grease_filter_cleaning_interval_in_hours
     hide: true
     sensor:
-      device_class: enum
-      options:
-        0: paused
-        1: active
-        2: stopped
-        3: ended
-        4: inactive
-  - property: SL2_Sand_timer_status
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: Grease_filter_reset_counter
+    hide: true
+  - property: Grease_filter_reset_counter_set_flag
+    disable: true
+  - property: Grease_filter_set_lifetime_in_hours
     hide: true
     sensor:
-      device_class: enum
-      options:
-        0: paused
-        1: active
-        2: stopped
-        3: ended
-        4: inactive
-  - property: SL3_Sand_timer_status
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: Grease_filter_set_lifetime_in_hours_set_flag
+    disable: true
+  - property: Grease_filter_status
+    hide: true
+  - property: Grease_filter_timer_active
+    hide: true
+  - property: Grease_filter_timer_active_set_flag
+    disable: true
+  - property: Grease_filter_used_hours
     hide: true
     sensor:
-      device_class: enum
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: HardPairingStatus
+    binary_sensor:
       options:
-        0: paused
-        1: active
-        2: stopped
-        3: ended
-        4: inactive
-  - property: SL4_Sand_timer_status
+        0: off
+        1: on
+  - property: HardPairingUnpairAll
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Hard_pairing_unpair_all_set_flag
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Hood_connected_via_RF
+    hide: true
+  - property: Hood_fan_speed
+    hide: true
+  - property: Hood_light
+    hide: true
+  - property: Hood_status
+    hide: true
+  - property: Hood_total_used_hours
     hide: true
     sensor:
-      device_class: enum
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: Key_sensitivity_level
+    hide: true
+  - property: Key_sound_level
+    hide: true
+  - property: Motor
+    hide: true
+  - property: Motor_level
+    hide: true
+  - property: Permanent_pot_detection
+    binary_sensor:
       options:
-        0: paused
-        1: active
-        2: stopped
-        3: ended
-        4: inactive
-  - property: SL5_Sand_timer_status
+        0: off
+        1: on
+  - property: Position_of_tower
+    hide: true
+  - property: Recirculation_filter_1_lifetime_in_hours
     hide: true
     sensor:
-      device_class: enum
-      options:
-        0: paused
-        1: active
-        2: stopped
-        3: ended
-        4: inactive
-  - property: SL6_Sand_timer_status
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: Recirculation_filter_1_reset_counter
+    hide: true
+  - property: Recirculation_filter_1_reset_counter_set_flag
+    disable: true
+  - property: Recirculation_filter_1_set_lifetime_in_hours
     hide: true
     sensor:
-      device_class: enum
-      options:
-        0: paused
-        1: active
-        2: stopped
-        3: ended
-        4: inactive
-  - property: SL1_Stopwatch_status
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: Recirculation_filter_1_set_lifetime_in_hours_set_flag
+    disable: true
+  - property: Recirculation_filter_1_set_type
+    hide: true
+  - property: Recirculation_filter_1_set_type_set_flag
+    disable: true
+  - property: Recirculation_filter_1_status
+    hide: true
+  - property: Recirculation_filter_1_timer_active
+    hide: true
+  - property: Recirculation_filter_1_timer_active_set_flag
+    disable: true
+  - property: Recirculation_filter_1_type
+    hide: true
+  - property: Recirculation_filter_1_used_hours
     hide: true
     sensor:
-      device_class: enum
-      options:
-        0: hold
-        1: active
-        2: paused
-        3: inactive
-  - property: SL2_Stopwatch_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: hold
-        1: active
-        2: paused
-        3: inactive
-  - property: SL3_Stopwatch_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: hold
-        1: active
-        2: paused
-        3: inactive
-  - property: SL4_Stopwatch_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: hold
-        1: active
-        2: paused
-        3: inactive
-  - property: SL5_Stopwatch_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: hold
-        1: active
-        2: paused
-        3: inactive
-  - property: SL6_Stopwatch_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: hold
-        1: active
-        2: paused
-        3: inactive
-  - property: SL1_Residual_heat_signal
-    hide: true
+      device_class: duration
+      unit: h
+      state_class: measurement
+  - property: Recovery
     binary_sensor:
       options:
         0: off
         1: on
-  - property: SL2_Residual_heat_signal
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Residual_heat_signal
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Residual_heat_signal
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Residual_heat_signal
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Residual_heat_signal
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL1_Alarm_auto_program_notification
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL2_Alarm_auto_program_notification
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Alarm_auto_program_notification
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Alarm_auto_program_notification
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Alarm_auto_program_notification
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Alarm_auto_program_notification
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL1_Alarm_automatic_switch_off_zone
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL2_Alarm_automatic_switch_off_zone
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Alarm_automatic_switch_off_zone
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Alarm_automatic_switch_off_zone
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Alarm_automatic_switch_off_zone
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Alarm_automatic_switch_off_zone
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL1_Alarm_timer_ended
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL2_Alarm_timer_ended
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Alarm_timer_ended
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Alarm_timer_ended
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Alarm_timer_ended
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Alarm_timer_ended
-    hide: true
+  - property: Remote_controlmode
     binary_sensor:
       options:
         0: off
@@ -470,113 +383,31 @@ properties:
         0: inactive
         1: stopwatch
         2: timer
-  - property: SL2_Active_timer
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: inactive
-        1: stopwatch
-        2: timer
-  - property: SL3_Active_timer
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: inactive
-        1: stopwatch
-        2: timer
-  - property: SL4_Active_timer
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: inactive
-        1: stopwatch
-        2: timer
-  - property: SL5_Active_timer
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: inactive
-        1: stopwatch
-        2: timer
-  - property: SL6_Active_timer
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: inactive
-        1: stopwatch
-        2: timer
-  - property: SL1_Alarm_zone_turned_off
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL2_Alarm_zone_turned_off
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Alarm_zone_turned_off
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Alarm_zone_turned_off
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Alarm_zone_turned_off
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Alarm_zone_turned_off
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
   - property: SL1_Alarm_NTC_coil
     hide: true
     binary_sensor:
       options:
         0: off
         1: on
-  - property: SL2_Alarm_NTC_coil
+  - property: SL1_Alarm_auto_program_notification
     hide: true
     binary_sensor:
       options:
         0: off
         1: on
-  - property: SL3_Alarm_NTC_coil
+  - property: SL1_Alarm_automatic_switch_off_zone
     hide: true
     binary_sensor:
       options:
         0: off
         1: on
-  - property: SL4_Alarm_NTC_coil
+  - property: SL1_Alarm_timer_ended
     hide: true
     binary_sensor:
       options:
         0: off
         1: on
-  - property: SL5_Alarm_NTC_coil
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Alarm_NTC_coil
+  - property: SL1_Alarm_zone_turned_off
     hide: true
     binary_sensor:
       options:
@@ -588,67 +419,61 @@ properties:
       options:
         0: off
         1: on
-  - property: SL2_Bridge_function_active
+  - property: SL1_Bridged_to_zone
     hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Bridge_function_active
+  - property: SL1_Cooking_method
     hide: true
-    binary_sensor:
+    sensor:
+      device_class: enum
       options:
-        0: off
-        1: on
-  - property: SL4_Bridge_function_active
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL1_Function_status
     hide: true
-    binary_sensor:
+    sensor:
+      device_class: enum
       options:
-        0: off
-        1: on
-  - property: SL5_Bridge_function_active
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL1_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL1_Hestan_Cue_Set_Temperature
     hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Bridge_function_active
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL1_Hestan_Cue_Temperature
     hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL1_Hestan_Cue_cookware_type
+    hide: true
+  - property: SL1_Hestan_Cue_next_step_required_warning
+    hide: true
+  - property: SL1_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
   - property: SL1_Pot_detected
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL2_Pot_detected
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL3_Pot_detected
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL4_Pot_detected
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL5_Pot_detected
-    hide: true
-    binary_sensor:
-      options:
-        0: off
-        1: on
-  - property: SL6_Pot_detected
     hide: true
     binary_sensor:
       options:
@@ -672,6 +497,320 @@ properties:
         11: "11"
         12: "12"
         13: boost
+  - property: SL1_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Sand_timer_UTC_start_time_hours
+    hide: true
+  - property: SL1_Sand_timer_UTC_start_time_minutes
+    hide: true
+  - property: SL1_Sand_timer_UTC_start_time_seconds
+    hide: true
+  - property: SL1_Sand_timer_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL1_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL1_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL1_Stopwatch_UTC_start_time_hours
+    hide: true
+  - property: SL1_Stopwatch_UTC_start_time_minutes
+    hide: true
+  - property: SL1_Stopwatch_UTC_start_time_seconds
+    hide: true
+  - property: SL1_Stopwatch_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL1_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL1_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL1_Timer_UTC_end_time_hours
+    hide: true
+  - property: SL1_Timer_UTC_end_time_minutes
+    hide: true
+  - property: SL1_Timer_UTC_end_time_seconds
+    hide: true
+  - property: SL1_Timer_UTC_paused_hours
+    hide: true
+  - property: SL1_Timer_UTC_paused_minutes
+    hide: true
+  - property: SL1_Timer_UTC_paused_seconds
+    hide: true
+  - property: SL1_error_1
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_10
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_11
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_12
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_13
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_14
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_15
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_16
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_17
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_2
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_3
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_4
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_5
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_6
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_7
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_8
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL1_error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL2_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Bridged_to_zone
+    hide: true
+  - property: SL2_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL2_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL2_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL2_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Hestan_Cue_cookware_type
+    hide: true
+  - property: SL2_Hestan_Cue_next_step_required_warning
+    hide: true
+  - property: SL2_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL2_Power_level
     sensor:
       device_class: enum
@@ -690,6 +829,320 @@ properties:
         11: "11"
         12: "12"
         13: boost
+  - property: SL2_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Sand_timer_UTC_start_time_hours
+    hide: true
+  - property: SL2_Sand_timer_UTC_start_time_minutes
+    hide: true
+  - property: SL2_Sand_timer_UTC_start_time_seconds
+    hide: true
+  - property: SL2_Sand_timer_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL2_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL2_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL2_Stopwatch_UTC_start_time_hours
+    hide: true
+  - property: SL2_Stopwatch_UTC_start_time_minutes
+    hide: true
+  - property: SL2_Stopwatch_UTC_start_time_seconds
+    hide: true
+  - property: SL2_Stopwatch_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL2_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL2_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL2_Timer_UTC_end_time_hours
+    hide: true
+  - property: SL2_Timer_UTC_end_time_minutes
+    hide: true
+  - property: SL2_Timer_UTC_end_time_seconds
+    hide: true
+  - property: SL2_Timer_UTC_paused_hours
+    hide: true
+  - property: SL2_Timer_UTC_paused_minutes
+    hide: true
+  - property: SL2_Timer_UTC_paused_seconds
+    hide: true
+  - property: SL2_error_1
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_10
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_11
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_12
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_13
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_14
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_15
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_16
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_17
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_2
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_3
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_4
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_5
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_6
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_7
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_8
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL2_error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL3_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Bridged_to_zone
+    hide: true
+  - property: SL3_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL3_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL3_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL3_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Hestan_Cue_cookware_type
+    hide: true
+  - property: SL3_Hestan_Cue_next_step_required_warning
+    hide: true
+  - property: SL3_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL3_Power_level
     sensor:
       device_class: enum
@@ -708,6 +1161,320 @@ properties:
         11: "11"
         12: "12"
         13: boost
+  - property: SL3_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Sand_timer_UTC_start_time_hours
+    hide: true
+  - property: SL3_Sand_timer_UTC_start_time_minutes
+    hide: true
+  - property: SL3_Sand_timer_UTC_start_time_seconds
+    hide: true
+  - property: SL3_Sand_timer_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL3_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL3_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL3_Stopwatch_UTC_start_time_hours
+    hide: true
+  - property: SL3_Stopwatch_UTC_start_time_minutes
+    hide: true
+  - property: SL3_Stopwatch_UTC_start_time_seconds
+    hide: true
+  - property: SL3_Stopwatch_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL3_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL3_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL3_Timer_UTC_end_time_hours
+    hide: true
+  - property: SL3_Timer_UTC_end_time_minutes
+    hide: true
+  - property: SL3_Timer_UTC_end_time_seconds
+    hide: true
+  - property: SL3_Timer_UTC_paused_hours
+    hide: true
+  - property: SL3_Timer_UTC_paused_minutes
+    hide: true
+  - property: SL3_Timer_UTC_paused_seconds
+    hide: true
+  - property: SL3_error_1
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_10
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_11
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_12
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_13
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_14
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_15
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_16
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_17
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_2
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_3
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_4
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_5
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_6
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_7
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_8
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL3_error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL4_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Bridged_to_zone
+    hide: true
+  - property: SL4_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL4_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL4_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL4_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Hestan_Cue_cookware_type
+    hide: true
+  - property: SL4_Hestan_Cue_next_step_required_warning
+    hide: true
+  - property: SL4_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL4_Power_level
     sensor:
       device_class: enum
@@ -726,6 +1493,320 @@ properties:
         11: "11"
         12: "12"
         13: boost
+  - property: SL4_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Sand_timer_UTC_start_time_hours
+    hide: true
+  - property: SL4_Sand_timer_UTC_start_time_minutes
+    hide: true
+  - property: SL4_Sand_timer_UTC_start_time_seconds
+    hide: true
+  - property: SL4_Sand_timer_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL4_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL4_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL4_Stopwatch_UTC_start_time_hours
+    hide: true
+  - property: SL4_Stopwatch_UTC_start_time_minutes
+    hide: true
+  - property: SL4_Stopwatch_UTC_start_time_seconds
+    hide: true
+  - property: SL4_Stopwatch_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL4_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL4_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL4_Timer_UTC_end_time_hours
+    hide: true
+  - property: SL4_Timer_UTC_end_time_minutes
+    hide: true
+  - property: SL4_Timer_UTC_end_time_seconds
+    hide: true
+  - property: SL4_Timer_UTC_paused_hours
+    hide: true
+  - property: SL4_Timer_UTC_paused_minutes
+    hide: true
+  - property: SL4_Timer_UTC_paused_seconds
+    hide: true
+  - property: SL4_error_1
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_10
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_11
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_12
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_13
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_14
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_15
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_16
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_17
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_2
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_3
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_4
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_5
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_6
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_7
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_8
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL4_error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL5_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Bridged_to_zone
+    hide: true
+  - property: SL5_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL5_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL5_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL5_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL5_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL5_Hestan_Cue_cookware_type
+    hide: true
+  - property: SL5_Hestan_Cue_next_step_required_warning
+    hide: true
+  - property: SL5_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL5_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL5_Power_level
     sensor:
       device_class: enum
@@ -744,6 +1825,320 @@ properties:
         11: "11"
         12: "12"
         13: boost
+  - property: SL5_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Sand_timer_UTC_start_time_hours
+    hide: true
+  - property: SL5_Sand_timer_UTC_start_time_minutes
+    hide: true
+  - property: SL5_Sand_timer_UTC_start_time_seconds
+    hide: true
+  - property: SL5_Sand_timer_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL5_Sand_timer_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL5_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL5_Stopwatch_UTC_start_time_hours
+    hide: true
+  - property: SL5_Stopwatch_UTC_start_time_minutes
+    hide: true
+  - property: SL5_Stopwatch_UTC_start_time_seconds
+    hide: true
+  - property: SL5_Stopwatch_paused_total_seconds
+    hide: true
+    sensor:
+      device_class: duration
+      unit: s
+      state_class: measurement
+  - property: SL5_Stopwatch_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
+  - property: SL5_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL5_Timer_UTC_end_time_hours
+    hide: true
+  - property: SL5_Timer_UTC_end_time_minutes
+    hide: true
+  - property: SL5_Timer_UTC_end_time_seconds
+    hide: true
+  - property: SL5_Timer_UTC_paused_hours
+    hide: true
+  - property: SL5_Timer_UTC_paused_minutes
+    hide: true
+  - property: SL5_Timer_UTC_paused_seconds
+    hide: true
+  - property: SL5_error_1
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_10
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_11
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_12
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_13
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_14
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_15
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_16
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_17
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_2
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_3
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_4
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_5
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_6
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_7
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_8
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL5_error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_Active_timer
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: inactive
+        1: stopwatch
+        2: timer
+  - property: SL6_Alarm_NTC_coil
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_auto_program_notification
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_automatic_switch_off_zone
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_timer_ended
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Alarm_zone_turned_off
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Bridge_function_active
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Bridged_to_zone
+    hide: true
+  - property: SL6_Cooking_method
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: method_1
+        2: method_2
+  - property: SL6_Function_status
+    hide: true
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: function_1
+        2: function_2
+  - property: SL6_Functions
+    sensor:
+      device_class: enum
+      options:
+        0: none
+        1: keep_warm_and_heat_up
+        2: fry
+        3: grill
+        4: slow_cook
+        5: boil
+        6: heat_up_and_fry
+  - property: SL6_Hestan_Cue_Set_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_Hestan_Cue_Temperature
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_Hestan_Cue_cookware_type
+    hide: true
+  - property: SL6_Hestan_Cue_next_step_required_warning
+    hide: true
+  - property: SL6_NTC_sensor
+    hide: true
+    sensor:
+      read_only: true
+      state_class: measurement
+      device_class: temperature
+      unit: °C
+  - property: SL6_Pot_detected
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL6_Power_level
     sensor:
       device_class: enum
@@ -762,203 +2157,61 @@ properties:
         11: "11"
         12: "12"
         13: boost
-  - property: SL1_Function_status
+  - property: SL6_Residual_heat_signal
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Sand_timer_UTC_start_time_hours
+    hide: true
+  - property: SL6_Sand_timer_UTC_start_time_minutes
+    hide: true
+  - property: SL6_Sand_timer_UTC_start_time_seconds
+    hide: true
+  - property: SL6_Sand_timer_paused_total_seconds
     hide: true
     sensor:
-      device_class: enum
-      options:
-        0: none
-        1: function_1
-        2: function_2
-  - property: SL2_Function_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: function_1
-        2: function_2
-  - property: SL3_Function_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: function_1
-        2: function_2
-  - property: SL4_Function_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: function_1
-        2: function_2
-  - property: SL5_Function_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: function_1
-        2: function_2
-  - property: SL6_Function_status
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: function_1
-        2: function_2
-  - property: SL1_Cooking_method
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: method_1
-        2: method_2
-  - property: SL2_Cooking_method
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: method_1
-        2: method_2
-  - property: SL3_Cooking_method
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: method_1
-        2: method_2
-  - property: SL4_Cooking_method
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: method_1
-        2: method_2
-  - property: SL5_Cooking_method
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: method_1
-        2: method_2
-  - property: SL6_Cooking_method
-    hide: true
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: method_1
-        2: method_2
-  - property: SL1_Functions
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: keep_warm_and_heat_up
-        2: fry
-        3: grill
-        4: slow_cook
-        5: boil
-        6: heat_up_and_fry
-  - property: SL2_Functions
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: keep_warm_and_heat_up
-        2: fry
-        3: grill
-        4: slow_cook
-        5: boil
-        6: heat_up_and_fry
-  - property: SL3_Functions
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: keep_warm_and_heat_up
-        2: fry
-        3: grill
-        4: slow_cook
-        5: boil
-        6: heat_up_and_fry
-  - property: SL4_Functions
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: keep_warm_and_heat_up
-        2: fry
-        3: grill
-        4: slow_cook
-        5: boil
-        6: heat_up_and_fry
-  - property: SL5_Functions
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: keep_warm_and_heat_up
-        2: fry
-        3: grill
-        4: slow_cook
-        5: boil
-        6: heat_up_and_fry
-  - property: SL6_Functions
-    sensor:
-      device_class: enum
-      options:
-        0: none
-        1: keep_warm_and_heat_up
-        2: fry
-        3: grill
-        4: slow_cook
-        5: boil
-        6: heat_up_and_fry
-  - property: SL1_Temperature
-    hide: true
-    sensor:
-      read_only: true
+      device_class: duration
+      unit: s
       state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL2_Temperature
+  - property: SL6_Sand_timer_status
     hide: true
     sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL3_Temperature
+      device_class: enum
+      options:
+        0: paused
+        1: active
+        2: stopped
+        3: ended
+        4: inactive
+  - property: SL6_Status
+    hide: true
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: SL6_Stopwatch_UTC_start_time_hours
+    hide: true
+  - property: SL6_Stopwatch_UTC_start_time_minutes
+    hide: true
+  - property: SL6_Stopwatch_UTC_start_time_seconds
+    hide: true
+  - property: SL6_Stopwatch_paused_total_seconds
     hide: true
     sensor:
-      read_only: true
+      device_class: duration
+      unit: s
       state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL4_Temperature
+  - property: SL6_Stopwatch_status
     hide: true
     sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL5_Temperature
-    hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
+      device_class: enum
+      options:
+        0: hold
+        1: active
+        2: paused
+        3: inactive
   - property: SL6_Temperature
     hide: true
     sensor:
@@ -966,129 +2219,173 @@ properties:
       state_class: measurement
       device_class: temperature
       unit: °C
-  - property: SL1_NTC_sensor
+  - property: SL6_Timer_UTC_end_time_hours
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL2_NTC_sensor
+  - property: SL6_Timer_UTC_end_time_minutes
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL3_NTC_sensor
+  - property: SL6_Timer_UTC_end_time_seconds
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL4_NTC_sensor
+  - property: SL6_Timer_UTC_paused_hours
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL5_NTC_sensor
+  - property: SL6_Timer_UTC_paused_minutes
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL6_NTC_sensor
+  - property: SL6_Timer_UTC_paused_seconds
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL1_Hestan_Cue_Set_Temperature
+  - property: SL6_error_1
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL2_Hestan_Cue_Set_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_10
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL3_Hestan_Cue_Set_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_11
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL4_Hestan_Cue_Set_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_12
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL5_Hestan_Cue_Set_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_13
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL6_Hestan_Cue_Set_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_14
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL1_Hestan_Cue_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_15
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL2_Hestan_Cue_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_16
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL3_Hestan_Cue_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_17
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL4_Hestan_Cue_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_2
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL5_Hestan_Cue_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_3
     hide: true
-    sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
-  - property: SL6_Hestan_Cue_Temperature
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_4
     hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_5
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_6
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_7
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_8
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: SL6_error_9
+    hide: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: off
+        1: on
+  - property: Stand_by_time
+    hide: true
+  - property: Synchro_Start_Level
+    hide: true
+  - property: Synchro_Stop_Level
+    hide: true
+  - property: Test_mode
+    binary_sensor:
+      options:
+        0: off
+        1: on
+  - property: Total_time_of_cooking_in_minute
     sensor:
-      read_only: true
-      state_class: measurement
-      device_class: temperature
-      unit: °C
+      state_class: total
+      unit: min
+  - property: Window_status
+    hide: true
+  - property: daily_energy_kwh
+    sensor:
+      device_class: energy
+      unit: kWh
+      state_class: total_increasing

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1086,6 +1086,9 @@
       "sl5_alarm_automatic_switch_off_zone": {
         "name": "Zone 5 automatically switched off"
       },
+      "sl5_alarm_ntc_coil": {
+        "name": "Zone 5 alarm NTC coil"
+      },
       "sl5_alarm_ntc_coil_overheating": {
         "name": "Zone 5 coil overheating"
       },
@@ -1101,6 +1104,9 @@
       "sl5_pot_detected": {
         "name": "Zone 5 pot detected"
       },
+      "sl5_residual_heat_signal": {
+        "name": "Zone 5 residual heat"
+      },
       "sl5_status": {
         "name": "Zone 5 status"
       },
@@ -1109,6 +1115,9 @@
       },
       "sl6_alarm_automatic_switch_off_zone": {
         "name": "Zone 6 automatically switched off"
+      },
+      "sl6_alarm_ntc_coil": {
+        "name": "Zone 6 alarm NTC coil"
       },
       "sl6_alarm_ntc_coil_overheating": {
         "name": "Zone 6 coil overheating"
@@ -1124,6 +1133,9 @@
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot detected"
+      },
+      "sl6_residual_heat_signal": {
+        "name": "Zone 6 residual heat"
       },
       "sl6_status": {
         "name": "Zone 6 status"
@@ -4700,8 +4712,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -4789,8 +4802,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -4878,8 +4892,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -4967,8 +4982,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -5034,26 +5050,77 @@
           "timer": "Timer"
         }
       },
+      "sl5_cooking_method": {
+        "name": "Zone 5 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl5_function_status": {
+        "name": "Zone 5 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl5_functions": {
         "name": "Zone 5 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl5_hestan_cue_set_temperature": {
+        "name": "Zone 5 Hestan Cue set temperature"
+      },
+      "sl5_hestan_cue_temperature": {
+        "name": "Zone 5 Hestan Cue temperature"
       },
       "sl5_ntc_sensor": {
         "name": "Zone 5 NTC sensor"
       },
       "sl5_power_level": {
-        "name": "Zone 5 power level"
+        "name": "Zone 5 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl5_power_level_max": {
         "name": "Zone 5 max power level"
+      },
+      "sl5_sand_timer_status": {
+        "name": "Zone 5 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl5_stopwatch_status": {
+        "name": "Zone 5 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl5_temperature": {
+        "name": "Zone 5 temperature"
       },
       "sl5_zone_shape": {
         "name": "Zone 5 shape",
@@ -5073,26 +5140,77 @@
           "timer": "Timer"
         }
       },
+      "sl6_cooking_method": {
+        "name": "Zone 6 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl6_function_status": {
+        "name": "Zone 6 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl6_functions": {
         "name": "Zone 6 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl6_hestan_cue_set_temperature": {
+        "name": "Zone 6 Hestan Cue set temperature"
+      },
+      "sl6_hestan_cue_temperature": {
+        "name": "Zone 6 Hestan Cue temperature"
       },
       "sl6_ntc_sensor": {
         "name": "Zone 6 NTC sensor"
       },
       "sl6_power_level": {
-        "name": "Zone 6 power level"
+        "name": "Zone 6 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl6_power_level_max": {
         "name": "Zone 6 max power level"
+      },
+      "sl6_sand_timer_status": {
+        "name": "Zone 6 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl6_stopwatch_status": {
+        "name": "Zone 6 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl6_temperature": {
+        "name": "Zone 6 temperature"
       },
       "sl6_zone_shape": {
         "name": "Zone 6 shape",

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -78,6 +78,9 @@
       "alarm_auto_dose_refill": {
         "name": "Auto-dose refill"
       },
+      "alarm_auto_program_ended": {
+        "name": "Auto program ended"
+      },
       "alarm_auto_program_notification": {
         "name": "Auto program notification"
       },
@@ -357,8 +360,17 @@
       "ali_wifi_fault_flag": {
         "name": "WiFi fault"
       },
+      "auto_boost": {
+        "name": "Auto boost"
+      },
+      "auto_bridge": {
+        "name": "Auto bridge"
+      },
       "auto_dose_refill": {
         "name": "Auto-dose refill"
+      },
+      "auto_timer": {
+        "name": "Auto timer"
       },
       "charcoal_filter_expiration_alarm": {
         "name": "Charcoal filter expiration alarm"
@@ -368,6 +380,9 @@
       },
       "charcoal_filter_time_reset": {
         "name": "Charcoal filter time reset"
+      },
+      "chef_mode": {
+        "name": "Chef mode"
       },
       "child_lock": {
         "name": "Child lock"
@@ -663,6 +678,15 @@
       "float_switch": {
         "name": "Float switch"
       },
+      "fota_set": {
+        "name": "FOTA set"
+      },
+      "fota_set_flag": {
+        "name": "FOTA set flag"
+      },
+      "fota_status": {
+        "name": "FOTA status"
+      },
       "free_defrosting_failure": {
         "name": "Freezer defrosting failure"
       },
@@ -716,6 +740,15 @@
       },
       "hard_pairing_status": {
         "name": "Hard pairing status"
+      },
+      "hard_pairing_unpair_all_set_flag": {
+        "name": "Hard pairing unpair all set flag"
+      },
+      "hardpairingstatus": {
+        "name": "Hard pairing status"
+      },
+      "hardpairingunpairall": {
+        "name": "Hard pairing unpair all"
       },
       "hob_status": {
         "name": "Hob status"
@@ -798,11 +831,17 @@
       "open_variation_door_alarm": {
         "name": "Open variation door alarm"
       },
+      "permanent_pot_detection": {
+        "name": "Permanent pot detection"
+      },
       "preheat": {
         "name": "Preheat"
       },
       "quiet_mode_status": {
         "name": "Quiet mode status"
+      },
+      "recovery": {
+        "name": "Recovery"
       },
       "reed_switch": {
         "name": "Reed switch"
@@ -870,6 +909,9 @@
       "remote_control_monitoring_set_commands_actions": {
         "name": "Remote control"
       },
+      "remote_controlmode": {
+        "name": "Remote control mode"
+      },
       "right_free_sensor_failure": {
         "name": "Right free sensor failure"
       },
@@ -924,6 +966,9 @@
       "sl1_alarm_automatic_switch_off_zone": {
         "name": "Zone 1 automatically switched off"
       },
+      "sl1_alarm_ntc_coil": {
+        "name": "Zone 1 alarm NTC coil"
+      },
       "sl1_alarm_ntc_coil_overheating": {
         "name": "Zone 1 coil overheating"
       },
@@ -939,6 +984,9 @@
       "sl1_pot_detected": {
         "name": "Zone 1 pot detected"
       },
+      "sl1_residual_heat_signal": {
+        "name": "Zone 1 residual heat"
+      },
       "sl1_status": {
         "name": "Zone 1 status"
       },
@@ -947,6 +995,9 @@
       },
       "sl2_alarm_automatic_switch_off_zone": {
         "name": "Zone 2 automatically switched off"
+      },
+      "sl2_alarm_ntc_coil": {
+        "name": "Zone 2 alarm NTC coil"
       },
       "sl2_alarm_ntc_coil_overheating": {
         "name": "Zone 2 coil overheating"
@@ -963,6 +1014,9 @@
       "sl2_pot_detected": {
         "name": "Zone 2 pot detected"
       },
+      "sl2_residual_heat_signal": {
+        "name": "Zone 2 residual heat"
+      },
       "sl2_status": {
         "name": "Zone 2 status"
       },
@@ -971,6 +1025,9 @@
       },
       "sl3_alarm_automatic_switch_off_zone": {
         "name": "Zone 3 automatically switched off"
+      },
+      "sl3_alarm_ntc_coil": {
+        "name": "Zone 3 alarm NTC coil"
       },
       "sl3_alarm_ntc_coil_overheating": {
         "name": "Zone 3 coil overheating"
@@ -987,6 +1044,9 @@
       "sl3_pot_detected": {
         "name": "Zone 3 pot detected"
       },
+      "sl3_residual_heat_signal": {
+        "name": "Zone 3 residual heat"
+      },
       "sl3_status": {
         "name": "Zone 3 status"
       },
@@ -995,6 +1055,9 @@
       },
       "sl4_alarm_automatic_switch_off_zone": {
         "name": "Zone 4 automatically switched off"
+      },
+      "sl4_alarm_ntc_coil": {
+        "name": "Zone 4 alarm NTC coil"
       },
       "sl4_alarm_ntc_coil_overheating": {
         "name": "Zone 4 coil overheating"
@@ -1010,6 +1073,9 @@
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot detected"
+      },
+      "sl4_residual_heat_signal": {
+        "name": "Zone 4 residual heat"
       },
       "sl4_status": {
         "name": "Zone 4 status"
@@ -1118,6 +1184,9 @@
       },
       "t_beep": {
         "name": "Beep"
+      },
+      "test_mode": {
+        "name": "Test mode"
       },
       "tx_failure": {
         "name": "TX failure"
@@ -4609,26 +4678,76 @@
           "timer": "Timer"
         }
       },
+      "sl1_cooking_method": {
+        "name": "Zone 1 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl1_function_status": {
+        "name": "Zone 1 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl1_functions": {
         "name": "Zone 1 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl1_hestan_cue_set_temperature": {
+        "name": "Zone 1 Hestan Cue set temperature"
+      },
+      "sl1_hestan_cue_temperature": {
+        "name": "Zone 1 Hestan Cue temperature"
       },
       "sl1_ntc_sensor": {
         "name": "Zone 1 NTC sensor"
       },
       "sl1_power_level": {
-        "name": "Zone 1 power level"
+        "name": "Zone 1 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl1_power_level_max": {
         "name": "Zone 1 max power level"
+      },
+      "sl1_sand_timer_status": {
+        "name": "Zone 1 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl1_stopwatch_status": {
+        "name": "Zone 1 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl1_temperature": {
+        "name": "Zone 1 temperature"
       },
       "sl1_zone_shape": {
         "name": "Zone 1 shape",
@@ -4648,26 +4767,76 @@
           "timer": "Timer"
         }
       },
+      "sl2_cooking_method": {
+        "name": "Zone 2 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl2_function_status": {
+        "name": "Zone 2 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl2_functions": {
         "name": "Zone 2 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl2_hestan_cue_set_temperature": {
+        "name": "Zone 2 Hestan Cue set temperature"
+      },
+      "sl2_hestan_cue_temperature": {
+        "name": "Zone 2 Hestan Cue temperature"
       },
       "sl2_ntc_sensor": {
         "name": "Zone 2 NTC sensor"
       },
       "sl2_power_level": {
-        "name": "Zone 2 power level"
+        "name": "Zone 2 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl2_power_level_max": {
         "name": "Zone 2 max power level"
+      },
+      "sl2_sand_timer_status": {
+        "name": "Zone 2 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl2_stopwatch_status": {
+        "name": "Zone 2 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl2_temperature": {
+        "name": "Zone 2 temperature"
       },
       "sl2_zone_shape": {
         "name": "Zone 2 shape",
@@ -4687,26 +4856,76 @@
           "timer": "Timer"
         }
       },
+      "sl3_cooking_method": {
+        "name": "Zone 3 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl3_function_status": {
+        "name": "Zone 3 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl3_functions": {
         "name": "Zone 3 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl3_hestan_cue_set_temperature": {
+        "name": "Zone 3 Hestan Cue set temperature"
+      },
+      "sl3_hestan_cue_temperature": {
+        "name": "Zone 3 Hestan Cue temperature"
       },
       "sl3_ntc_sensor": {
         "name": "Zone 3 NTC sensor"
       },
       "sl3_power_level": {
-        "name": "Zone 3 power level"
+        "name": "Zone 3 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl3_power_level_max": {
         "name": "Zone 3 max power level"
+      },
+      "sl3_sand_timer_status": {
+        "name": "Zone 3 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl3_stopwatch_status": {
+        "name": "Zone 3 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl3_temperature": {
+        "name": "Zone 3 temperature"
       },
       "sl3_zone_shape": {
         "name": "Zone 3 shape",
@@ -4726,26 +4945,76 @@
           "timer": "Timer"
         }
       },
+      "sl4_cooking_method": {
+        "name": "Zone 4 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl4_function_status": {
+        "name": "Zone 4 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl4_functions": {
         "name": "Zone 4 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl4_hestan_cue_set_temperature": {
+        "name": "Zone 4 Hestan Cue set temperature"
+      },
+      "sl4_hestan_cue_temperature": {
+        "name": "Zone 4 Hestan Cue temperature"
       },
       "sl4_ntc_sensor": {
         "name": "Zone 4 NTC sensor"
       },
       "sl4_power_level": {
-        "name": "Zone 4 power level"
+        "name": "Zone 4 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl4_power_level_max": {
         "name": "Zone 4 max power level"
+      },
+      "sl4_sand_timer_status": {
+        "name": "Zone 4 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl4_stopwatch_status": {
+        "name": "Zone 4 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl4_temperature": {
+        "name": "Zone 4 temperature"
       },
       "sl4_zone_shape": {
         "name": "Zone 4 shape",
@@ -6109,6 +6378,9 @@
         "name": "Total run time"
       },
       "total_time_of_cooking_in_hours": {
+        "name": "Total time of cooking"
+      },
+      "total_time_of_cooking_in_minute": {
         "name": "Total time of cooking"
       },
       "total_water_consumption": {

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -687,9 +687,6 @@
       "fota_set": {
         "name": "FOTA set"
       },
-      "fota_set_flag": {
-        "name": "FOTA set flag"
-      },
       "fota_status": {
         "name": "FOTA status"
       },
@@ -746,9 +743,6 @@
       },
       "hard_pairing_status": {
         "name": "Hard pairing status"
-      },
-      "hard_pairing_unpair_all_set_flag": {
-        "name": "Hard pairing unpair all set flag"
       },
       "hardpairingstatus": {
         "name": "Hard pairing status"
@@ -2474,13 +2468,13 @@
         "name": "Auto-dose system setting status"
       },
       "auto_grease_filter_indication": {
-        "name": "Auto grease filter indication"
+        "name": "Auto grease filter"
       },
       "auto_super_rinse_setting_status": {
         "name": "Auto super rinse setting status"
       },
       "auto_tower_up": {
-        "name": "Auto tower up"
+        "name": "Tower auto-raise"
       },
       "autodose_flag": {
         "name": "Auto-dose flag",
@@ -3898,7 +3892,7 @@
         "name": "Hood status"
       },
       "hood_total_used_hours": {
-        "name": "Hood total used hours"
+        "name": "Hood runtime hours"
       },
       "hottime": {
         "name": "Hot time"
@@ -5096,7 +5090,7 @@
         }
       },
       "sl1_bridged_to_zone": {
-        "name": "Zone 1 bridged to zone"
+        "name": "Zone 1 bridge target"
       },
       "sl1_cooking_method": {
         "name": "Zone 1 cooking method",
@@ -5237,7 +5231,7 @@
         }
       },
       "sl2_bridged_to_zone": {
-        "name": "Zone 2 bridged to zone"
+        "name": "Zone 2 bridge target"
       },
       "sl2_cooking_method": {
         "name": "Zone 2 cooking method",
@@ -5378,7 +5372,7 @@
         }
       },
       "sl3_bridged_to_zone": {
-        "name": "Zone 3 bridged to zone"
+        "name": "Zone 3 bridge target"
       },
       "sl3_cooking_method": {
         "name": "Zone 3 cooking method",
@@ -5519,7 +5513,7 @@
         }
       },
       "sl4_bridged_to_zone": {
-        "name": "Zone 4 bridged to zone"
+        "name": "Zone 4 bridge target"
       },
       "sl4_cooking_method": {
         "name": "Zone 4 cooking method",
@@ -5660,7 +5654,7 @@
         }
       },
       "sl5_bridged_to_zone": {
-        "name": "Zone 5 bridged to zone"
+        "name": "Zone 5 bridge target"
       },
       "sl5_cooking_method": {
         "name": "Zone 5 cooking method",
@@ -5801,7 +5795,7 @@
         }
       },
       "sl6_bridged_to_zone": {
-        "name": "Zone 6 bridged to zone"
+        "name": "Zone 6 bridge target"
       },
       "sl6_cooking_method": {
         "name": "Zone 6 cooking method",

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -144,6 +144,9 @@
       "alarm_fast_preheating_finished": {
         "name": "Alarm fast preheating finished"
       },
+      "alarm_grease_filter": {
+        "name": "Grease filter alarm"
+      },
       "alarm_hob_hood_started": {
         "name": "Hob hood started"
       },
@@ -191,6 +194,9 @@
       },
       "alarm_pyrolytic_finished": {
         "name": "Alarm pyrolytic finished"
+      },
+      "alarm_recirculation_filter_1": {
+        "name": "Recirculation filter 1 alarm"
       },
       "alarm_remote_start_canceled": {
         "name": "Remote start canceled"
@@ -981,6 +987,57 @@
       "sl1_bridge_function_active": {
         "name": "Zone 1 bridge active"
       },
+      "sl1_error_1": {
+        "name": "Zone 1 error 1"
+      },
+      "sl1_error_10": {
+        "name": "Zone 1 error 10"
+      },
+      "sl1_error_11": {
+        "name": "Zone 1 error 11"
+      },
+      "sl1_error_12": {
+        "name": "Zone 1 error 12"
+      },
+      "sl1_error_13": {
+        "name": "Zone 1 error 13"
+      },
+      "sl1_error_14": {
+        "name": "Zone 1 error 14"
+      },
+      "sl1_error_15": {
+        "name": "Zone 1 error 15"
+      },
+      "sl1_error_16": {
+        "name": "Zone 1 error 16"
+      },
+      "sl1_error_17": {
+        "name": "Zone 1 error 17"
+      },
+      "sl1_error_2": {
+        "name": "Zone 1 error 2"
+      },
+      "sl1_error_3": {
+        "name": "Zone 1 error 3"
+      },
+      "sl1_error_4": {
+        "name": "Zone 1 error 4"
+      },
+      "sl1_error_5": {
+        "name": "Zone 1 error 5"
+      },
+      "sl1_error_6": {
+        "name": "Zone 1 error 6"
+      },
+      "sl1_error_7": {
+        "name": "Zone 1 error 7"
+      },
+      "sl1_error_8": {
+        "name": "Zone 1 error 8"
+      },
+      "sl1_error_9": {
+        "name": "Zone 1 error 9"
+      },
       "sl1_pot_detected": {
         "name": "Zone 1 pot detected"
       },
@@ -1010,6 +1067,57 @@
       },
       "sl2_bridge_function_active": {
         "name": "Zone 2 bridge active"
+      },
+      "sl2_error_1": {
+        "name": "Zone 2 error 1"
+      },
+      "sl2_error_10": {
+        "name": "Zone 2 error 10"
+      },
+      "sl2_error_11": {
+        "name": "Zone 2 error 11"
+      },
+      "sl2_error_12": {
+        "name": "Zone 2 error 12"
+      },
+      "sl2_error_13": {
+        "name": "Zone 2 error 13"
+      },
+      "sl2_error_14": {
+        "name": "Zone 2 error 14"
+      },
+      "sl2_error_15": {
+        "name": "Zone 2 error 15"
+      },
+      "sl2_error_16": {
+        "name": "Zone 2 error 16"
+      },
+      "sl2_error_17": {
+        "name": "Zone 2 error 17"
+      },
+      "sl2_error_2": {
+        "name": "Zone 2 error 2"
+      },
+      "sl2_error_3": {
+        "name": "Zone 2 error 3"
+      },
+      "sl2_error_4": {
+        "name": "Zone 2 error 4"
+      },
+      "sl2_error_5": {
+        "name": "Zone 2 error 5"
+      },
+      "sl2_error_6": {
+        "name": "Zone 2 error 6"
+      },
+      "sl2_error_7": {
+        "name": "Zone 2 error 7"
+      },
+      "sl2_error_8": {
+        "name": "Zone 2 error 8"
+      },
+      "sl2_error_9": {
+        "name": "Zone 2 error 9"
       },
       "sl2_pot_detected": {
         "name": "Zone 2 pot detected"
@@ -1041,6 +1149,57 @@
       "sl3_bridge_function_active": {
         "name": "Zone 3 bridge active"
       },
+      "sl3_error_1": {
+        "name": "Zone 3 error 1"
+      },
+      "sl3_error_10": {
+        "name": "Zone 3 error 10"
+      },
+      "sl3_error_11": {
+        "name": "Zone 3 error 11"
+      },
+      "sl3_error_12": {
+        "name": "Zone 3 error 12"
+      },
+      "sl3_error_13": {
+        "name": "Zone 3 error 13"
+      },
+      "sl3_error_14": {
+        "name": "Zone 3 error 14"
+      },
+      "sl3_error_15": {
+        "name": "Zone 3 error 15"
+      },
+      "sl3_error_16": {
+        "name": "Zone 3 error 16"
+      },
+      "sl3_error_17": {
+        "name": "Zone 3 error 17"
+      },
+      "sl3_error_2": {
+        "name": "Zone 3 error 2"
+      },
+      "sl3_error_3": {
+        "name": "Zone 3 error 3"
+      },
+      "sl3_error_4": {
+        "name": "Zone 3 error 4"
+      },
+      "sl3_error_5": {
+        "name": "Zone 3 error 5"
+      },
+      "sl3_error_6": {
+        "name": "Zone 3 error 6"
+      },
+      "sl3_error_7": {
+        "name": "Zone 3 error 7"
+      },
+      "sl3_error_8": {
+        "name": "Zone 3 error 8"
+      },
+      "sl3_error_9": {
+        "name": "Zone 3 error 9"
+      },
       "sl3_pot_detected": {
         "name": "Zone 3 pot detected"
       },
@@ -1070,6 +1229,57 @@
       },
       "sl4_bridge_function_active": {
         "name": "Zone 4 bridge active"
+      },
+      "sl4_error_1": {
+        "name": "Zone 4 error 1"
+      },
+      "sl4_error_10": {
+        "name": "Zone 4 error 10"
+      },
+      "sl4_error_11": {
+        "name": "Zone 4 error 11"
+      },
+      "sl4_error_12": {
+        "name": "Zone 4 error 12"
+      },
+      "sl4_error_13": {
+        "name": "Zone 4 error 13"
+      },
+      "sl4_error_14": {
+        "name": "Zone 4 error 14"
+      },
+      "sl4_error_15": {
+        "name": "Zone 4 error 15"
+      },
+      "sl4_error_16": {
+        "name": "Zone 4 error 16"
+      },
+      "sl4_error_17": {
+        "name": "Zone 4 error 17"
+      },
+      "sl4_error_2": {
+        "name": "Zone 4 error 2"
+      },
+      "sl4_error_3": {
+        "name": "Zone 4 error 3"
+      },
+      "sl4_error_4": {
+        "name": "Zone 4 error 4"
+      },
+      "sl4_error_5": {
+        "name": "Zone 4 error 5"
+      },
+      "sl4_error_6": {
+        "name": "Zone 4 error 6"
+      },
+      "sl4_error_7": {
+        "name": "Zone 4 error 7"
+      },
+      "sl4_error_8": {
+        "name": "Zone 4 error 8"
+      },
+      "sl4_error_9": {
+        "name": "Zone 4 error 9"
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot detected"
@@ -1101,6 +1311,57 @@
       "sl5_bridge_function_active": {
         "name": "Zone 5 bridge active"
       },
+      "sl5_error_1": {
+        "name": "Zone 5 error 1"
+      },
+      "sl5_error_10": {
+        "name": "Zone 5 error 10"
+      },
+      "sl5_error_11": {
+        "name": "Zone 5 error 11"
+      },
+      "sl5_error_12": {
+        "name": "Zone 5 error 12"
+      },
+      "sl5_error_13": {
+        "name": "Zone 5 error 13"
+      },
+      "sl5_error_14": {
+        "name": "Zone 5 error 14"
+      },
+      "sl5_error_15": {
+        "name": "Zone 5 error 15"
+      },
+      "sl5_error_16": {
+        "name": "Zone 5 error 16"
+      },
+      "sl5_error_17": {
+        "name": "Zone 5 error 17"
+      },
+      "sl5_error_2": {
+        "name": "Zone 5 error 2"
+      },
+      "sl5_error_3": {
+        "name": "Zone 5 error 3"
+      },
+      "sl5_error_4": {
+        "name": "Zone 5 error 4"
+      },
+      "sl5_error_5": {
+        "name": "Zone 5 error 5"
+      },
+      "sl5_error_6": {
+        "name": "Zone 5 error 6"
+      },
+      "sl5_error_7": {
+        "name": "Zone 5 error 7"
+      },
+      "sl5_error_8": {
+        "name": "Zone 5 error 8"
+      },
+      "sl5_error_9": {
+        "name": "Zone 5 error 9"
+      },
       "sl5_pot_detected": {
         "name": "Zone 5 pot detected"
       },
@@ -1130,6 +1391,57 @@
       },
       "sl6_bridge_function_active": {
         "name": "Zone 6 bridge active"
+      },
+      "sl6_error_1": {
+        "name": "Zone 6 error 1"
+      },
+      "sl6_error_10": {
+        "name": "Zone 6 error 10"
+      },
+      "sl6_error_11": {
+        "name": "Zone 6 error 11"
+      },
+      "sl6_error_12": {
+        "name": "Zone 6 error 12"
+      },
+      "sl6_error_13": {
+        "name": "Zone 6 error 13"
+      },
+      "sl6_error_14": {
+        "name": "Zone 6 error 14"
+      },
+      "sl6_error_15": {
+        "name": "Zone 6 error 15"
+      },
+      "sl6_error_16": {
+        "name": "Zone 6 error 16"
+      },
+      "sl6_error_17": {
+        "name": "Zone 6 error 17"
+      },
+      "sl6_error_2": {
+        "name": "Zone 6 error 2"
+      },
+      "sl6_error_3": {
+        "name": "Zone 6 error 3"
+      },
+      "sl6_error_4": {
+        "name": "Zone 6 error 4"
+      },
+      "sl6_error_5": {
+        "name": "Zone 6 error 5"
+      },
+      "sl6_error_6": {
+        "name": "Zone 6 error 6"
+      },
+      "sl6_error_7": {
+        "name": "Zone 6 error 7"
+      },
+      "sl6_error_8": {
+        "name": "Zone 6 error 8"
+      },
+      "sl6_error_9": {
+        "name": "Zone 6 error 9"
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot detected"
@@ -1971,6 +2283,9 @@
       "ai_energy_mode_switch": {
         "name": "AI energy mode switch"
       },
+      "air_dry_function": {
+        "name": "Air dry function"
+      },
       "air_dry_function_status": {
         "name": "Air dry function status"
       },
@@ -2158,8 +2473,14 @@
       "auto_dose_system_setting_status": {
         "name": "Auto-dose system setting status"
       },
+      "auto_grease_filter_indication": {
+        "name": "Auto grease filter indication"
+      },
       "auto_super_rinse_setting_status": {
         "name": "Auto super rinse setting status"
+      },
+      "auto_tower_up": {
+        "name": "Auto tower up"
       },
       "autodose_flag": {
         "name": "Auto-dose flag",
@@ -2222,6 +2543,9 @@
       "brightness_setting": {
         "name": "Brightness setting"
       },
+      "builtin_hood_status": {
+        "name": "Built-in hood status"
+      },
       "bundling_humidity": {
         "name": "Bundling humidity"
       },
@@ -2282,6 +2606,9 @@
       "childlock_pause": {
         "name": "Child lock pause"
       },
+      "circulation_mode": {
+        "name": "Circulation mode"
+      },
       "circulationmodestatus": {
         "name": "Circulation mode status"
       },
@@ -2338,6 +2665,9 @@
       },
       "condensed_watermode": {
         "name": "Condensed water mode"
+      },
+      "control_response_level": {
+        "name": "Control response level"
       },
       "cool_c": {
         "name": "Cool C"
@@ -2472,7 +2802,7 @@
         "name": "Daily energy consumption"
       },
       "daily_energy_kwh": {
-        "name": "Daily energy consumption"
+        "name": "Daily energy"
       },
       "darhcdq": {
         "name": "Darhcdq"
@@ -3454,6 +3784,27 @@
       "gratin_total_passed_time_in_minutes": {
         "name": "Gratin total passed time in minutes"
       },
+      "grease_filter_cleaning_interval_in_hours": {
+        "name": "Grease filter cleaning interval"
+      },
+      "grease_filter_reset_counter": {
+        "name": "Grease filter reset counter"
+      },
+      "grease_filter_saturation": {
+        "name": "Grease filter saturation"
+      },
+      "grease_filter_set_lifetime_in_hours": {
+        "name": "Grease filter lifetime"
+      },
+      "grease_filter_status": {
+        "name": "Grease filter status"
+      },
+      "grease_filter_timer_active": {
+        "name": "Grease filter timer active"
+      },
+      "grease_filter_used_hours": {
+        "name": "Grease filter used hours"
+      },
       "greasefiltercleaningintervalinhours": {
         "name": "Grease filter cleaning interval in hours"
       },
@@ -3533,6 +3884,21 @@
         "state": {
           "off_hot": "Off hot"
         }
+      },
+      "hood_connected_via_rf": {
+        "name": "Hood connected via RF"
+      },
+      "hood_fan_speed": {
+        "name": "Hood fan speed"
+      },
+      "hood_light": {
+        "name": "Hood light"
+      },
+      "hood_status": {
+        "name": "Hood status"
+      },
+      "hood_total_used_hours": {
+        "name": "Hood total used hours"
       },
       "hottime": {
         "name": "Hot time"
@@ -3623,6 +3989,12 @@
       },
       "key_press_sound_volume": {
         "name": "Key press sound volume"
+      },
+      "key_sensitivity_level": {
+        "name": "Key sensitivity level"
+      },
+      "key_sound_level": {
+        "name": "Key sound level"
       },
       "language": {
         "name": "Language"
@@ -3770,6 +4142,12 @@
       },
       "monitor_set_act": {
         "name": "Monitor set act"
+      },
+      "motor": {
+        "name": "Motor"
+      },
+      "motor_level": {
+        "name": "Motor level"
       },
       "navigation_sound_setting": {
         "name": "Navigation sound setting"
@@ -3924,6 +4302,9 @@
       "permanent_remote_start": {
         "name": "Permanent remote start"
       },
+      "position_of_tower": {
+        "name": "Position of tower"
+      },
       "power_one_tenths_value": {
         "name": "Power one tenths value"
       },
@@ -4022,6 +4403,30 @@
       },
       "real_humidity_c": {
         "name": "Real humidity c"
+      },
+      "recirculation_filter_1_lifetime_in_hours": {
+        "name": "Recirculation filter 1 lifetime"
+      },
+      "recirculation_filter_1_reset_counter": {
+        "name": "Recirculation filter 1 reset counter"
+      },
+      "recirculation_filter_1_set_lifetime_in_hours": {
+        "name": "Recirculation filter 1 set lifetime"
+      },
+      "recirculation_filter_1_set_type": {
+        "name": "Recirculation filter 1 set type"
+      },
+      "recirculation_filter_1_status": {
+        "name": "Recirculation filter 1 status"
+      },
+      "recirculation_filter_1_timer_active": {
+        "name": "Recirculation filter 1 timer active"
+      },
+      "recirculation_filter_1_type": {
+        "name": "Recirculation filter 1 type"
+      },
+      "recirculation_filter_1_used_hours": {
+        "name": "Recirculation filter 1 used hours"
       },
       "recirculationfilter1lifetimeinhours": {
         "name": "Recirculation filter 1 lifetime in hours"
@@ -4690,6 +5095,9 @@
           "timer": "Timer"
         }
       },
+      "sl1_bridged_to_zone": {
+        "name": "Zone 1 bridged to zone"
+      },
       "sl1_cooking_method": {
         "name": "Zone 1 cooking method",
         "state": {
@@ -4722,6 +5130,12 @@
           "wok": "Wok"
         }
       },
+      "sl1_hestan_cue_cookware_type": {
+        "name": "Zone 1 Hestan Cue cookware type"
+      },
+      "sl1_hestan_cue_next_step_required_warning": {
+        "name": "Zone 1 Hestan Cue next step required"
+      },
       "sl1_hestan_cue_set_temperature": {
         "name": "Zone 1 Hestan Cue set temperature"
       },
@@ -4740,6 +5154,9 @@
       "sl1_power_level_max": {
         "name": "Zone 1 max power level"
       },
+      "sl1_sand_timer_paused_total_seconds": {
+        "name": "Zone 1 sand timer paused"
+      },
       "sl1_sand_timer_status": {
         "name": "Zone 1 sand timer status",
         "state": {
@@ -4750,6 +5167,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl1_sand_timer_utc_start_time_hours": {
+        "name": "Zone 1 sand timer start hours"
+      },
+      "sl1_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 1 sand timer start minutes"
+      },
+      "sl1_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 1 sand timer start seconds"
+      },
+      "sl1_stopwatch_paused_total_seconds": {
+        "name": "Zone 1 stopwatch paused"
+      },
       "sl1_stopwatch_status": {
         "name": "Zone 1 stopwatch status",
         "state": {
@@ -4759,8 +5188,35 @@
           "paused": "Paused"
         }
       },
+      "sl1_stopwatch_utc_start_time_hours": {
+        "name": "Zone 1 stopwatch start hours"
+      },
+      "sl1_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 1 stopwatch start minutes"
+      },
+      "sl1_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 1 stopwatch start seconds"
+      },
       "sl1_temperature": {
         "name": "Zone 1 temperature"
+      },
+      "sl1_timer_utc_end_time_hours": {
+        "name": "Zone 1 timer end hours"
+      },
+      "sl1_timer_utc_end_time_minutes": {
+        "name": "Zone 1 timer end minutes"
+      },
+      "sl1_timer_utc_end_time_seconds": {
+        "name": "Zone 1 timer end seconds"
+      },
+      "sl1_timer_utc_paused_hours": {
+        "name": "Zone 1 timer paused hours"
+      },
+      "sl1_timer_utc_paused_minutes": {
+        "name": "Zone 1 timer paused minutes"
+      },
+      "sl1_timer_utc_paused_seconds": {
+        "name": "Zone 1 timer paused seconds"
       },
       "sl1_zone_shape": {
         "name": "Zone 1 shape",
@@ -4779,6 +5235,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl2_bridged_to_zone": {
+        "name": "Zone 2 bridged to zone"
       },
       "sl2_cooking_method": {
         "name": "Zone 2 cooking method",
@@ -4812,6 +5271,12 @@
           "wok": "Wok"
         }
       },
+      "sl2_hestan_cue_cookware_type": {
+        "name": "Zone 2 Hestan Cue cookware type"
+      },
+      "sl2_hestan_cue_next_step_required_warning": {
+        "name": "Zone 2 Hestan Cue next step required"
+      },
       "sl2_hestan_cue_set_temperature": {
         "name": "Zone 2 Hestan Cue set temperature"
       },
@@ -4830,6 +5295,9 @@
       "sl2_power_level_max": {
         "name": "Zone 2 max power level"
       },
+      "sl2_sand_timer_paused_total_seconds": {
+        "name": "Zone 2 sand timer paused"
+      },
       "sl2_sand_timer_status": {
         "name": "Zone 2 sand timer status",
         "state": {
@@ -4840,6 +5308,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl2_sand_timer_utc_start_time_hours": {
+        "name": "Zone 2 sand timer start hours"
+      },
+      "sl2_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 2 sand timer start minutes"
+      },
+      "sl2_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 2 sand timer start seconds"
+      },
+      "sl2_stopwatch_paused_total_seconds": {
+        "name": "Zone 2 stopwatch paused"
+      },
       "sl2_stopwatch_status": {
         "name": "Zone 2 stopwatch status",
         "state": {
@@ -4849,8 +5329,35 @@
           "paused": "Paused"
         }
       },
+      "sl2_stopwatch_utc_start_time_hours": {
+        "name": "Zone 2 stopwatch start hours"
+      },
+      "sl2_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 2 stopwatch start minutes"
+      },
+      "sl2_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 2 stopwatch start seconds"
+      },
       "sl2_temperature": {
         "name": "Zone 2 temperature"
+      },
+      "sl2_timer_utc_end_time_hours": {
+        "name": "Zone 2 timer end hours"
+      },
+      "sl2_timer_utc_end_time_minutes": {
+        "name": "Zone 2 timer end minutes"
+      },
+      "sl2_timer_utc_end_time_seconds": {
+        "name": "Zone 2 timer end seconds"
+      },
+      "sl2_timer_utc_paused_hours": {
+        "name": "Zone 2 timer paused hours"
+      },
+      "sl2_timer_utc_paused_minutes": {
+        "name": "Zone 2 timer paused minutes"
+      },
+      "sl2_timer_utc_paused_seconds": {
+        "name": "Zone 2 timer paused seconds"
       },
       "sl2_zone_shape": {
         "name": "Zone 2 shape",
@@ -4869,6 +5376,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl3_bridged_to_zone": {
+        "name": "Zone 3 bridged to zone"
       },
       "sl3_cooking_method": {
         "name": "Zone 3 cooking method",
@@ -4902,6 +5412,12 @@
           "wok": "Wok"
         }
       },
+      "sl3_hestan_cue_cookware_type": {
+        "name": "Zone 3 Hestan Cue cookware type"
+      },
+      "sl3_hestan_cue_next_step_required_warning": {
+        "name": "Zone 3 Hestan Cue next step required"
+      },
       "sl3_hestan_cue_set_temperature": {
         "name": "Zone 3 Hestan Cue set temperature"
       },
@@ -4920,6 +5436,9 @@
       "sl3_power_level_max": {
         "name": "Zone 3 max power level"
       },
+      "sl3_sand_timer_paused_total_seconds": {
+        "name": "Zone 3 sand timer paused"
+      },
       "sl3_sand_timer_status": {
         "name": "Zone 3 sand timer status",
         "state": {
@@ -4930,6 +5449,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl3_sand_timer_utc_start_time_hours": {
+        "name": "Zone 3 sand timer start hours"
+      },
+      "sl3_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 3 sand timer start minutes"
+      },
+      "sl3_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 3 sand timer start seconds"
+      },
+      "sl3_stopwatch_paused_total_seconds": {
+        "name": "Zone 3 stopwatch paused"
+      },
       "sl3_stopwatch_status": {
         "name": "Zone 3 stopwatch status",
         "state": {
@@ -4939,8 +5470,35 @@
           "paused": "Paused"
         }
       },
+      "sl3_stopwatch_utc_start_time_hours": {
+        "name": "Zone 3 stopwatch start hours"
+      },
+      "sl3_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 3 stopwatch start minutes"
+      },
+      "sl3_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 3 stopwatch start seconds"
+      },
       "sl3_temperature": {
         "name": "Zone 3 temperature"
+      },
+      "sl3_timer_utc_end_time_hours": {
+        "name": "Zone 3 timer end hours"
+      },
+      "sl3_timer_utc_end_time_minutes": {
+        "name": "Zone 3 timer end minutes"
+      },
+      "sl3_timer_utc_end_time_seconds": {
+        "name": "Zone 3 timer end seconds"
+      },
+      "sl3_timer_utc_paused_hours": {
+        "name": "Zone 3 timer paused hours"
+      },
+      "sl3_timer_utc_paused_minutes": {
+        "name": "Zone 3 timer paused minutes"
+      },
+      "sl3_timer_utc_paused_seconds": {
+        "name": "Zone 3 timer paused seconds"
       },
       "sl3_zone_shape": {
         "name": "Zone 3 shape",
@@ -4959,6 +5517,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl4_bridged_to_zone": {
+        "name": "Zone 4 bridged to zone"
       },
       "sl4_cooking_method": {
         "name": "Zone 4 cooking method",
@@ -4992,6 +5553,12 @@
           "wok": "Wok"
         }
       },
+      "sl4_hestan_cue_cookware_type": {
+        "name": "Zone 4 Hestan Cue cookware type"
+      },
+      "sl4_hestan_cue_next_step_required_warning": {
+        "name": "Zone 4 Hestan Cue next step required"
+      },
       "sl4_hestan_cue_set_temperature": {
         "name": "Zone 4 Hestan Cue set temperature"
       },
@@ -5010,6 +5577,9 @@
       "sl4_power_level_max": {
         "name": "Zone 4 max power level"
       },
+      "sl4_sand_timer_paused_total_seconds": {
+        "name": "Zone 4 sand timer paused"
+      },
       "sl4_sand_timer_status": {
         "name": "Zone 4 sand timer status",
         "state": {
@@ -5020,6 +5590,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl4_sand_timer_utc_start_time_hours": {
+        "name": "Zone 4 sand timer start hours"
+      },
+      "sl4_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 4 sand timer start minutes"
+      },
+      "sl4_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 4 sand timer start seconds"
+      },
+      "sl4_stopwatch_paused_total_seconds": {
+        "name": "Zone 4 stopwatch paused"
+      },
       "sl4_stopwatch_status": {
         "name": "Zone 4 stopwatch status",
         "state": {
@@ -5029,8 +5611,35 @@
           "paused": "Paused"
         }
       },
+      "sl4_stopwatch_utc_start_time_hours": {
+        "name": "Zone 4 stopwatch start hours"
+      },
+      "sl4_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 4 stopwatch start minutes"
+      },
+      "sl4_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 4 stopwatch start seconds"
+      },
       "sl4_temperature": {
         "name": "Zone 4 temperature"
+      },
+      "sl4_timer_utc_end_time_hours": {
+        "name": "Zone 4 timer end hours"
+      },
+      "sl4_timer_utc_end_time_minutes": {
+        "name": "Zone 4 timer end minutes"
+      },
+      "sl4_timer_utc_end_time_seconds": {
+        "name": "Zone 4 timer end seconds"
+      },
+      "sl4_timer_utc_paused_hours": {
+        "name": "Zone 4 timer paused hours"
+      },
+      "sl4_timer_utc_paused_minutes": {
+        "name": "Zone 4 timer paused minutes"
+      },
+      "sl4_timer_utc_paused_seconds": {
+        "name": "Zone 4 timer paused seconds"
       },
       "sl4_zone_shape": {
         "name": "Zone 4 shape",
@@ -5049,6 +5658,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl5_bridged_to_zone": {
+        "name": "Zone 5 bridged to zone"
       },
       "sl5_cooking_method": {
         "name": "Zone 5 cooking method",
@@ -5082,6 +5694,12 @@
           "wok": "Wok"
         }
       },
+      "sl5_hestan_cue_cookware_type": {
+        "name": "Zone 5 Hestan Cue cookware type"
+      },
+      "sl5_hestan_cue_next_step_required_warning": {
+        "name": "Zone 5 Hestan Cue next step required"
+      },
       "sl5_hestan_cue_set_temperature": {
         "name": "Zone 5 Hestan Cue set temperature"
       },
@@ -5100,6 +5718,9 @@
       "sl5_power_level_max": {
         "name": "Zone 5 max power level"
       },
+      "sl5_sand_timer_paused_total_seconds": {
+        "name": "Zone 5 sand timer paused"
+      },
       "sl5_sand_timer_status": {
         "name": "Zone 5 sand timer status",
         "state": {
@@ -5110,6 +5731,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl5_sand_timer_utc_start_time_hours": {
+        "name": "Zone 5 sand timer start hours"
+      },
+      "sl5_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 5 sand timer start minutes"
+      },
+      "sl5_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 5 sand timer start seconds"
+      },
+      "sl5_stopwatch_paused_total_seconds": {
+        "name": "Zone 5 stopwatch paused"
+      },
       "sl5_stopwatch_status": {
         "name": "Zone 5 stopwatch status",
         "state": {
@@ -5119,8 +5752,35 @@
           "paused": "Paused"
         }
       },
+      "sl5_stopwatch_utc_start_time_hours": {
+        "name": "Zone 5 stopwatch start hours"
+      },
+      "sl5_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 5 stopwatch start minutes"
+      },
+      "sl5_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 5 stopwatch start seconds"
+      },
       "sl5_temperature": {
         "name": "Zone 5 temperature"
+      },
+      "sl5_timer_utc_end_time_hours": {
+        "name": "Zone 5 timer end hours"
+      },
+      "sl5_timer_utc_end_time_minutes": {
+        "name": "Zone 5 timer end minutes"
+      },
+      "sl5_timer_utc_end_time_seconds": {
+        "name": "Zone 5 timer end seconds"
+      },
+      "sl5_timer_utc_paused_hours": {
+        "name": "Zone 5 timer paused hours"
+      },
+      "sl5_timer_utc_paused_minutes": {
+        "name": "Zone 5 timer paused minutes"
+      },
+      "sl5_timer_utc_paused_seconds": {
+        "name": "Zone 5 timer paused seconds"
       },
       "sl5_zone_shape": {
         "name": "Zone 5 shape",
@@ -5139,6 +5799,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl6_bridged_to_zone": {
+        "name": "Zone 6 bridged to zone"
       },
       "sl6_cooking_method": {
         "name": "Zone 6 cooking method",
@@ -5172,6 +5835,12 @@
           "wok": "Wok"
         }
       },
+      "sl6_hestan_cue_cookware_type": {
+        "name": "Zone 6 Hestan Cue cookware type"
+      },
+      "sl6_hestan_cue_next_step_required_warning": {
+        "name": "Zone 6 Hestan Cue next step required"
+      },
       "sl6_hestan_cue_set_temperature": {
         "name": "Zone 6 Hestan Cue set temperature"
       },
@@ -5190,6 +5859,9 @@
       "sl6_power_level_max": {
         "name": "Zone 6 max power level"
       },
+      "sl6_sand_timer_paused_total_seconds": {
+        "name": "Zone 6 sand timer paused"
+      },
       "sl6_sand_timer_status": {
         "name": "Zone 6 sand timer status",
         "state": {
@@ -5200,6 +5872,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl6_sand_timer_utc_start_time_hours": {
+        "name": "Zone 6 sand timer start hours"
+      },
+      "sl6_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 6 sand timer start minutes"
+      },
+      "sl6_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 6 sand timer start seconds"
+      },
+      "sl6_stopwatch_paused_total_seconds": {
+        "name": "Zone 6 stopwatch paused"
+      },
       "sl6_stopwatch_status": {
         "name": "Zone 6 stopwatch status",
         "state": {
@@ -5209,8 +5893,35 @@
           "paused": "Paused"
         }
       },
+      "sl6_stopwatch_utc_start_time_hours": {
+        "name": "Zone 6 stopwatch start hours"
+      },
+      "sl6_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 6 stopwatch start minutes"
+      },
+      "sl6_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 6 stopwatch start seconds"
+      },
       "sl6_temperature": {
         "name": "Zone 6 temperature"
+      },
+      "sl6_timer_utc_end_time_hours": {
+        "name": "Zone 6 timer end hours"
+      },
+      "sl6_timer_utc_end_time_minutes": {
+        "name": "Zone 6 timer end minutes"
+      },
+      "sl6_timer_utc_end_time_seconds": {
+        "name": "Zone 6 timer end seconds"
+      },
+      "sl6_timer_utc_paused_hours": {
+        "name": "Zone 6 timer paused hours"
+      },
+      "sl6_timer_utc_paused_minutes": {
+        "name": "Zone 6 timer paused minutes"
+      },
+      "sl6_timer_utc_paused_seconds": {
+        "name": "Zone 6 timer paused seconds"
       },
       "sl6_zone_shape": {
         "name": "Zone 6 shape",
@@ -5347,6 +6058,9 @@
       },
       "stain_removal": {
         "name": "Stain removal"
+      },
+      "stand_by_time": {
+        "name": "Stand-by time"
       },
       "standardelectricitconsumption": {
         "name": "Standard electricity consumption"
@@ -6348,6 +7062,12 @@
       "support_preheat_state": {
         "name": "Support preheat state"
       },
+      "synchro_start_level": {
+        "name": "Synchro start level"
+      },
+      "synchro_stop_level": {
+        "name": "Synchro stop level"
+      },
       "t_beep": {
         "name": "T beep"
       },
@@ -6885,6 +7605,9 @@
       },
       "winddryingflag": {
         "name": "Wind drying flag"
+      },
+      "window_status": {
+        "name": "Window status"
       },
       "wine_area_switch_status": {
         "name": "Wine area switch status"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1086,6 +1086,9 @@
       "sl5_alarm_automatic_switch_off_zone": {
         "name": "Zone 5 automatically switched off"
       },
+      "sl5_alarm_ntc_coil": {
+        "name": "Zone 5 alarm NTC coil"
+      },
       "sl5_alarm_ntc_coil_overheating": {
         "name": "Zone 5 coil overheating"
       },
@@ -1101,6 +1104,9 @@
       "sl5_pot_detected": {
         "name": "Zone 5 pot detected"
       },
+      "sl5_residual_heat_signal": {
+        "name": "Zone 5 residual heat"
+      },
       "sl5_status": {
         "name": "Zone 5 status"
       },
@@ -1109,6 +1115,9 @@
       },
       "sl6_alarm_automatic_switch_off_zone": {
         "name": "Zone 6 automatically switched off"
+      },
+      "sl6_alarm_ntc_coil": {
+        "name": "Zone 6 alarm NTC coil"
       },
       "sl6_alarm_ntc_coil_overheating": {
         "name": "Zone 6 coil overheating"
@@ -1124,6 +1133,9 @@
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot detected"
+      },
+      "sl6_residual_heat_signal": {
+        "name": "Zone 6 residual heat"
       },
       "sl6_status": {
         "name": "Zone 6 status"
@@ -4700,8 +4712,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -4789,8 +4802,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -4878,8 +4892,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -4967,8 +4982,9 @@
           "boil": "Boil",
           "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
-          "keep_warm_and_fry": "Keep warm and fry",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
@@ -5034,26 +5050,77 @@
           "timer": "Timer"
         }
       },
+      "sl5_cooking_method": {
+        "name": "Zone 5 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl5_function_status": {
+        "name": "Zone 5 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl5_functions": {
         "name": "Zone 5 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl5_hestan_cue_set_temperature": {
+        "name": "Zone 5 Hestan Cue set temperature"
+      },
+      "sl5_hestan_cue_temperature": {
+        "name": "Zone 5 Hestan Cue temperature"
       },
       "sl5_ntc_sensor": {
         "name": "Zone 5 NTC sensor"
       },
       "sl5_power_level": {
-        "name": "Zone 5 power level"
+        "name": "Zone 5 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl5_power_level_max": {
         "name": "Zone 5 max power level"
+      },
+      "sl5_sand_timer_status": {
+        "name": "Zone 5 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl5_stopwatch_status": {
+        "name": "Zone 5 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl5_temperature": {
+        "name": "Zone 5 temperature"
       },
       "sl5_zone_shape": {
         "name": "Zone 5 shape",
@@ -5073,26 +5140,77 @@
           "timer": "Timer"
         }
       },
+      "sl6_cooking_method": {
+        "name": "Zone 6 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl6_function_status": {
+        "name": "Zone 6 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl6_functions": {
         "name": "Zone 6 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
+          "heat_up_and_fry": "Heat up and fry",
           "keep_warm": "Keep warm",
+          "keep_warm_and_heat_up": "Keep warm and heat up",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl6_hestan_cue_set_temperature": {
+        "name": "Zone 6 Hestan Cue set temperature"
+      },
+      "sl6_hestan_cue_temperature": {
+        "name": "Zone 6 Hestan Cue temperature"
       },
       "sl6_ntc_sensor": {
         "name": "Zone 6 NTC sensor"
       },
       "sl6_power_level": {
-        "name": "Zone 6 power level"
+        "name": "Zone 6 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl6_power_level_max": {
         "name": "Zone 6 max power level"
+      },
+      "sl6_sand_timer_status": {
+        "name": "Zone 6 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl6_stopwatch_status": {
+        "name": "Zone 6 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl6_temperature": {
+        "name": "Zone 6 temperature"
       },
       "sl6_zone_shape": {
         "name": "Zone 6 shape",

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -78,6 +78,9 @@
       "alarm_auto_dose_refill": {
         "name": "Auto-dose refill"
       },
+      "alarm_auto_program_ended": {
+        "name": "Auto program ended"
+      },
       "alarm_auto_program_notification": {
         "name": "Auto program notification"
       },
@@ -357,8 +360,17 @@
       "ali_wifi_fault_flag": {
         "name": "WiFi fault"
       },
+      "auto_boost": {
+        "name": "Auto boost"
+      },
+      "auto_bridge": {
+        "name": "Auto bridge"
+      },
       "auto_dose_refill": {
         "name": "Auto-dose refill"
+      },
+      "auto_timer": {
+        "name": "Auto timer"
       },
       "charcoal_filter_expiration_alarm": {
         "name": "Charcoal filter expiration alarm"
@@ -368,6 +380,9 @@
       },
       "charcoal_filter_time_reset": {
         "name": "Charcoal filter time reset"
+      },
+      "chef_mode": {
+        "name": "Chef mode"
       },
       "child_lock": {
         "name": "Child lock"
@@ -663,6 +678,15 @@
       "float_switch": {
         "name": "Float switch"
       },
+      "fota_set": {
+        "name": "FOTA set"
+      },
+      "fota_set_flag": {
+        "name": "FOTA set flag"
+      },
+      "fota_status": {
+        "name": "FOTA status"
+      },
       "free_defrosting_failure": {
         "name": "Freezer defrosting failure"
       },
@@ -716,6 +740,15 @@
       },
       "hard_pairing_status": {
         "name": "Hard pairing status"
+      },
+      "hard_pairing_unpair_all_set_flag": {
+        "name": "Hard pairing unpair all set flag"
+      },
+      "hardpairingstatus": {
+        "name": "Hard pairing status"
+      },
+      "hardpairingunpairall": {
+        "name": "Hard pairing unpair all"
       },
       "hob_status": {
         "name": "Hob status"
@@ -798,11 +831,17 @@
       "open_variation_door_alarm": {
         "name": "Open variation door alarm"
       },
+      "permanent_pot_detection": {
+        "name": "Permanent pot detection"
+      },
       "preheat": {
         "name": "Preheat"
       },
       "quiet_mode_status": {
         "name": "Quiet mode status"
+      },
+      "recovery": {
+        "name": "Recovery"
       },
       "reed_switch": {
         "name": "Reed switch"
@@ -870,6 +909,9 @@
       "remote_control_monitoring_set_commands_actions": {
         "name": "Remote control"
       },
+      "remote_controlmode": {
+        "name": "Remote control mode"
+      },
       "right_free_sensor_failure": {
         "name": "Right free sensor failure"
       },
@@ -924,6 +966,9 @@
       "sl1_alarm_automatic_switch_off_zone": {
         "name": "Zone 1 automatically switched off"
       },
+      "sl1_alarm_ntc_coil": {
+        "name": "Zone 1 alarm NTC coil"
+      },
       "sl1_alarm_ntc_coil_overheating": {
         "name": "Zone 1 coil overheating"
       },
@@ -939,6 +984,9 @@
       "sl1_pot_detected": {
         "name": "Zone 1 pot detected"
       },
+      "sl1_residual_heat_signal": {
+        "name": "Zone 1 residual heat"
+      },
       "sl1_status": {
         "name": "Zone 1 status"
       },
@@ -947,6 +995,9 @@
       },
       "sl2_alarm_automatic_switch_off_zone": {
         "name": "Zone 2 automatically switched off"
+      },
+      "sl2_alarm_ntc_coil": {
+        "name": "Zone 2 alarm NTC coil"
       },
       "sl2_alarm_ntc_coil_overheating": {
         "name": "Zone 2 coil overheating"
@@ -963,6 +1014,9 @@
       "sl2_pot_detected": {
         "name": "Zone 2 pot detected"
       },
+      "sl2_residual_heat_signal": {
+        "name": "Zone 2 residual heat"
+      },
       "sl2_status": {
         "name": "Zone 2 status"
       },
@@ -971,6 +1025,9 @@
       },
       "sl3_alarm_automatic_switch_off_zone": {
         "name": "Zone 3 automatically switched off"
+      },
+      "sl3_alarm_ntc_coil": {
+        "name": "Zone 3 alarm NTC coil"
       },
       "sl3_alarm_ntc_coil_overheating": {
         "name": "Zone 3 coil overheating"
@@ -987,6 +1044,9 @@
       "sl3_pot_detected": {
         "name": "Zone 3 pot detected"
       },
+      "sl3_residual_heat_signal": {
+        "name": "Zone 3 residual heat"
+      },
       "sl3_status": {
         "name": "Zone 3 status"
       },
@@ -995,6 +1055,9 @@
       },
       "sl4_alarm_automatic_switch_off_zone": {
         "name": "Zone 4 automatically switched off"
+      },
+      "sl4_alarm_ntc_coil": {
+        "name": "Zone 4 alarm NTC coil"
       },
       "sl4_alarm_ntc_coil_overheating": {
         "name": "Zone 4 coil overheating"
@@ -1010,6 +1073,9 @@
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot detected"
+      },
+      "sl4_residual_heat_signal": {
+        "name": "Zone 4 residual heat"
       },
       "sl4_status": {
         "name": "Zone 4 status"
@@ -1118,6 +1184,9 @@
       },
       "t_beep": {
         "name": "Beep"
+      },
+      "test_mode": {
+        "name": "Test mode"
       },
       "tx_failure": {
         "name": "TX failure"
@@ -4609,26 +4678,76 @@
           "timer": "Timer"
         }
       },
+      "sl1_cooking_method": {
+        "name": "Zone 1 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl1_function_status": {
+        "name": "Zone 1 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl1_functions": {
         "name": "Zone 1 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl1_hestan_cue_set_temperature": {
+        "name": "Zone 1 Hestan Cue set temperature"
+      },
+      "sl1_hestan_cue_temperature": {
+        "name": "Zone 1 Hestan Cue temperature"
       },
       "sl1_ntc_sensor": {
         "name": "Zone 1 NTC sensor"
       },
       "sl1_power_level": {
-        "name": "Zone 1 power level"
+        "name": "Zone 1 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl1_power_level_max": {
         "name": "Zone 1 max power level"
+      },
+      "sl1_sand_timer_status": {
+        "name": "Zone 1 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl1_stopwatch_status": {
+        "name": "Zone 1 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl1_temperature": {
+        "name": "Zone 1 temperature"
       },
       "sl1_zone_shape": {
         "name": "Zone 1 shape",
@@ -4648,26 +4767,76 @@
           "timer": "Timer"
         }
       },
+      "sl2_cooking_method": {
+        "name": "Zone 2 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl2_function_status": {
+        "name": "Zone 2 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl2_functions": {
         "name": "Zone 2 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl2_hestan_cue_set_temperature": {
+        "name": "Zone 2 Hestan Cue set temperature"
+      },
+      "sl2_hestan_cue_temperature": {
+        "name": "Zone 2 Hestan Cue temperature"
       },
       "sl2_ntc_sensor": {
         "name": "Zone 2 NTC sensor"
       },
       "sl2_power_level": {
-        "name": "Zone 2 power level"
+        "name": "Zone 2 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl2_power_level_max": {
         "name": "Zone 2 max power level"
+      },
+      "sl2_sand_timer_status": {
+        "name": "Zone 2 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl2_stopwatch_status": {
+        "name": "Zone 2 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl2_temperature": {
+        "name": "Zone 2 temperature"
       },
       "sl2_zone_shape": {
         "name": "Zone 2 shape",
@@ -4687,26 +4856,76 @@
           "timer": "Timer"
         }
       },
+      "sl3_cooking_method": {
+        "name": "Zone 3 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl3_function_status": {
+        "name": "Zone 3 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl3_functions": {
         "name": "Zone 3 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl3_hestan_cue_set_temperature": {
+        "name": "Zone 3 Hestan Cue set temperature"
+      },
+      "sl3_hestan_cue_temperature": {
+        "name": "Zone 3 Hestan Cue temperature"
       },
       "sl3_ntc_sensor": {
         "name": "Zone 3 NTC sensor"
       },
       "sl3_power_level": {
-        "name": "Zone 3 power level"
+        "name": "Zone 3 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl3_power_level_max": {
         "name": "Zone 3 max power level"
+      },
+      "sl3_sand_timer_status": {
+        "name": "Zone 3 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl3_stopwatch_status": {
+        "name": "Zone 3 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl3_temperature": {
+        "name": "Zone 3 temperature"
       },
       "sl3_zone_shape": {
         "name": "Zone 3 shape",
@@ -4726,26 +4945,76 @@
           "timer": "Timer"
         }
       },
+      "sl4_cooking_method": {
+        "name": "Zone 4 cooking method",
+        "state": {
+          "method_1": "Method 1",
+          "method_2": "Method 2",
+          "none": "None"
+        }
+      },
+      "sl4_function_status": {
+        "name": "Zone 4 function status",
+        "state": {
+          "function_1": "Function 1",
+          "function_2": "Function 2",
+          "none": "None"
+        }
+      },
       "sl4_functions": {
         "name": "Zone 4 function",
         "state": {
           "boil": "Boil",
+          "fry": "Fry",
           "grill": "Grill",
           "keep_warm": "Keep warm",
+          "keep_warm_and_fry": "Keep warm and fry",
           "none": "None",
           "roast": "Roast",
           "simmer": "Simmer",
+          "slow_cook": "Slow cook",
           "wok": "Wok"
         }
+      },
+      "sl4_hestan_cue_set_temperature": {
+        "name": "Zone 4 Hestan Cue set temperature"
+      },
+      "sl4_hestan_cue_temperature": {
+        "name": "Zone 4 Hestan Cue temperature"
       },
       "sl4_ntc_sensor": {
         "name": "Zone 4 NTC sensor"
       },
       "sl4_power_level": {
-        "name": "Zone 4 power level"
+        "name": "Zone 4 power level",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl4_power_level_max": {
         "name": "Zone 4 max power level"
+      },
+      "sl4_sand_timer_status": {
+        "name": "Zone 4 sand timer status",
+        "state": {
+          "active": "Active",
+          "ended": "Ended",
+          "inactive": "Inactive",
+          "paused": "Paused",
+          "stopped": "Stopped"
+        }
+      },
+      "sl4_stopwatch_status": {
+        "name": "Zone 4 stopwatch status",
+        "state": {
+          "active": "Active",
+          "hold": "Hold",
+          "inactive": "Inactive",
+          "paused": "Paused"
+        }
+      },
+      "sl4_temperature": {
+        "name": "Zone 4 temperature"
       },
       "sl4_zone_shape": {
         "name": "Zone 4 shape",
@@ -6109,6 +6378,9 @@
         "name": "Total run time"
       },
       "total_time_of_cooking_in_hours": {
+        "name": "Total time of cooking"
+      },
+      "total_time_of_cooking_in_minute": {
         "name": "Total time of cooking"
       },
       "total_water_consumption": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -687,9 +687,6 @@
       "fota_set": {
         "name": "FOTA set"
       },
-      "fota_set_flag": {
-        "name": "FOTA set flag"
-      },
       "fota_status": {
         "name": "FOTA status"
       },
@@ -746,9 +743,6 @@
       },
       "hard_pairing_status": {
         "name": "Hard pairing status"
-      },
-      "hard_pairing_unpair_all_set_flag": {
-        "name": "Hard pairing unpair all set flag"
       },
       "hardpairingstatus": {
         "name": "Hard pairing status"
@@ -2474,13 +2468,13 @@
         "name": "Auto-dose system setting status"
       },
       "auto_grease_filter_indication": {
-        "name": "Auto grease filter indication"
+        "name": "Auto grease filter"
       },
       "auto_super_rinse_setting_status": {
         "name": "Auto super rinse setting status"
       },
       "auto_tower_up": {
-        "name": "Auto tower up"
+        "name": "Tower auto-raise"
       },
       "autodose_flag": {
         "name": "Auto-dose flag",
@@ -3898,7 +3892,7 @@
         "name": "Hood status"
       },
       "hood_total_used_hours": {
-        "name": "Hood total used hours"
+        "name": "Hood runtime hours"
       },
       "hottime": {
         "name": "Hot time"
@@ -5096,7 +5090,7 @@
         }
       },
       "sl1_bridged_to_zone": {
-        "name": "Zone 1 bridged to zone"
+        "name": "Zone 1 bridge target"
       },
       "sl1_cooking_method": {
         "name": "Zone 1 cooking method",
@@ -5237,7 +5231,7 @@
         }
       },
       "sl2_bridged_to_zone": {
-        "name": "Zone 2 bridged to zone"
+        "name": "Zone 2 bridge target"
       },
       "sl2_cooking_method": {
         "name": "Zone 2 cooking method",
@@ -5378,7 +5372,7 @@
         }
       },
       "sl3_bridged_to_zone": {
-        "name": "Zone 3 bridged to zone"
+        "name": "Zone 3 bridge target"
       },
       "sl3_cooking_method": {
         "name": "Zone 3 cooking method",
@@ -5519,7 +5513,7 @@
         }
       },
       "sl4_bridged_to_zone": {
-        "name": "Zone 4 bridged to zone"
+        "name": "Zone 4 bridge target"
       },
       "sl4_cooking_method": {
         "name": "Zone 4 cooking method",
@@ -5660,7 +5654,7 @@
         }
       },
       "sl5_bridged_to_zone": {
-        "name": "Zone 5 bridged to zone"
+        "name": "Zone 5 bridge target"
       },
       "sl5_cooking_method": {
         "name": "Zone 5 cooking method",
@@ -5801,7 +5795,7 @@
         }
       },
       "sl6_bridged_to_zone": {
-        "name": "Zone 6 bridged to zone"
+        "name": "Zone 6 bridge target"
       },
       "sl6_cooking_method": {
         "name": "Zone 6 cooking method",

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -144,6 +144,9 @@
       "alarm_fast_preheating_finished": {
         "name": "Alarm fast preheating finished"
       },
+      "alarm_grease_filter": {
+        "name": "Grease filter alarm"
+      },
       "alarm_hob_hood_started": {
         "name": "Hob hood started"
       },
@@ -191,6 +194,9 @@
       },
       "alarm_pyrolytic_finished": {
         "name": "Alarm pyrolytic finished"
+      },
+      "alarm_recirculation_filter_1": {
+        "name": "Recirculation filter 1 alarm"
       },
       "alarm_remote_start_canceled": {
         "name": "Remote start canceled"
@@ -981,6 +987,57 @@
       "sl1_bridge_function_active": {
         "name": "Zone 1 bridge active"
       },
+      "sl1_error_1": {
+        "name": "Zone 1 error 1"
+      },
+      "sl1_error_10": {
+        "name": "Zone 1 error 10"
+      },
+      "sl1_error_11": {
+        "name": "Zone 1 error 11"
+      },
+      "sl1_error_12": {
+        "name": "Zone 1 error 12"
+      },
+      "sl1_error_13": {
+        "name": "Zone 1 error 13"
+      },
+      "sl1_error_14": {
+        "name": "Zone 1 error 14"
+      },
+      "sl1_error_15": {
+        "name": "Zone 1 error 15"
+      },
+      "sl1_error_16": {
+        "name": "Zone 1 error 16"
+      },
+      "sl1_error_17": {
+        "name": "Zone 1 error 17"
+      },
+      "sl1_error_2": {
+        "name": "Zone 1 error 2"
+      },
+      "sl1_error_3": {
+        "name": "Zone 1 error 3"
+      },
+      "sl1_error_4": {
+        "name": "Zone 1 error 4"
+      },
+      "sl1_error_5": {
+        "name": "Zone 1 error 5"
+      },
+      "sl1_error_6": {
+        "name": "Zone 1 error 6"
+      },
+      "sl1_error_7": {
+        "name": "Zone 1 error 7"
+      },
+      "sl1_error_8": {
+        "name": "Zone 1 error 8"
+      },
+      "sl1_error_9": {
+        "name": "Zone 1 error 9"
+      },
       "sl1_pot_detected": {
         "name": "Zone 1 pot detected"
       },
@@ -1010,6 +1067,57 @@
       },
       "sl2_bridge_function_active": {
         "name": "Zone 2 bridge active"
+      },
+      "sl2_error_1": {
+        "name": "Zone 2 error 1"
+      },
+      "sl2_error_10": {
+        "name": "Zone 2 error 10"
+      },
+      "sl2_error_11": {
+        "name": "Zone 2 error 11"
+      },
+      "sl2_error_12": {
+        "name": "Zone 2 error 12"
+      },
+      "sl2_error_13": {
+        "name": "Zone 2 error 13"
+      },
+      "sl2_error_14": {
+        "name": "Zone 2 error 14"
+      },
+      "sl2_error_15": {
+        "name": "Zone 2 error 15"
+      },
+      "sl2_error_16": {
+        "name": "Zone 2 error 16"
+      },
+      "sl2_error_17": {
+        "name": "Zone 2 error 17"
+      },
+      "sl2_error_2": {
+        "name": "Zone 2 error 2"
+      },
+      "sl2_error_3": {
+        "name": "Zone 2 error 3"
+      },
+      "sl2_error_4": {
+        "name": "Zone 2 error 4"
+      },
+      "sl2_error_5": {
+        "name": "Zone 2 error 5"
+      },
+      "sl2_error_6": {
+        "name": "Zone 2 error 6"
+      },
+      "sl2_error_7": {
+        "name": "Zone 2 error 7"
+      },
+      "sl2_error_8": {
+        "name": "Zone 2 error 8"
+      },
+      "sl2_error_9": {
+        "name": "Zone 2 error 9"
       },
       "sl2_pot_detected": {
         "name": "Zone 2 pot detected"
@@ -1041,6 +1149,57 @@
       "sl3_bridge_function_active": {
         "name": "Zone 3 bridge active"
       },
+      "sl3_error_1": {
+        "name": "Zone 3 error 1"
+      },
+      "sl3_error_10": {
+        "name": "Zone 3 error 10"
+      },
+      "sl3_error_11": {
+        "name": "Zone 3 error 11"
+      },
+      "sl3_error_12": {
+        "name": "Zone 3 error 12"
+      },
+      "sl3_error_13": {
+        "name": "Zone 3 error 13"
+      },
+      "sl3_error_14": {
+        "name": "Zone 3 error 14"
+      },
+      "sl3_error_15": {
+        "name": "Zone 3 error 15"
+      },
+      "sl3_error_16": {
+        "name": "Zone 3 error 16"
+      },
+      "sl3_error_17": {
+        "name": "Zone 3 error 17"
+      },
+      "sl3_error_2": {
+        "name": "Zone 3 error 2"
+      },
+      "sl3_error_3": {
+        "name": "Zone 3 error 3"
+      },
+      "sl3_error_4": {
+        "name": "Zone 3 error 4"
+      },
+      "sl3_error_5": {
+        "name": "Zone 3 error 5"
+      },
+      "sl3_error_6": {
+        "name": "Zone 3 error 6"
+      },
+      "sl3_error_7": {
+        "name": "Zone 3 error 7"
+      },
+      "sl3_error_8": {
+        "name": "Zone 3 error 8"
+      },
+      "sl3_error_9": {
+        "name": "Zone 3 error 9"
+      },
       "sl3_pot_detected": {
         "name": "Zone 3 pot detected"
       },
@@ -1070,6 +1229,57 @@
       },
       "sl4_bridge_function_active": {
         "name": "Zone 4 bridge active"
+      },
+      "sl4_error_1": {
+        "name": "Zone 4 error 1"
+      },
+      "sl4_error_10": {
+        "name": "Zone 4 error 10"
+      },
+      "sl4_error_11": {
+        "name": "Zone 4 error 11"
+      },
+      "sl4_error_12": {
+        "name": "Zone 4 error 12"
+      },
+      "sl4_error_13": {
+        "name": "Zone 4 error 13"
+      },
+      "sl4_error_14": {
+        "name": "Zone 4 error 14"
+      },
+      "sl4_error_15": {
+        "name": "Zone 4 error 15"
+      },
+      "sl4_error_16": {
+        "name": "Zone 4 error 16"
+      },
+      "sl4_error_17": {
+        "name": "Zone 4 error 17"
+      },
+      "sl4_error_2": {
+        "name": "Zone 4 error 2"
+      },
+      "sl4_error_3": {
+        "name": "Zone 4 error 3"
+      },
+      "sl4_error_4": {
+        "name": "Zone 4 error 4"
+      },
+      "sl4_error_5": {
+        "name": "Zone 4 error 5"
+      },
+      "sl4_error_6": {
+        "name": "Zone 4 error 6"
+      },
+      "sl4_error_7": {
+        "name": "Zone 4 error 7"
+      },
+      "sl4_error_8": {
+        "name": "Zone 4 error 8"
+      },
+      "sl4_error_9": {
+        "name": "Zone 4 error 9"
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot detected"
@@ -1101,6 +1311,57 @@
       "sl5_bridge_function_active": {
         "name": "Zone 5 bridge active"
       },
+      "sl5_error_1": {
+        "name": "Zone 5 error 1"
+      },
+      "sl5_error_10": {
+        "name": "Zone 5 error 10"
+      },
+      "sl5_error_11": {
+        "name": "Zone 5 error 11"
+      },
+      "sl5_error_12": {
+        "name": "Zone 5 error 12"
+      },
+      "sl5_error_13": {
+        "name": "Zone 5 error 13"
+      },
+      "sl5_error_14": {
+        "name": "Zone 5 error 14"
+      },
+      "sl5_error_15": {
+        "name": "Zone 5 error 15"
+      },
+      "sl5_error_16": {
+        "name": "Zone 5 error 16"
+      },
+      "sl5_error_17": {
+        "name": "Zone 5 error 17"
+      },
+      "sl5_error_2": {
+        "name": "Zone 5 error 2"
+      },
+      "sl5_error_3": {
+        "name": "Zone 5 error 3"
+      },
+      "sl5_error_4": {
+        "name": "Zone 5 error 4"
+      },
+      "sl5_error_5": {
+        "name": "Zone 5 error 5"
+      },
+      "sl5_error_6": {
+        "name": "Zone 5 error 6"
+      },
+      "sl5_error_7": {
+        "name": "Zone 5 error 7"
+      },
+      "sl5_error_8": {
+        "name": "Zone 5 error 8"
+      },
+      "sl5_error_9": {
+        "name": "Zone 5 error 9"
+      },
       "sl5_pot_detected": {
         "name": "Zone 5 pot detected"
       },
@@ -1130,6 +1391,57 @@
       },
       "sl6_bridge_function_active": {
         "name": "Zone 6 bridge active"
+      },
+      "sl6_error_1": {
+        "name": "Zone 6 error 1"
+      },
+      "sl6_error_10": {
+        "name": "Zone 6 error 10"
+      },
+      "sl6_error_11": {
+        "name": "Zone 6 error 11"
+      },
+      "sl6_error_12": {
+        "name": "Zone 6 error 12"
+      },
+      "sl6_error_13": {
+        "name": "Zone 6 error 13"
+      },
+      "sl6_error_14": {
+        "name": "Zone 6 error 14"
+      },
+      "sl6_error_15": {
+        "name": "Zone 6 error 15"
+      },
+      "sl6_error_16": {
+        "name": "Zone 6 error 16"
+      },
+      "sl6_error_17": {
+        "name": "Zone 6 error 17"
+      },
+      "sl6_error_2": {
+        "name": "Zone 6 error 2"
+      },
+      "sl6_error_3": {
+        "name": "Zone 6 error 3"
+      },
+      "sl6_error_4": {
+        "name": "Zone 6 error 4"
+      },
+      "sl6_error_5": {
+        "name": "Zone 6 error 5"
+      },
+      "sl6_error_6": {
+        "name": "Zone 6 error 6"
+      },
+      "sl6_error_7": {
+        "name": "Zone 6 error 7"
+      },
+      "sl6_error_8": {
+        "name": "Zone 6 error 8"
+      },
+      "sl6_error_9": {
+        "name": "Zone 6 error 9"
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot detected"
@@ -1971,6 +2283,9 @@
       "ai_energy_mode_switch": {
         "name": "AI energy mode switch"
       },
+      "air_dry_function": {
+        "name": "Air dry function"
+      },
       "air_dry_function_status": {
         "name": "Air dry function status"
       },
@@ -2158,8 +2473,14 @@
       "auto_dose_system_setting_status": {
         "name": "Auto-dose system setting status"
       },
+      "auto_grease_filter_indication": {
+        "name": "Auto grease filter indication"
+      },
       "auto_super_rinse_setting_status": {
         "name": "Auto super rinse setting status"
+      },
+      "auto_tower_up": {
+        "name": "Auto tower up"
       },
       "autodose_flag": {
         "name": "Auto-dose flag",
@@ -2222,6 +2543,9 @@
       "brightness_setting": {
         "name": "Brightness setting"
       },
+      "builtin_hood_status": {
+        "name": "Built-in hood status"
+      },
       "bundling_humidity": {
         "name": "Bundling humidity"
       },
@@ -2282,6 +2606,9 @@
       "childlock_pause": {
         "name": "Child lock pause"
       },
+      "circulation_mode": {
+        "name": "Circulation mode"
+      },
       "circulationmodestatus": {
         "name": "Circulation mode status"
       },
@@ -2338,6 +2665,9 @@
       },
       "condensed_watermode": {
         "name": "Condensed water mode"
+      },
+      "control_response_level": {
+        "name": "Control response level"
       },
       "cool_c": {
         "name": "Cool C"
@@ -2472,7 +2802,7 @@
         "name": "Daily energy consumption"
       },
       "daily_energy_kwh": {
-        "name": "Daily energy consumption"
+        "name": "Daily energy"
       },
       "darhcdq": {
         "name": "Darhcdq"
@@ -3454,6 +3784,27 @@
       "gratin_total_passed_time_in_minutes": {
         "name": "Gratin total passed time in minutes"
       },
+      "grease_filter_cleaning_interval_in_hours": {
+        "name": "Grease filter cleaning interval"
+      },
+      "grease_filter_reset_counter": {
+        "name": "Grease filter reset counter"
+      },
+      "grease_filter_saturation": {
+        "name": "Grease filter saturation"
+      },
+      "grease_filter_set_lifetime_in_hours": {
+        "name": "Grease filter lifetime"
+      },
+      "grease_filter_status": {
+        "name": "Grease filter status"
+      },
+      "grease_filter_timer_active": {
+        "name": "Grease filter timer active"
+      },
+      "grease_filter_used_hours": {
+        "name": "Grease filter used hours"
+      },
       "greasefiltercleaningintervalinhours": {
         "name": "Grease filter cleaning interval in hours"
       },
@@ -3533,6 +3884,21 @@
         "state": {
           "off_hot": "Off hot"
         }
+      },
+      "hood_connected_via_rf": {
+        "name": "Hood connected via RF"
+      },
+      "hood_fan_speed": {
+        "name": "Hood fan speed"
+      },
+      "hood_light": {
+        "name": "Hood light"
+      },
+      "hood_status": {
+        "name": "Hood status"
+      },
+      "hood_total_used_hours": {
+        "name": "Hood total used hours"
       },
       "hottime": {
         "name": "Hot time"
@@ -3623,6 +3989,12 @@
       },
       "key_press_sound_volume": {
         "name": "Key press sound volume"
+      },
+      "key_sensitivity_level": {
+        "name": "Key sensitivity level"
+      },
+      "key_sound_level": {
+        "name": "Key sound level"
       },
       "language": {
         "name": "Language"
@@ -3770,6 +4142,12 @@
       },
       "monitor_set_act": {
         "name": "Monitor set act"
+      },
+      "motor": {
+        "name": "Motor"
+      },
+      "motor_level": {
+        "name": "Motor level"
       },
       "navigation_sound_setting": {
         "name": "Navigation sound setting"
@@ -3924,6 +4302,9 @@
       "permanent_remote_start": {
         "name": "Permanent remote start"
       },
+      "position_of_tower": {
+        "name": "Position of tower"
+      },
       "power_one_tenths_value": {
         "name": "Power one tenths value"
       },
@@ -4022,6 +4403,30 @@
       },
       "real_humidity_c": {
         "name": "Real humidity c"
+      },
+      "recirculation_filter_1_lifetime_in_hours": {
+        "name": "Recirculation filter 1 lifetime"
+      },
+      "recirculation_filter_1_reset_counter": {
+        "name": "Recirculation filter 1 reset counter"
+      },
+      "recirculation_filter_1_set_lifetime_in_hours": {
+        "name": "Recirculation filter 1 set lifetime"
+      },
+      "recirculation_filter_1_set_type": {
+        "name": "Recirculation filter 1 set type"
+      },
+      "recirculation_filter_1_status": {
+        "name": "Recirculation filter 1 status"
+      },
+      "recirculation_filter_1_timer_active": {
+        "name": "Recirculation filter 1 timer active"
+      },
+      "recirculation_filter_1_type": {
+        "name": "Recirculation filter 1 type"
+      },
+      "recirculation_filter_1_used_hours": {
+        "name": "Recirculation filter 1 used hours"
       },
       "recirculationfilter1lifetimeinhours": {
         "name": "Recirculation filter 1 lifetime in hours"
@@ -4690,6 +5095,9 @@
           "timer": "Timer"
         }
       },
+      "sl1_bridged_to_zone": {
+        "name": "Zone 1 bridged to zone"
+      },
       "sl1_cooking_method": {
         "name": "Zone 1 cooking method",
         "state": {
@@ -4722,6 +5130,12 @@
           "wok": "Wok"
         }
       },
+      "sl1_hestan_cue_cookware_type": {
+        "name": "Zone 1 Hestan Cue cookware type"
+      },
+      "sl1_hestan_cue_next_step_required_warning": {
+        "name": "Zone 1 Hestan Cue next step required"
+      },
       "sl1_hestan_cue_set_temperature": {
         "name": "Zone 1 Hestan Cue set temperature"
       },
@@ -4740,6 +5154,9 @@
       "sl1_power_level_max": {
         "name": "Zone 1 max power level"
       },
+      "sl1_sand_timer_paused_total_seconds": {
+        "name": "Zone 1 sand timer paused"
+      },
       "sl1_sand_timer_status": {
         "name": "Zone 1 sand timer status",
         "state": {
@@ -4750,6 +5167,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl1_sand_timer_utc_start_time_hours": {
+        "name": "Zone 1 sand timer start hours"
+      },
+      "sl1_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 1 sand timer start minutes"
+      },
+      "sl1_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 1 sand timer start seconds"
+      },
+      "sl1_stopwatch_paused_total_seconds": {
+        "name": "Zone 1 stopwatch paused"
+      },
       "sl1_stopwatch_status": {
         "name": "Zone 1 stopwatch status",
         "state": {
@@ -4759,8 +5188,35 @@
           "paused": "Paused"
         }
       },
+      "sl1_stopwatch_utc_start_time_hours": {
+        "name": "Zone 1 stopwatch start hours"
+      },
+      "sl1_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 1 stopwatch start minutes"
+      },
+      "sl1_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 1 stopwatch start seconds"
+      },
       "sl1_temperature": {
         "name": "Zone 1 temperature"
+      },
+      "sl1_timer_utc_end_time_hours": {
+        "name": "Zone 1 timer end hours"
+      },
+      "sl1_timer_utc_end_time_minutes": {
+        "name": "Zone 1 timer end minutes"
+      },
+      "sl1_timer_utc_end_time_seconds": {
+        "name": "Zone 1 timer end seconds"
+      },
+      "sl1_timer_utc_paused_hours": {
+        "name": "Zone 1 timer paused hours"
+      },
+      "sl1_timer_utc_paused_minutes": {
+        "name": "Zone 1 timer paused minutes"
+      },
+      "sl1_timer_utc_paused_seconds": {
+        "name": "Zone 1 timer paused seconds"
       },
       "sl1_zone_shape": {
         "name": "Zone 1 shape",
@@ -4779,6 +5235,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl2_bridged_to_zone": {
+        "name": "Zone 2 bridged to zone"
       },
       "sl2_cooking_method": {
         "name": "Zone 2 cooking method",
@@ -4812,6 +5271,12 @@
           "wok": "Wok"
         }
       },
+      "sl2_hestan_cue_cookware_type": {
+        "name": "Zone 2 Hestan Cue cookware type"
+      },
+      "sl2_hestan_cue_next_step_required_warning": {
+        "name": "Zone 2 Hestan Cue next step required"
+      },
       "sl2_hestan_cue_set_temperature": {
         "name": "Zone 2 Hestan Cue set temperature"
       },
@@ -4830,6 +5295,9 @@
       "sl2_power_level_max": {
         "name": "Zone 2 max power level"
       },
+      "sl2_sand_timer_paused_total_seconds": {
+        "name": "Zone 2 sand timer paused"
+      },
       "sl2_sand_timer_status": {
         "name": "Zone 2 sand timer status",
         "state": {
@@ -4840,6 +5308,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl2_sand_timer_utc_start_time_hours": {
+        "name": "Zone 2 sand timer start hours"
+      },
+      "sl2_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 2 sand timer start minutes"
+      },
+      "sl2_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 2 sand timer start seconds"
+      },
+      "sl2_stopwatch_paused_total_seconds": {
+        "name": "Zone 2 stopwatch paused"
+      },
       "sl2_stopwatch_status": {
         "name": "Zone 2 stopwatch status",
         "state": {
@@ -4849,8 +5329,35 @@
           "paused": "Paused"
         }
       },
+      "sl2_stopwatch_utc_start_time_hours": {
+        "name": "Zone 2 stopwatch start hours"
+      },
+      "sl2_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 2 stopwatch start minutes"
+      },
+      "sl2_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 2 stopwatch start seconds"
+      },
       "sl2_temperature": {
         "name": "Zone 2 temperature"
+      },
+      "sl2_timer_utc_end_time_hours": {
+        "name": "Zone 2 timer end hours"
+      },
+      "sl2_timer_utc_end_time_minutes": {
+        "name": "Zone 2 timer end minutes"
+      },
+      "sl2_timer_utc_end_time_seconds": {
+        "name": "Zone 2 timer end seconds"
+      },
+      "sl2_timer_utc_paused_hours": {
+        "name": "Zone 2 timer paused hours"
+      },
+      "sl2_timer_utc_paused_minutes": {
+        "name": "Zone 2 timer paused minutes"
+      },
+      "sl2_timer_utc_paused_seconds": {
+        "name": "Zone 2 timer paused seconds"
       },
       "sl2_zone_shape": {
         "name": "Zone 2 shape",
@@ -4869,6 +5376,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl3_bridged_to_zone": {
+        "name": "Zone 3 bridged to zone"
       },
       "sl3_cooking_method": {
         "name": "Zone 3 cooking method",
@@ -4902,6 +5412,12 @@
           "wok": "Wok"
         }
       },
+      "sl3_hestan_cue_cookware_type": {
+        "name": "Zone 3 Hestan Cue cookware type"
+      },
+      "sl3_hestan_cue_next_step_required_warning": {
+        "name": "Zone 3 Hestan Cue next step required"
+      },
       "sl3_hestan_cue_set_temperature": {
         "name": "Zone 3 Hestan Cue set temperature"
       },
@@ -4920,6 +5436,9 @@
       "sl3_power_level_max": {
         "name": "Zone 3 max power level"
       },
+      "sl3_sand_timer_paused_total_seconds": {
+        "name": "Zone 3 sand timer paused"
+      },
       "sl3_sand_timer_status": {
         "name": "Zone 3 sand timer status",
         "state": {
@@ -4930,6 +5449,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl3_sand_timer_utc_start_time_hours": {
+        "name": "Zone 3 sand timer start hours"
+      },
+      "sl3_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 3 sand timer start minutes"
+      },
+      "sl3_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 3 sand timer start seconds"
+      },
+      "sl3_stopwatch_paused_total_seconds": {
+        "name": "Zone 3 stopwatch paused"
+      },
       "sl3_stopwatch_status": {
         "name": "Zone 3 stopwatch status",
         "state": {
@@ -4939,8 +5470,35 @@
           "paused": "Paused"
         }
       },
+      "sl3_stopwatch_utc_start_time_hours": {
+        "name": "Zone 3 stopwatch start hours"
+      },
+      "sl3_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 3 stopwatch start minutes"
+      },
+      "sl3_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 3 stopwatch start seconds"
+      },
       "sl3_temperature": {
         "name": "Zone 3 temperature"
+      },
+      "sl3_timer_utc_end_time_hours": {
+        "name": "Zone 3 timer end hours"
+      },
+      "sl3_timer_utc_end_time_minutes": {
+        "name": "Zone 3 timer end minutes"
+      },
+      "sl3_timer_utc_end_time_seconds": {
+        "name": "Zone 3 timer end seconds"
+      },
+      "sl3_timer_utc_paused_hours": {
+        "name": "Zone 3 timer paused hours"
+      },
+      "sl3_timer_utc_paused_minutes": {
+        "name": "Zone 3 timer paused minutes"
+      },
+      "sl3_timer_utc_paused_seconds": {
+        "name": "Zone 3 timer paused seconds"
       },
       "sl3_zone_shape": {
         "name": "Zone 3 shape",
@@ -4959,6 +5517,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl4_bridged_to_zone": {
+        "name": "Zone 4 bridged to zone"
       },
       "sl4_cooking_method": {
         "name": "Zone 4 cooking method",
@@ -4992,6 +5553,12 @@
           "wok": "Wok"
         }
       },
+      "sl4_hestan_cue_cookware_type": {
+        "name": "Zone 4 Hestan Cue cookware type"
+      },
+      "sl4_hestan_cue_next_step_required_warning": {
+        "name": "Zone 4 Hestan Cue next step required"
+      },
       "sl4_hestan_cue_set_temperature": {
         "name": "Zone 4 Hestan Cue set temperature"
       },
@@ -5010,6 +5577,9 @@
       "sl4_power_level_max": {
         "name": "Zone 4 max power level"
       },
+      "sl4_sand_timer_paused_total_seconds": {
+        "name": "Zone 4 sand timer paused"
+      },
       "sl4_sand_timer_status": {
         "name": "Zone 4 sand timer status",
         "state": {
@@ -5020,6 +5590,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl4_sand_timer_utc_start_time_hours": {
+        "name": "Zone 4 sand timer start hours"
+      },
+      "sl4_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 4 sand timer start minutes"
+      },
+      "sl4_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 4 sand timer start seconds"
+      },
+      "sl4_stopwatch_paused_total_seconds": {
+        "name": "Zone 4 stopwatch paused"
+      },
       "sl4_stopwatch_status": {
         "name": "Zone 4 stopwatch status",
         "state": {
@@ -5029,8 +5611,35 @@
           "paused": "Paused"
         }
       },
+      "sl4_stopwatch_utc_start_time_hours": {
+        "name": "Zone 4 stopwatch start hours"
+      },
+      "sl4_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 4 stopwatch start minutes"
+      },
+      "sl4_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 4 stopwatch start seconds"
+      },
       "sl4_temperature": {
         "name": "Zone 4 temperature"
+      },
+      "sl4_timer_utc_end_time_hours": {
+        "name": "Zone 4 timer end hours"
+      },
+      "sl4_timer_utc_end_time_minutes": {
+        "name": "Zone 4 timer end minutes"
+      },
+      "sl4_timer_utc_end_time_seconds": {
+        "name": "Zone 4 timer end seconds"
+      },
+      "sl4_timer_utc_paused_hours": {
+        "name": "Zone 4 timer paused hours"
+      },
+      "sl4_timer_utc_paused_minutes": {
+        "name": "Zone 4 timer paused minutes"
+      },
+      "sl4_timer_utc_paused_seconds": {
+        "name": "Zone 4 timer paused seconds"
       },
       "sl4_zone_shape": {
         "name": "Zone 4 shape",
@@ -5049,6 +5658,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl5_bridged_to_zone": {
+        "name": "Zone 5 bridged to zone"
       },
       "sl5_cooking_method": {
         "name": "Zone 5 cooking method",
@@ -5082,6 +5694,12 @@
           "wok": "Wok"
         }
       },
+      "sl5_hestan_cue_cookware_type": {
+        "name": "Zone 5 Hestan Cue cookware type"
+      },
+      "sl5_hestan_cue_next_step_required_warning": {
+        "name": "Zone 5 Hestan Cue next step required"
+      },
       "sl5_hestan_cue_set_temperature": {
         "name": "Zone 5 Hestan Cue set temperature"
       },
@@ -5100,6 +5718,9 @@
       "sl5_power_level_max": {
         "name": "Zone 5 max power level"
       },
+      "sl5_sand_timer_paused_total_seconds": {
+        "name": "Zone 5 sand timer paused"
+      },
       "sl5_sand_timer_status": {
         "name": "Zone 5 sand timer status",
         "state": {
@@ -5110,6 +5731,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl5_sand_timer_utc_start_time_hours": {
+        "name": "Zone 5 sand timer start hours"
+      },
+      "sl5_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 5 sand timer start minutes"
+      },
+      "sl5_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 5 sand timer start seconds"
+      },
+      "sl5_stopwatch_paused_total_seconds": {
+        "name": "Zone 5 stopwatch paused"
+      },
       "sl5_stopwatch_status": {
         "name": "Zone 5 stopwatch status",
         "state": {
@@ -5119,8 +5752,35 @@
           "paused": "Paused"
         }
       },
+      "sl5_stopwatch_utc_start_time_hours": {
+        "name": "Zone 5 stopwatch start hours"
+      },
+      "sl5_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 5 stopwatch start minutes"
+      },
+      "sl5_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 5 stopwatch start seconds"
+      },
       "sl5_temperature": {
         "name": "Zone 5 temperature"
+      },
+      "sl5_timer_utc_end_time_hours": {
+        "name": "Zone 5 timer end hours"
+      },
+      "sl5_timer_utc_end_time_minutes": {
+        "name": "Zone 5 timer end minutes"
+      },
+      "sl5_timer_utc_end_time_seconds": {
+        "name": "Zone 5 timer end seconds"
+      },
+      "sl5_timer_utc_paused_hours": {
+        "name": "Zone 5 timer paused hours"
+      },
+      "sl5_timer_utc_paused_minutes": {
+        "name": "Zone 5 timer paused minutes"
+      },
+      "sl5_timer_utc_paused_seconds": {
+        "name": "Zone 5 timer paused seconds"
       },
       "sl5_zone_shape": {
         "name": "Zone 5 shape",
@@ -5139,6 +5799,9 @@
           "stopwatch": "Stopwatch",
           "timer": "Timer"
         }
+      },
+      "sl6_bridged_to_zone": {
+        "name": "Zone 6 bridged to zone"
       },
       "sl6_cooking_method": {
         "name": "Zone 6 cooking method",
@@ -5172,6 +5835,12 @@
           "wok": "Wok"
         }
       },
+      "sl6_hestan_cue_cookware_type": {
+        "name": "Zone 6 Hestan Cue cookware type"
+      },
+      "sl6_hestan_cue_next_step_required_warning": {
+        "name": "Zone 6 Hestan Cue next step required"
+      },
       "sl6_hestan_cue_set_temperature": {
         "name": "Zone 6 Hestan Cue set temperature"
       },
@@ -5190,6 +5859,9 @@
       "sl6_power_level_max": {
         "name": "Zone 6 max power level"
       },
+      "sl6_sand_timer_paused_total_seconds": {
+        "name": "Zone 6 sand timer paused"
+      },
       "sl6_sand_timer_status": {
         "name": "Zone 6 sand timer status",
         "state": {
@@ -5200,6 +5872,18 @@
           "stopped": "Stopped"
         }
       },
+      "sl6_sand_timer_utc_start_time_hours": {
+        "name": "Zone 6 sand timer start hours"
+      },
+      "sl6_sand_timer_utc_start_time_minutes": {
+        "name": "Zone 6 sand timer start minutes"
+      },
+      "sl6_sand_timer_utc_start_time_seconds": {
+        "name": "Zone 6 sand timer start seconds"
+      },
+      "sl6_stopwatch_paused_total_seconds": {
+        "name": "Zone 6 stopwatch paused"
+      },
       "sl6_stopwatch_status": {
         "name": "Zone 6 stopwatch status",
         "state": {
@@ -5209,8 +5893,35 @@
           "paused": "Paused"
         }
       },
+      "sl6_stopwatch_utc_start_time_hours": {
+        "name": "Zone 6 stopwatch start hours"
+      },
+      "sl6_stopwatch_utc_start_time_minutes": {
+        "name": "Zone 6 stopwatch start minutes"
+      },
+      "sl6_stopwatch_utc_start_time_seconds": {
+        "name": "Zone 6 stopwatch start seconds"
+      },
       "sl6_temperature": {
         "name": "Zone 6 temperature"
+      },
+      "sl6_timer_utc_end_time_hours": {
+        "name": "Zone 6 timer end hours"
+      },
+      "sl6_timer_utc_end_time_minutes": {
+        "name": "Zone 6 timer end minutes"
+      },
+      "sl6_timer_utc_end_time_seconds": {
+        "name": "Zone 6 timer end seconds"
+      },
+      "sl6_timer_utc_paused_hours": {
+        "name": "Zone 6 timer paused hours"
+      },
+      "sl6_timer_utc_paused_minutes": {
+        "name": "Zone 6 timer paused minutes"
+      },
+      "sl6_timer_utc_paused_seconds": {
+        "name": "Zone 6 timer paused seconds"
       },
       "sl6_zone_shape": {
         "name": "Zone 6 shape",
@@ -5347,6 +6058,9 @@
       },
       "stain_removal": {
         "name": "Stain removal"
+      },
+      "stand_by_time": {
+        "name": "Stand-by time"
       },
       "standardelectricitconsumption": {
         "name": "Standard electricity consumption"
@@ -6348,6 +7062,12 @@
       "support_preheat_state": {
         "name": "Support preheat state"
       },
+      "synchro_start_level": {
+        "name": "Synchro start level"
+      },
+      "synchro_stop_level": {
+        "name": "Synchro stop level"
+      },
       "t_beep": {
         "name": "T beep"
       },
@@ -6885,6 +7605,9 @@
       },
       "winddryingflag": {
         "name": "Wind drying flag"
+      },
+      "window_status": {
+        "name": "Window status"
       },
       "wine_area_switch_status": {
         "name": "Wine area switch status"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -2649,8 +2649,7 @@
       "sl1_power_level": {
         "name": "Zone 1 vermogensniveau",
         "state": {
-          "boost": "Boost",
-          "off": "Uit"
+          "boost": "Boost"
         }
       },
       "sl1_power_level_max": {
@@ -2739,8 +2738,7 @@
       "sl2_power_level": {
         "name": "Zone 2 vermogensniveau",
         "state": {
-          "boost": "Boost",
-          "off": "Uit"
+          "boost": "Boost"
         }
       },
       "sl2_power_level_max": {
@@ -2829,8 +2827,7 @@
       "sl3_power_level": {
         "name": "Zone 3 vermogensniveau",
         "state": {
-          "boost": "Boost",
-          "off": "Uit"
+          "boost": "Boost"
         }
       },
       "sl3_power_level_max": {
@@ -2919,8 +2916,7 @@
       "sl4_power_level": {
         "name": "Zone 4 vermogensniveau",
         "state": {
-          "boost": "Boost",
-          "off": "Uit"
+          "boost": "Boost"
         }
       },
       "sl4_power_level_max": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -78,6 +78,9 @@
       "alarm_auto_dose_refill": {
         "name": "Auto doseer bijvullen"
       },
+      "alarm_auto_program_ended": {
+        "name": "Automatisch programma be\u00ebindigd"
+      },
       "alarm_auto_program_notification": {
         "name": "Auto program melding"
       },
@@ -357,8 +360,17 @@
       "ali_wifi_fault_flag": {
         "name": "Wifi fout"
       },
+      "auto_boost": {
+        "name": "Auto boost"
+      },
+      "auto_bridge": {
+        "name": "Automatische brug"
+      },
       "auto_dose_refill": {
         "name": "Auto doseer bijvullen"
+      },
+      "auto_timer": {
+        "name": "Automatische timer"
       },
       "charcoal_filter_expiration_alarm": {
         "name": "Einde levensduur koolstoffilter"
@@ -368,6 +380,9 @@
       },
       "charcoal_filter_time_reset": {
         "name": "Koolstoffilter tijd reset"
+      },
+      "chef_mode": {
+        "name": "Chef-modus"
       },
       "child_lock": {
         "name": "Kinderbeveiliging"
@@ -663,6 +678,15 @@
       "float_switch": {
         "name": "Vlotterschakelaar"
       },
+      "fota_set": {
+        "name": "FOTA instellen"
+      },
+      "fota_set_flag": {
+        "name": "FOTA instel-flag"
+      },
+      "fota_status": {
+        "name": "FOTA-status"
+      },
       "free_defrosting_failure": {
         "name": "Vriezer ontdooien mislukt"
       },
@@ -716,6 +740,15 @@
       },
       "hard_pairing_status": {
         "name": "Harde koppelingsstatus"
+      },
+      "hard_pairing_unpair_all_set_flag": {
+        "name": "Hard pairing alles loskoppelen flag"
+      },
+      "hardpairingstatus": {
+        "name": "Hard pairing status"
+      },
+      "hardpairingunpairall": {
+        "name": "Hard pairing alles loskoppelen"
       },
       "hob_status": {
         "name": "Kookplaatstatus"
@@ -798,11 +831,17 @@
       "open_variation_door_alarm": {
         "name": "Variatie deur open alarm"
       },
+      "permanent_pot_detection": {
+        "name": "Permanente pandetectie"
+      },
       "preheat": {
         "name": "Voorverwarmen"
       },
       "quiet_mode_status": {
         "name": "Stille modus status"
+      },
+      "recovery": {
+        "name": "Herstel"
       },
       "reed_switch": {
         "name": "Reed schakelaar"
@@ -870,6 +909,9 @@
       "remote_control_monitoring_set_commands_actions": {
         "name": "Afstandsbediening"
       },
+      "remote_controlmode": {
+        "name": "Afstandsbedieningsmodus"
+      },
       "right_free_sensor_failure": {
         "name": "Rechter sensorstoring vrije ruimte"
       },
@@ -924,6 +966,9 @@
       "sl1_alarm_automatic_switch_off_zone": {
         "name": "Zone 1 automatisch uitgeschakeld"
       },
+      "sl1_alarm_ntc_coil": {
+        "name": "Zone 1 NTC-spoelalarm"
+      },
       "sl1_alarm_ntc_coil_overheating": {
         "name": "Zone 1 spoel oververhitting"
       },
@@ -939,6 +984,9 @@
       "sl1_pot_detected": {
         "name": "Zone 1 pot gedetecteerd"
       },
+      "sl1_residual_heat_signal": {
+        "name": "Zone 1 restwarmte"
+      },
       "sl1_status": {
         "name": "Zone 1 status"
       },
@@ -947,6 +995,9 @@
       },
       "sl2_alarm_automatic_switch_off_zone": {
         "name": "Zone 2 automatisch uitgeschakeld"
+      },
+      "sl2_alarm_ntc_coil": {
+        "name": "Zone 2 NTC-spoelalarm"
       },
       "sl2_alarm_ntc_coil_overheating": {
         "name": "Zone 2 spoel oververhitting"
@@ -963,6 +1014,9 @@
       "sl2_pot_detected": {
         "name": "Zone 2 pot gedetecteerd"
       },
+      "sl2_residual_heat_signal": {
+        "name": "Zone 2 restwarmte"
+      },
       "sl2_status": {
         "name": "Zone 2 status"
       },
@@ -971,6 +1025,9 @@
       },
       "sl3_alarm_automatic_switch_off_zone": {
         "name": "Zone 3 automatisch uitgeschakeld"
+      },
+      "sl3_alarm_ntc_coil": {
+        "name": "Zone 3 NTC-spoelalarm"
       },
       "sl3_alarm_ntc_coil_overheating": {
         "name": "Zone 3 spoel oververhitting"
@@ -987,6 +1044,9 @@
       "sl3_pot_detected": {
         "name": "Zone 3 pot gedetecteerd"
       },
+      "sl3_residual_heat_signal": {
+        "name": "Zone 3 restwarmte"
+      },
       "sl3_status": {
         "name": "Zone 3 status"
       },
@@ -995,6 +1055,9 @@
       },
       "sl4_alarm_automatic_switch_off_zone": {
         "name": "Zone 4 automatisch uitgeschakeld"
+      },
+      "sl4_alarm_ntc_coil": {
+        "name": "Zone 4 NTC-spoelalarm"
       },
       "sl4_alarm_ntc_coil_overheating": {
         "name": "Zone 4 spoel oververhitting"
@@ -1010,6 +1073,9 @@
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot gedetecteerd"
+      },
+      "sl4_residual_heat_signal": {
+        "name": "Zone 4 restwarmte"
       },
       "sl4_status": {
         "name": "Zone 4 status"
@@ -1118,6 +1184,9 @@
       },
       "t_beep": {
         "name": "Piep"
+      },
+      "test_mode": {
+        "name": "Testmodus"
       },
       "tx_failure": {
         "name": "TX storing"
@@ -2537,26 +2606,77 @@
           "timer": "Timer"
         }
       },
+      "sl1_cooking_method": {
+        "name": "Zone 1 kookmethode",
+        "state": {
+          "method_1": "Methode 1",
+          "method_2": "Methode 2",
+          "none": "Geen"
+        }
+      },
+      "sl1_function_status": {
+        "name": "Zone 1 functiestatus",
+        "state": {
+          "function_1": "Functie 1",
+          "function_2": "Functie 2",
+          "none": "Geen"
+        }
+      },
       "sl1_functions": {
         "name": "Zone 1 functie",
         "state": {
           "boil": "Koken",
+          "fry": "Bakken",
           "grill": "Grillen",
           "keep_warm": "Warm houden",
+          "keep_warm_and_fry": "Warm houden en bakken",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
+          "slow_cook": "Langzaam garen",
           "wok": "Wok"
         }
+      },
+      "sl1_hestan_cue_set_temperature": {
+        "name": "Zone 1 Hestan Cue ingestelde temperatuur"
+      },
+      "sl1_hestan_cue_temperature": {
+        "name": "Zone 1 Hestan Cue temperatuur"
       },
       "sl1_ntc_sensor": {
         "name": "Zone 1 NTC sensor"
       },
       "sl1_power_level": {
-        "name": "Zone 1 vermogensniveau"
+        "name": "Zone 1 vermogensniveau",
+        "state": {
+          "boost": "Boost",
+          "off": "Uit"
+        }
       },
       "sl1_power_level_max": {
         "name": "Zone 1 maximaal vermogensniveau"
+      },
+      "sl1_sand_timer_status": {
+        "name": "Zone 1 zandlopertimer-status",
+        "state": {
+          "active": "Actief",
+          "ended": "Be\u00ebindigd",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd",
+          "stopped": "Gestopt"
+        }
+      },
+      "sl1_stopwatch_status": {
+        "name": "Zone 1 stopwatch-status",
+        "state": {
+          "active": "Actief",
+          "hold": "Vastgehouden",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd"
+        }
+      },
+      "sl1_temperature": {
+        "name": "Zone 1 temperatuur"
       },
       "sl1_zone_shape": {
         "name": "Zone 1 vorm",
@@ -2576,26 +2696,77 @@
           "timer": "Timer"
         }
       },
+      "sl2_cooking_method": {
+        "name": "Zone 2 kookmethode",
+        "state": {
+          "method_1": "Methode 1",
+          "method_2": "Methode 2",
+          "none": "Geen"
+        }
+      },
+      "sl2_function_status": {
+        "name": "Zone 2 functiestatus",
+        "state": {
+          "function_1": "Functie 1",
+          "function_2": "Functie 2",
+          "none": "Geen"
+        }
+      },
       "sl2_functions": {
         "name": "Zone 2 functie",
         "state": {
           "boil": "Koken",
+          "fry": "Bakken",
           "grill": "Grillen",
           "keep_warm": "Warm houden",
+          "keep_warm_and_fry": "Warm houden en bakken",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
+          "slow_cook": "Langzaam garen",
           "wok": "Wok"
         }
+      },
+      "sl2_hestan_cue_set_temperature": {
+        "name": "Zone 2 Hestan Cue ingestelde temperatuur"
+      },
+      "sl2_hestan_cue_temperature": {
+        "name": "Zone 2 Hestan Cue temperatuur"
       },
       "sl2_ntc_sensor": {
         "name": "Zone 2 NTC sensor"
       },
       "sl2_power_level": {
-        "name": "Zone 2 vermogensniveau"
+        "name": "Zone 2 vermogensniveau",
+        "state": {
+          "boost": "Boost",
+          "off": "Uit"
+        }
       },
       "sl2_power_level_max": {
         "name": "Zone 2 maximaal vermogensniveau"
+      },
+      "sl2_sand_timer_status": {
+        "name": "Zone 2 zandlopertimer-status",
+        "state": {
+          "active": "Actief",
+          "ended": "Be\u00ebindigd",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd",
+          "stopped": "Gestopt"
+        }
+      },
+      "sl2_stopwatch_status": {
+        "name": "Zone 2 stopwatch-status",
+        "state": {
+          "active": "Actief",
+          "hold": "Vastgehouden",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd"
+        }
+      },
+      "sl2_temperature": {
+        "name": "Zone 2 temperatuur"
       },
       "sl2_zone_shape": {
         "name": "Zone 2 vorm",
@@ -2615,26 +2786,77 @@
           "timer": "Timer"
         }
       },
+      "sl3_cooking_method": {
+        "name": "Zone 3 kookmethode",
+        "state": {
+          "method_1": "Methode 1",
+          "method_2": "Methode 2",
+          "none": "Geen"
+        }
+      },
+      "sl3_function_status": {
+        "name": "Zone 3 functiestatus",
+        "state": {
+          "function_1": "Functie 1",
+          "function_2": "Functie 2",
+          "none": "Geen"
+        }
+      },
       "sl3_functions": {
         "name": "Zone 3 functie",
         "state": {
           "boil": "Koken",
+          "fry": "Bakken",
           "grill": "Grillen",
           "keep_warm": "Warm houden",
+          "keep_warm_and_fry": "Warm houden en bakken",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
+          "slow_cook": "Langzaam garen",
           "wok": "Wok"
         }
+      },
+      "sl3_hestan_cue_set_temperature": {
+        "name": "Zone 3 Hestan Cue ingestelde temperatuur"
+      },
+      "sl3_hestan_cue_temperature": {
+        "name": "Zone 3 Hestan Cue temperatuur"
       },
       "sl3_ntc_sensor": {
         "name": "Zone 3 NTC sensor"
       },
       "sl3_power_level": {
-        "name": "Zone 3 vermogensniveau"
+        "name": "Zone 3 vermogensniveau",
+        "state": {
+          "boost": "Boost",
+          "off": "Uit"
+        }
       },
       "sl3_power_level_max": {
         "name": "Zone 3 maximaal vermogensniveau"
+      },
+      "sl3_sand_timer_status": {
+        "name": "Zone 3 zandlopertimer-status",
+        "state": {
+          "active": "Actief",
+          "ended": "Be\u00ebindigd",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd",
+          "stopped": "Gestopt"
+        }
+      },
+      "sl3_stopwatch_status": {
+        "name": "Zone 3 stopwatch-status",
+        "state": {
+          "active": "Actief",
+          "hold": "Vastgehouden",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd"
+        }
+      },
+      "sl3_temperature": {
+        "name": "Zone 3 temperatuur"
       },
       "sl3_zone_shape": {
         "name": "Zone 3 vorm",
@@ -2654,26 +2876,77 @@
           "timer": "Timer"
         }
       },
+      "sl4_cooking_method": {
+        "name": "Zone 4 kookmethode",
+        "state": {
+          "method_1": "Methode 1",
+          "method_2": "Methode 2",
+          "none": "Geen"
+        }
+      },
+      "sl4_function_status": {
+        "name": "Zone 4 functiestatus",
+        "state": {
+          "function_1": "Functie 1",
+          "function_2": "Functie 2",
+          "none": "Geen"
+        }
+      },
       "sl4_functions": {
         "name": "Zone 4 functie",
         "state": {
           "boil": "Koken",
+          "fry": "Bakken",
           "grill": "Grillen",
           "keep_warm": "Warm houden",
+          "keep_warm_and_fry": "Warm houden en bakken",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
+          "slow_cook": "Langzaam garen",
           "wok": "Wok"
         }
+      },
+      "sl4_hestan_cue_set_temperature": {
+        "name": "Zone 4 Hestan Cue ingestelde temperatuur"
+      },
+      "sl4_hestan_cue_temperature": {
+        "name": "Zone 4 Hestan Cue temperatuur"
       },
       "sl4_ntc_sensor": {
         "name": "Zone 4 NTC sensor"
       },
       "sl4_power_level": {
-        "name": "Zone 4 vermogensniveau"
+        "name": "Zone 4 vermogensniveau",
+        "state": {
+          "boost": "Boost",
+          "off": "Uit"
+        }
       },
       "sl4_power_level_max": {
         "name": "Zone 4 maximaal vermogensniveau"
+      },
+      "sl4_sand_timer_status": {
+        "name": "Zone 4 zandlopertimer-status",
+        "state": {
+          "active": "Actief",
+          "ended": "Be\u00ebindigd",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd",
+          "stopped": "Gestopt"
+        }
+      },
+      "sl4_stopwatch_status": {
+        "name": "Zone 4 stopwatch-status",
+        "state": {
+          "active": "Actief",
+          "hold": "Vastgehouden",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd"
+        }
+      },
+      "sl4_temperature": {
+        "name": "Zone 4 temperatuur"
       },
       "sl4_zone_shape": {
         "name": "Zone 4 vorm",
@@ -3515,6 +3788,9 @@
         "name": "Totale looptijd"
       },
       "total_time_of_cooking_in_hours": {
+        "name": "Totale kooktijd"
+      },
+      "total_time_of_cooking_in_minute": {
         "name": "Totale kooktijd"
       },
       "total_water_consumption": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1086,6 +1086,9 @@
       "sl5_alarm_automatic_switch_off_zone": {
         "name": "Zone 5 automatisch uitgeschakeld"
       },
+      "sl5_alarm_ntc_coil": {
+        "name": "Zone 5 NTC-spoelalarm"
+      },
       "sl5_alarm_ntc_coil_overheating": {
         "name": "Zone 5 spoel oververhitting"
       },
@@ -1101,6 +1104,9 @@
       "sl5_pot_detected": {
         "name": "Zone 5 pot gedetecteerd"
       },
+      "sl5_residual_heat_signal": {
+        "name": "Zone 5 restwarmte"
+      },
       "sl5_status": {
         "name": "Zone 5 status"
       },
@@ -1109,6 +1115,9 @@
       },
       "sl6_alarm_automatic_switch_off_zone": {
         "name": "Zone 6 automatisch uitgeschakeld"
+      },
+      "sl6_alarm_ntc_coil": {
+        "name": "Zone 6 NTC-spoelalarm"
       },
       "sl6_alarm_ntc_coil_overheating": {
         "name": "Zone 6 spoel oververhitting"
@@ -1124,6 +1133,9 @@
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot gedetecteerd"
+      },
+      "sl6_residual_heat_signal": {
+        "name": "Zone 6 restwarmte"
       },
       "sl6_status": {
         "name": "Zone 6 status"
@@ -2628,8 +2640,8 @@
           "boil": "Koken",
           "fry": "Bakken",
           "grill": "Grillen",
-          "keep_warm": "Warm houden",
-          "keep_warm_and_fry": "Warm houden en bakken",
+          "heat_up_and_fry": "Opwarmen en bakken",
+          "keep_warm_and_heat_up": "Warm houden en opwarmen",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
@@ -2717,8 +2729,8 @@
           "boil": "Koken",
           "fry": "Bakken",
           "grill": "Grillen",
-          "keep_warm": "Warm houden",
-          "keep_warm_and_fry": "Warm houden en bakken",
+          "heat_up_and_fry": "Opwarmen en bakken",
+          "keep_warm_and_heat_up": "Warm houden en opwarmen",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
@@ -2806,8 +2818,8 @@
           "boil": "Koken",
           "fry": "Bakken",
           "grill": "Grillen",
-          "keep_warm": "Warm houden",
-          "keep_warm_and_fry": "Warm houden en bakken",
+          "heat_up_and_fry": "Opwarmen en bakken",
+          "keep_warm_and_heat_up": "Warm houden en opwarmen",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
@@ -2895,8 +2907,8 @@
           "boil": "Koken",
           "fry": "Bakken",
           "grill": "Grillen",
-          "keep_warm": "Warm houden",
-          "keep_warm_and_fry": "Warm houden en bakken",
+          "heat_up_and_fry": "Opwarmen en bakken",
+          "keep_warm_and_heat_up": "Warm houden en opwarmen",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
@@ -2962,17 +2974,40 @@
           "timer": "Timer"
         }
       },
+      "sl5_cooking_method": {
+        "name": "Zone 5 kookmethode",
+        "state": {
+          "method_1": "Methode 1",
+          "method_2": "Methode 2",
+          "none": "Geen"
+        }
+      },
+      "sl5_function_status": {
+        "name": "Zone 5 functiestatus",
+        "state": {
+          "function_1": "Functie 1",
+          "function_2": "Functie 2",
+          "none": "Geen"
+        }
+      },
       "sl5_functions": {
         "name": "Zone 5 functie",
         "state": {
           "boil": "Koken",
           "grill": "Grillen",
-          "keep_warm": "Warm houden",
+          "heat_up_and_fry": "Opwarmen en bakken",
+          "keep_warm_and_heat_up": "Warm houden en opwarmen",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
           "wok": "Wok"
         }
+      },
+      "sl5_hestan_cue_set_temperature": {
+        "name": "Zone 5 Hestan Cue ingestelde temperatuur"
+      },
+      "sl5_hestan_cue_temperature": {
+        "name": "Zone 5 Hestan Cue temperatuur"
       },
       "sl5_ntc_sensor": {
         "name": "Zone 5 NTC sensor"
@@ -2982,6 +3017,28 @@
       },
       "sl5_power_level_max": {
         "name": "Zone 5 maximaal vermogensniveau"
+      },
+      "sl5_sand_timer_status": {
+        "name": "Zone 5 zandlopertimer-status",
+        "state": {
+          "active": "Actief",
+          "ended": "Be\u00ebindigd",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd",
+          "stopped": "Gestopt"
+        }
+      },
+      "sl5_stopwatch_status": {
+        "name": "Zone 5 stopwatch-status",
+        "state": {
+          "active": "Actief",
+          "hold": "Vastgehouden",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd"
+        }
+      },
+      "sl5_temperature": {
+        "name": "Zone 5 temperatuur"
       },
       "sl5_zone_shape": {
         "name": "Zone 5 vorm",
@@ -3001,17 +3058,40 @@
           "timer": "Timer"
         }
       },
+      "sl6_cooking_method": {
+        "name": "Zone 6 kookmethode",
+        "state": {
+          "method_1": "Methode 1",
+          "method_2": "Methode 2",
+          "none": "Geen"
+        }
+      },
+      "sl6_function_status": {
+        "name": "Zone 6 functiestatus",
+        "state": {
+          "function_1": "Functie 1",
+          "function_2": "Functie 2",
+          "none": "Geen"
+        }
+      },
       "sl6_functions": {
         "name": "Zone 6 functie",
         "state": {
           "boil": "Koken",
           "grill": "Grillen",
-          "keep_warm": "Warm houden",
+          "heat_up_and_fry": "Opwarmen en bakken",
+          "keep_warm_and_heat_up": "Warm houden en opwarmen",
           "none": "Geen",
           "roast": "Braden",
           "simmer": "Sudderen",
           "wok": "Wok"
         }
+      },
+      "sl6_hestan_cue_set_temperature": {
+        "name": "Zone 6 Hestan Cue ingestelde temperatuur"
+      },
+      "sl6_hestan_cue_temperature": {
+        "name": "Zone 6 Hestan Cue temperatuur"
       },
       "sl6_ntc_sensor": {
         "name": "Zone 6 NTC sensor"
@@ -3021,6 +3101,28 @@
       },
       "sl6_power_level_max": {
         "name": "Zone 6 maximaal vermogensniveau"
+      },
+      "sl6_sand_timer_status": {
+        "name": "Zone 6 zandlopertimer-status",
+        "state": {
+          "active": "Actief",
+          "ended": "Be\u00ebindigd",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd",
+          "stopped": "Gestopt"
+        }
+      },
+      "sl6_stopwatch_status": {
+        "name": "Zone 6 stopwatch-status",
+        "state": {
+          "active": "Actief",
+          "hold": "Vastgehouden",
+          "inactive": "Inactief",
+          "paused": "Gepauzeerd"
+        }
+      },
+      "sl6_temperature": {
+        "name": "Zone 6 temperatuur"
       },
       "sl6_zone_shape": {
         "name": "Zone 6 vorm",

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -681,9 +681,6 @@
       "fota_set": {
         "name": "FOTA instellen"
       },
-      "fota_set_flag": {
-        "name": "FOTA instel-flag"
-      },
       "fota_status": {
         "name": "FOTA-status"
       },
@@ -740,9 +737,6 @@
       },
       "hard_pairing_status": {
         "name": "Harde koppelingsstatus"
-      },
-      "hard_pairing_unpair_all_set_flag": {
-        "name": "Hard pairing alles loskoppelen flag"
       },
       "hardpairingstatus": {
         "name": "Hard pairing status"


### PR DESCRIPTION
New default mapping `010.yaml` for induction hobs, covering up to 6 cooking zones (power level, temperature, status, function, timers, residual heat, alarms, error codes, Hestan Cue), an optional WiFi-paired extraction hood, shared controls, and FOTA/pairing properties.

Closes issue #311, discussion #457