### PR TITLE
Default `f_electricity` to mA, expose `f_ecm` as diagnostic

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -1,9 +1,23 @@
 # Portable air conditioner
 properties:
+- property: f_ecm
+  # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1
+  # has been observed alongside mA current values; absent in 009-104,
+  # which reports in hW). Exposed as a diagnostic so users can report
+  # the value alongside f_electricity readings.
+  sensor:
+    read_only: true
+  entity_category: diagnostic
+  hide: true
 - property: f_electricity
+  # f_electricity: unit varies by device. Most devices observed report
+  # in mA. Devices that report in other units (e.g. hW), need a
+  # per-feature override mapping to power/kW (see e.g. 009-104).
+  # The companion property f_ecm appears to discriminate the scheme
+  # (f_ecm=1 → mA; absent → hW).
   sensor:
     device_class: current
-    unit: A
+    unit: mA
     read_only: true
     state_class: measurement
   hide: true

--- a/custom_components/connectlife/data_dictionaries/007.yaml
+++ b/custom_components/connectlife/data_dictionaries/007.yaml
@@ -20,10 +20,24 @@ properties:
   - property: f_e_wetsensor
     binary_sensor:
       device_class: problem
+  - property: f_ecm
+    # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1
+    # has been observed alongside mA current values; absent in 009-104,
+    # which reports in hW). Exposed as a diagnostic so users can report
+    # the value alongside f_electricity readings.
+    sensor:
+      read_only: true
+    entity_category: diagnostic
+    hide: true
   - property: f_electricity
+    # f_electricity: unit varies by device. Most devices observed report
+    # in mA. Devices that report in other units (e.g.hW), need a
+    # per-feature override mapping to power/kW (see e.g. 009-104).
+    # The companion property f_ecm appears to discriminate the scheme
+    # (f_ecm=1 → mA; absent → hW).
     sensor:
       device_class: current
-      unit: A
+      unit: mA
       read_only: true
       state_class: measurement
     hide: true

--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -171,11 +171,23 @@ properties:
     hide: true
     entity_category: diagnostic
   - property: f_ecm
-    disable: true
+    # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1
+    # has been observed alongside mA current values; absent in 009-104,
+    # which reports in hW). Exposed as a diagnostic so users can report
+    # the value alongside f_electricity readings.
+    sensor:
+      read_only: true
+    entity_category: diagnostic
+    hide: true
   - property: f_electricity
+    # f_electricity: unit varies by device. Most devices observed report
+    # in mA. Devices that report in other units (e.g. hW), need a
+    # per-feature override mapping to power/kW (see e.g. 009-104).
+    # The companion property f_ecm appears to discriminate the scheme
+    # (f_ecm=1 → mA; absent → hW).
     sensor:
       device_class: current
-      unit: A
+      unit: mA
       read_only: true
       state_class: measurement
     hide: true

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -207,11 +207,23 @@ properties:
   - property: f_e_push
     disable: true
   - property: f_ecm
-    disable: true
+    # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1
+    # has been observed alongside mA current values; absent in 009-104,
+    # which reports in hW). Exposed as a diagnostic so users can report
+    # the value alongside f_electricity readings.
+    sensor:
+      read_only: true
+    entity_category: diagnostic
+    hide: true
   - property: f_electricity
+    # f_electricity: unit varies by device. Most devices observed report
+    # in mA. Devices that report in other units (e.g. hW), need a
+    # per-feature override mapping to power/kW (see e.g. 009-104).
+    # The companion property f_ecm appears to discriminate the scheme
+    # (f_ecm=1 → mA; absent → hW).
     sensor:
       device_class: current
-      unit: A
+      unit: mA
       read_only: true
       state_class: measurement
     hide: true

--- a/custom_components/connectlife/data_dictionaries/016.yaml
+++ b/custom_components/connectlife/data_dictionaries/016.yaml
@@ -1,8 +1,22 @@
 properties:
+  - property: f_ecm
+    # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1
+    # has been observed alongside mA current values; absent in 009-104,
+    # which reports in hW). Exposed as a diagnostic so users can report
+    # the value alongside f_electricity readings.
+    sensor:
+      read_only: true
+    entity_category: diagnostic
+    hide: true
   - property: f_electricity
+    # f_electricity: unit varies by device. Most devices observed report
+    # in mA. Devices that report in other units (e.g. hW) need a
+    # per-feature override mapping to power/kW (see e.g. 009-104).
+    # The companion property f_ecm appears to discriminate the scheme
+    # (f_ecm=1 → mA; absent → hW).
     sensor:
       device_class: current
-      unit: A
+      unit: mA
       read_only: true
       state_class: measurement
     hide: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -3228,6 +3228,9 @@
       "f_cool_qvalue": {
         "name": "Cooling"
       },
+      "f_ecm": {
+        "name": "Electricity reporting mode"
+      },
       "f_electricity": {
         "name": "Electricity"
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -3228,6 +3228,9 @@
       "f_cool_qvalue": {
         "name": "Cooling"
       },
+      "f_ecm": {
+        "name": "Electricity reporting mode"
+      },
       "f_electricity": {
         "name": "Electricity"
       },


### PR DESCRIPTION
`f_electricity` is observed to be reported in different units across devices. Most non-zero observations fit mA (see PR #480 for cooling samples on 009-100); the only confirmed exception so far is 009-104, which fits hW (PR #331). Plain ampere is not observed on any device, so the previous default unit was wrong on every device that reported a non-zero value.

Switch the default mapping in 006/007/008/009/016 from A to mA, keeping `device_class: current`. Per-feature overrides remain the path for variants that report in other units, e.g. hW.

Also expose `f_ecm` (previously disabled or unlisted) as a hidden diagnostic sensor. Its value appears to discriminate the scheme (`f_ecm=1` → mA; absent → hW), so surfacing it helps users reporting new variants.

## Breaking change

Note for users with existing long-term statistics: HA does not auto-convert when the unit changes within a device class and does not surface a repair issue. Incoming mA values get silently scaled into the old A unit (raw value / 1000), corrupting the chart. To migrate cleanly, change the unit on the `f_electricity` entities in Settings → Developer tools → Statistics to mA *before* upgrading!

Closes PR #480 - thanks to @kzaoaai for investigating!