### PR TITLE
Mark oven (023) pairing, timestamp, and skeleton diagnostics as optional

### DIFF
--- a/custom_components/connectlife/data_dictionaries/023.yaml
+++ b/custom_components/connectlife/data_dictionaries/023.yaml
@@ -72,12 +72,13 @@ properties:
         0: off
         1: on
   - property: Bake_start_utc_datetime_bdc_timestamp
+    optional: true
   - property: Baking_start_time_hour
     disable: true
   - property: Baking_start_time_minute
     disable: true
   - property: CURRENT_SET_STEP
-    hide: false
+    optional: true
     # 3162
   - property: Child_lock
     binary_sensor:
@@ -90,13 +91,9 @@ properties:
       device_class: enum
       options:
         3251: preheat
-        
         3252: step_1
-        
         3253: step_2
-        
         3254: step_3
-        
         3018: after_bake_finished
   - property: Delay_start_status
     binary_sensor:
@@ -127,7 +124,7 @@ properties:
         3041: off
         3042: on
   - property: Hard_pairing_status
-    hide: true
+    optional: true
     binary_sensor:
       options:
         9106: off
@@ -164,12 +161,13 @@ properties:
         1: on
   - property: Remote_control_mode
     # Example value: 2
+    optional: true
   - property: Sand_timer1_duration_in_seconds
     sensor:
       device_class: duration
       unit: s
   - property: Sand_timer1_start_utc_datetime_bdc_timestamp
-    hide: true
+    optional: true
   - property: Sand_timer1_status
     sensor:
       device_class: enum
@@ -182,7 +180,7 @@ properties:
       device_class: duration
       unit: s
   - property: Sand_timer2_start_utc_datetime_bdc_timestamp
-    hide: true
+    optional: true
   - property: Sand_timer2_status
     sensor:
       device_class: enum
@@ -195,7 +193,7 @@ properties:
       device_class: duration
       unit: s
   - property: Sand_timer3_start_utc_datetime_bdc_timestamp
-    hide: true
+    optional: true
   - property: Sand_timer3_status
     sensor:
       device_class: enum
@@ -204,7 +202,7 @@ properties:
         1: paused
         2: stopped
   - property: Set_progress_type
-    sensor: 
+    sensor:
       device_class: enum
       options:
         3401: oven_set
@@ -222,13 +220,14 @@ properties:
         3413: none
   - property: Status
     # Example value: 3011
+    optional: true
   - property: Step1_duration
     # Example value: 30
     sensor:
       device_class: duration
       unit: min
   - property: Step1_heater_system
-    sensor: 
+    sensor:
       device_class: enum
       options:
         3081: hot_air


### PR DESCRIPTION
Flip 4 `hide: true` diagnostics to `optional: true` and mark 4 previously-skeleton properties as optional so they register disabled-by-default. Existing entities preserve their stored state in the entity registry — only fresh installs and newly-discovered properties see the new defaults.

Flipped from `hide: true` (4):
- `Hard_pairing_status` — pairing diagnostic
- `Sand_timer{1,2,3}_start_utc_datetime_bdc_timestamp` — timer start-time internals

Marked from skeleton (4) — these previously had no platform mapping and defaulted to raw `Sensor({})` at runtime:
- `Bake_start_utc_datetime_bdc_timestamp`, `Remote_control_mode`, `Status`, `CURRENT_SET_STEP`