### PR TITLE
Map f_votage and Matter IDs on window AC (008)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -195,10 +195,31 @@ properties:
     climate:
       target: current_humidity
       unknown_value: 128
+  - property: f_matterOriginalProductId
+    sensor:
+      read_only: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_matterOriginalVendorId
+    sensor:
+      read_only: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_matterUniqueId
+    sensor:
+      read_only: true
+    hide: true
+    entity_category: diagnostic
   - property: f_temp_in
     icon: mdi:thermometer
     climate:
       target: current_temperature
+  - property: f_votage
+    sensor:
+      device_class: voltage
+      unit: V
+    hide: true
+    entity_category: diagnostic
   - property: measured_grid_voltage
     sensor:
       device_class: voltage

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -3237,6 +3237,15 @@
       "f_heat_qvalue": {
         "name": "Heating"
       },
+      "f_matteroriginalproductid": {
+        "name": "Matter product ID"
+      },
+      "f_matteroriginalvendorid": {
+        "name": "Matter vendor ID"
+      },
+      "f_matteruniqueid": {
+        "name": "Matter unique ID"
+      },
       "f_power_consumption": {
         "name": "Energy consumption"
       },
@@ -3244,7 +3253,7 @@
         "name": "Power"
       },
       "f_votage": {
-        "name": "Measured grid voltage"
+        "name": "Voltage"
       },
       "factory_reset": {
         "name": "Factory reset"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1969,7 +1969,7 @@
         "name": "Heizung"
       },
       "f_votage": {
-        "name": "Gemessene Netzspannung"
+        "name": "Spannung"
       },
       "factory_reset": {
         "name": "Werksreset"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -3237,6 +3237,15 @@
       "f_heat_qvalue": {
         "name": "Heating"
       },
+      "f_matteroriginalproductid": {
+        "name": "Matter product ID"
+      },
+      "f_matteroriginalvendorid": {
+        "name": "Matter vendor ID"
+      },
+      "f_matteruniqueid": {
+        "name": "Matter unique ID"
+      },
       "f_power_consumption": {
         "name": "Energy consumption"
       },
@@ -3244,7 +3253,7 @@
         "name": "Power"
       },
       "f_votage": {
-        "name": "Measured grid voltage"
+        "name": "Voltage"
       },
       "factory_reset": {
         "name": "Factory reset"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -2042,7 +2042,7 @@
         "name": "Verwarming"
       },
       "f_votage": {
-        "name": "Gemeten netspanning"
+        "name": "Spanning"
       },
       "factory_reset": {
         "name": "Reset naar fabrieksinstellingen"


### PR DESCRIPTION
These properties show up in 008-399 status dumps but were previously unmapped. Add as hidden diagnostic sensors on the base 008.yaml so all subtypes pick them up.

Refs #483