### PR TITLE
Correct current scale in electricity property for 009-100.yaml

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009-100.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-100.yaml
@@ -73,7 +73,7 @@ climate:
 properties:
   - property: f_electricity
     sensor:
-      device_class: power
+      device_class: current
       state_class: measurement
       read_only: true
       unit: A

--- a/custom_components/connectlife/data_dictionaries/009-100.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-100.yaml
@@ -70,3 +70,11 @@ climate:
       t_sleep: 4
       t_super: 0
       preset: eco_sleep_4
+properties:
+  - property: f_electricity
+    sensor:
+      device_class: power
+      state_class: measurement
+      read_only: true
+      unit: A
+      multiplier: 0.001


### PR DESCRIPTION
The sensor seems to be showing mA, not A. I observed cooling f_electricity values between 350 up to 3580. That makes sense as mA since my 3.58*230=823.4 W (even though i think the max is a little higher on my 1045W unit)

<img width="522" height="427" alt="image" src="https://github.com/user-attachments/assets/09bb22ae-3682-4392-bd40-5b9cbe22e487" />

<details>
<summary>Dump showing 550</summary>

```json
{
  "bindTime": 1752333542175,
  "createTime": 0,
  "deviceExtendInfoList": {
    "checkup_time": "null",
    "property_version": "v2"
  },
  "deviceFeatureCode": "100",
  "deviceFeatureName": "100\u51b7\u6696\u8282\u80fd\u6709\u529f\u7387",
  "deviceId": "<redacted>",
  "deviceNickName": "AC Dining Room",
  "deviceTypeCode": "009",
  "deviceTypeName": "",
  "energyRole": 0,
  "isShow": 0,
  "offlineState": 1,
  "puid": "<redacted>",
  "role": 1,
  "roomId": 9226507,
  "roomName": "Dining Room",
  "seq": 0,
  "statusList": {
    "f_e_arkgrille": "0",
    "f_e_incoiltemp": "0",
    "f_e_incom": "0",
    "f_e_indisplay": "0",
    "f_e_ineeprom": "0",
    "f_e_inele": "0",
    "f_e_infanmotor": "0",
    "f_e_inhumidity": "0",
    "f_e_inkeys": "0",
    "f_e_intemp": "0",
    "f_e_invzero": "0",
    "f_e_inwifi": "0",
    "f_e_outcoiltemp": "0",
    "f_e_outeeprom": "0",
    "f_e_outgastemp": "0",
    "f_e_outtemp": "0",
    "f_e_push": "0",
    "f_ecm": "1",
    "f_electricity": "550",
    "f_temp_in": "26",
    "f_votage": "226",
    "t_eco": "0",
    "t_fan_mute": "0",
    "t_fan_speed": "0",
    "t_fan_speed_s": "0",
    "t_power": "1",
    "t_sleep": "0",
    "t_super": "0",
    "t_temp": "26",
    "t_temp_type": "0",
    "t_up_down": "0",
    "t_work_mode": "2"
  },
  "useTime": 0,
  "wifiId": "<redacted>"
}
```

</details>

so unless there's a crazy ratio, the value is probably current in mA.