### PR TITLE
Mark AC (009) diagnostics as optional

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -214,7 +214,7 @@ properties:
     sensor:
       read_only: true
     entity_category: diagnostic
-    hide: true
+    optional: true
   - property: f_electricity
     # f_electricity: unit varies by device. Most devices observed report
     # in mA. Devices that report in other units (e.g. hW), need a
@@ -258,7 +258,7 @@ properties:
       device_class: voltage
       unit: V
       state_class: measurement
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: t_8heat
     switch:
@@ -269,7 +269,7 @@ properties:
       options:
         0: off
         1: on
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: t_device_info
     disable: true


### PR DESCRIPTION
Flip 3 `hide: true` diagnostic sensors to `optional: true` so they register disabled-by-default. Existing entities preserve their stored state in the entity registry — only fresh installs and newly-discovered properties see the new defaults.

Flipped:
- `f_ecm` — current-unit indicator diagnostic
- `f_votage` — voltage diagnostic
- `t_beep` — beep state

Kept `hide: true`:
- The 16 `f_e_*` hardware fault problem-class alarms, so safety alerts surface without an opt-in step.
- `f_electricity` — current sensor kept loaded so energy-monitoring automations have immediate access to readings; hidden from the default UI to reduce dashboard clutter.