### PR TITLE
Mark window AC (008) diagnostics as optional

### DIFF
--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -178,7 +178,7 @@ properties:
     sensor:
       read_only: true
     entity_category: diagnostic
-    hide: true
+    optional: true
   - property: f_electricity
     # f_electricity: unit varies by device. Most devices observed report
     # in mA. Devices that report in other units (e.g. hW), need a
@@ -198,17 +198,17 @@ properties:
   - property: f_matterOriginalProductId
     sensor:
       read_only: true
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: f_matterOriginalVendorId
     sensor:
       read_only: true
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: f_matterUniqueId
     sensor:
       read_only: true
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: f_temp_in
     icon: mdi:thermometer
@@ -218,21 +218,21 @@ properties:
     sensor:
       device_class: voltage
       unit: V
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: measured_grid_voltage
     sensor:
       device_class: voltage
       unit: V
       state_class: measurement
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: t_beep
     binary_sensor:
       options:
         0: off
         1: on
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: t_dimmer
     switch:


### PR DESCRIPTION
Flip 7 `hide: true` diagnostic sensors to `optional: true` so they register disabled-by-default. Existing entities preserve their stored state in the entity registry — only fresh installs and newly-discovered properties see the new defaults.

Flipped:
- `f_ecm` — current-unit indicator diagnostic
- `f_votage`, `measured_grid_voltage` — voltage diagnostics
- `f_matterOriginalProductId`, `f_matterOriginalVendorId`, `f_matterUniqueId` — Matter device IDs
- `t_beep` — beep state

Kept `hide: true`:
- The 21 `f_e_*` hardware fault problem-class alarms, so safety alerts surface without an opt-in step.
- `f_electricity` — kept loaded so energy-monitoring automations have immediate access to current readings; hidden from the default UI to reduce dashboard clutter.