### PR TITLE
Support disabled-by-default entities

### DIFF
--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -60,6 +60,7 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
         self.entity_description = BinarySensorEntityDescription(
             key=self._attr_unique_id,
             entity_registry_visible_default=not dd_entry.hide,
+            entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             translation_key=self.to_translation_key(status),

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -2,7 +2,7 @@
 
 Mapping files for known appliances are located in this directory. Appliances without a mapping file will still
 be loaded, but with a warning in the log. Their properties will all be mapped to [sensor](#type-sensor) entities,
-with `hidden` set to `true`.
+registered as disabled by default. Users can enable individual ones from the device page in Home Assistant.
 
 ## Default mapping files
 
@@ -26,6 +26,7 @@ The following top-level fields always inherit, even across platform changes:
 - `icon`
 - `hide`
 - `disable`
+- `optional`
 - `entity_category`
 - `unavailable`
 - `combine` — if you change the platform and want to drop the base's combine sources, clear it with
@@ -91,7 +92,7 @@ The file contains two top level items:
 - `properties`: list of [`Property`](#property)
 
 To make a property visible by default, just add the property to the list. Note that properties you do not map are still
-mapped to [sensor](#type-sensor) entities with `hidden` set to `true`.
+mapped to [sensor](#type-sensor) entities, but registered as disabled by default.
 
 Each property is mapped to _one_ entity or _one_ target property. In addition, each `climate` preset is mapped to a
 set of properties and values.
@@ -151,6 +152,7 @@ Note that translation keys must be lowercase!
 | `combine`                  | list of [CombineSource](#combine)  | Combine multiple source properties into a single sensor value. See [Combine](#combine).                                                                                                                                                                                                |
 | `disable`                  | `true`, `false`                    | If Home Assistant should not create an entity for this property. Defaults to `false`.                                                                                                                                                                                                  |
 | `hide`                     | `true`, `false`                    | If Home Assistant should initially hide the entity for this property. Defaults to `false`, but is set to `true` for unknown properties.                                                                                                                                                |
+| `optional`                 | `true`, `false`                    | If the entity should be registered as disabled by default. The user can enable it from the Home Assistant UI. Use for rarely-useful properties (e.g., per-slot error codes). Defaults to `false`. Only applies to per-property platforms (`binary_sensor`, `number`, `select`, `sensor`, `switch`). |
 | `icon`                     | `mdi:eye`, etc.                    | Icon to use for the entity.                                                                                                                                                                                                                                                            |
 | `unavailable`              | integer                            | If the property has this value on the device, no entity is created for it. Use for properties that the device reports as "not available" with a sentinel value.                                                                                                                        |
 | `entity_category`          | `config`, `diagnostic`             | Whether the entity should be considered a diagnostics or config entity. Defaults to `None`. [More info in HA docs](https://developers.home-assistant.io/docs/core/entity/#registry-properties:~:text=automatic%20device%20registration.-,entity_category,-EntityCategory%20%7C%20None) |

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -102,6 +102,11 @@
           "description": "If Home Assistant should not create an entity for this property.",
           "default": false
         },
+        "optional": {
+          "type": "boolean",
+          "description": "If the entity should be registered as disabled by default. The user can enable it from the Home Assistant UI. Use for rarely-useful properties (e.g., per-slot error codes) to keep them discoverable without paying for them on every install.",
+          "default": false
+        },
         "unavailable": {
           "type": ["integer", "null"],
           "description": "If the property has this value, it is not available on the device, and no entity is created."

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -44,6 +44,7 @@ PROPERTIES = "properties"
 MAX_VALUE = "max_value"
 MIN_VALUE = "min_value"
 MULTIPLIER = "multiplier"
+OPTIONAL = "optional"
 TARGET = "target"
 READ_ONLY = "read_only"
 STATE_CLASS = "state_class"
@@ -316,6 +317,7 @@ class Property:
     icon: str | None
     hide: bool
     disable: bool
+    optional: bool
     unavailable: int | None
     entity_category: EntityCategory | None
     combine: list[CombineSource] | None
@@ -333,6 +335,7 @@ class Property:
         self.icon = _val(entry, ICON) or None
         self.hide = bool(entry[HIDE]) if HIDE in entry else False
         self.disable = bool(entry[DISABLE]) if DISABLE in entry else False
+        self.optional = bool(entry[OPTIONAL]) if OPTIONAL in entry else False
         self.unavailable = _val(entry, UNAVAILABLE)
         entity_category = _val(entry, ENTITY_CATEGORY)
         self.entity_category = (
@@ -487,7 +490,7 @@ class Dictionaries:
                     raw_entries[name] = _merge_property(raw_entries.get(name), prop)
 
         properties: dict[str, Property] = defaultdict(
-            lambda: Property({PROPERTY: "default", HIDE: True})
+            lambda: Property({PROPERTY: "default", OPTIONAL: True})
         )
         for name, entry in raw_entries.items():
             properties[name] = Property(entry)

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -66,6 +66,7 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
             key=self._attr_unique_id,
             device_class=device_class,
             entity_registry_visible_default=not dd_entry.hide,
+            entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             native_max_value=dd_entry.number.max_value,  # type: ignore[arg-type]

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -65,6 +65,7 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
         self.entity_description = SelectEntityDescription(
             key=self._attr_unique_id,
             entity_registry_visible_default=not dd_entry.hide,
+            entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             translation_key=self.to_translation_key(status),

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -114,6 +114,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
             key=self._attr_unique_id,
             device_class=device_class,
             entity_registry_visible_default=not dd_entry.hide,
+            entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             native_unit_of_measurement=to_unit(

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -63,6 +63,7 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
         self.entity_description = SwitchEntityDescription(
             key=self._attr_unique_id,
             entity_registry_visible_default=not dd_entry.hide,
+            entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
             translation_key=self.to_translation_key(status),

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -265,3 +265,9 @@ def test_disable_false_actually_disables_disabling():
     assert Property({"property": "p", "disable": False}).disable is False
     assert Property({"property": "p", "disable": True}).disable is True
     assert Property({"property": "p"}).disable is False
+
+
+def test_optional_parsing():
+    assert Property({"property": "p", "optional": False}).optional is False
+    assert Property({"property": "p", "optional": True}).optional is True
+    assert Property({"property": "p"}).optional is False


### PR DESCRIPTION
New mapping configuration `optional: true` creates the entity but registers it as disabled in Home Assistant. Disabled entities aren't loaded: no state, no events, no overhead until enabled. Users can enable individual ones from the device page in HA.

Reduces the active entities for appliances with a lot of properties, without forcing contributors to remove them from the mapping files.

Distinct from existing fields:
- `disable: true` - skip entity creation entirely (write-only flags, combine sources). User cannot enable.
- `hide: true` - register and load enabled, but invisible in default UI; available for automations.
- `optional: true` - register disabled; user opts in via UI.

Properties without a mapping entry are also registered as disabled now (previously hidden), so future firmware-added properties don't auto-create active entities.

This PR only adds the field; per-appliance follow-ups apply it where appropriate.

Backwards compatible: HA's entity registry preserves stored `disabled_by` for entities it already knows about, so existing entities keep their current state — only newly-registered entities (fresh installs and new devices) get the new defaults.