### PR TITLE
Mark refrigerator (026) diagnostics as optional

### DIFF
--- a/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
+++ b/custom_components/connectlife/data_dictionaries/026-1b0610z0049j.yaml
@@ -24,12 +24,10 @@ properties:
       min_value: 0
       max_value: 8
   - property: variation_max_temperature
-    hide: true
     number:
       device_class: temperature
       unit: °C
   - property: variation_min_temperature
-    hide: true
     number:
       device_class: temperature
       unit: °C

--- a/custom_components/connectlife/data_dictionaries/026.yaml
+++ b/custom_components/connectlife/data_dictionaries/026.yaml
@@ -1,25 +1,25 @@
 # Refrigerator
 properties:
   - property: AIR_FRESHNESS
-    hide: true
+    optional: true
   - property: Kettle_overflow_alarm
-    hide: true
+    optional: true
   - property: ODOR_SENSOR_FAULT_FLAG
-    hide: true
+    optional: true
   - property: ODOR_SENSOR_NO_DISTURB_MODE_STATUS
-    hide: true
+    optional: true
   - property: ODOR_SENSOR_SENSITIVITY
-    hide: true
+    optional: true
   - property: ODOR_SENSOR_SWITHC_STATUS
-    hide: true
+    optional: true
   - property: STERI_PURI_CYCLE_FLAG
-    hide: true
+    optional: true
   - property: ai_energy_mode_switch
-    hide: true
+    optional: true
   - property: alarm_key
-    hide: true
+    optional: true
   - property: alarm_sound_volume
-    hide: true
+    optional: true
   - property: ali_wifi_fault_flag
     hide: true
     entity_category: diagnostic
@@ -32,7 +32,7 @@ properties:
     entity_category: config
     switch: {}
   - property: camera_state
-    hide: true
+    optional: true
   - property: charcoal_filter_expiration_alarm
     hide: true
     entity_category: diagnostic
@@ -88,13 +88,13 @@ properties:
         0: false
         1: true
   - property: clean_mode_switch_status
-    hide: true
+    optional: true
   - property: commodity_inspection
-    hide: true
+    optional: true
   - property: compressor_condition
-    hide: true
+    optional: true
   - property: compressor_frequency
-    hide: true
+    optional: true
     sensor:
       state_class: measurement
   - property: condensation_fan_failure_status
@@ -114,15 +114,15 @@ properties:
         0: false
         1: true
   - property: cool_c
-    hide: true
+    optional: true
   - property: cool_f
-    hide: true
+    optional: true
   - property: cool_fan_speed
-    hide: true
+    optional: true
   - property: cool_r
-    hide: true
+    optional: true
   - property: custard_room
-    hide: true
+    optional: true
   - property: daily_energy_consumption
     hide: true
     entity_category: diagnostic
@@ -132,53 +132,53 @@ properties:
       device_class: energy
       unit: kWh
   - property: date_display_format_status
-    hide: true
+    optional: true
   - property: date_format_status
-    hide: true
+    optional: true
   - property: date_time_format_day_state
-    hide: true
+    optional: true
   - property: date_time_format_month_state
-    hide: true
+    optional: true
   - property: date_time_format_year_state
-    hide: true
+    optional: true
   - property: dbd_clean_mode
-    hide: true
+    optional: true
   - property: debacilli_mode
-    hide: true
+    optional: true
   - property: display_panel_ronshen
-    hide: true
+    optional: true
   - property: displayboard_brand
-    hide: true
+    optional: true
   - property: displayboard_key_setting
-    hide: true
+    optional: true
   - property: displayboard_type
-    hide: true
+    optional: true
   - property: displayboard_version
-    hide: true
+    optional: true
   - property: door_close_light_status
-    hide: true
+    optional: true
   - property: door_close_ui_display_status
-    hide: true
+    optional: true
   - property: door_num_four_color
-    hide: true
+    optional: true
   - property: door_num_one_color
-    hide: true
+    optional: true
   - property: door_num_three_color
-    hide: true
+    optional: true
   - property: door_num_two_color
-    hide: true
+    optional: true
   - property: door_open_light_status
-    hide: true
+    optional: true
   - property: door_open_ui_display_status
-    hide: true
+    optional: true
   - property: electric_current
-    hide: true
+    optional: true
     sensor:
       state_class: measurement
   - property: electric_energy_one_tenths_value
-    hide: true
+    optional: true
   - property: electric_energy_percentile_thousands_value
-    hide: true
+    optional: true
   - property: envi_temp_sens_head_failure
     hide: true
     entity_category: diagnostic
@@ -234,13 +234,13 @@ properties:
         0: false
         1: true
   - property: fast_store_mode_exist
-    hide: true
+    optional: true
   - property: fast_store_mode_status
-    hide: true
+    optional: true
   - property: filter_alarm_time
-    hide: true
+    optional: true
   - property: filter_state
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       read_only: true
@@ -270,9 +270,9 @@ properties:
         0: false
         1: true
   - property: free_key
-    hide: true
+    optional: true
   - property: free_room
-    hide: true
+    optional: true
   - property: free_room_open
     entity_category: diagnostic
     binary_sensor:
@@ -281,7 +281,7 @@ properties:
         0: false
         1: true
   - property: free_room_open_2
-    hide: true
+    optional: true
   - property: free_room_over_temp_alarm_failure
     hide: true
     entity_category: diagnostic
@@ -299,7 +299,7 @@ properties:
         0: false
         1: true
   - property: freeri_fan_speed
-    hide: true
+    optional: true
   - property: freeze_door_open_time
     entity_category: diagnostic
     sensor:
@@ -307,9 +307,9 @@ properties:
       device_class: duration
       unit: s
   - property: freeze_drawer_room_temp
-    hide: true
+    optional: true
   - property: freeze_fan_speed
-    hide: true
+    optional: true
   - property: freeze_max_temperature
     sensor:
       read_only: true
@@ -323,14 +323,14 @@ properties:
       unit: °C
       state_class: measurement
   - property: freeze_poweroff_ad
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: freeze_poweron_ad
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
@@ -353,9 +353,9 @@ properties:
       min_value: -30
       max_value: -5
   - property: freezing_powerdown_temp_alarm
-    hide: true
+    optional: true
   - property: frize_temp_2_degree_above_starting_point
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       device_class: heat
@@ -363,14 +363,14 @@ properties:
         0: false
         1: true
   - property: frost_state
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: froze_convert_to_refri_switch_status
-    hide: true
+    optional: true
   - property: fruit_vegetables_temperature
     entity_category: diagnostic
     sensor:
@@ -378,28 +378,28 @@ properties:
       unit: °C
       state_class: measurement
   - property: fuzzy_mode
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: gold_water_supply_mode
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: high_humidity
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: humidity
       unit: "%"
       state_class: measurement
   - property: high_temperature
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: temperature
@@ -409,17 +409,17 @@ properties:
     entity_category: config
     switch: {}
   - property: human_on_off_status
-    hide: true
+    optional: true
   - property: human_sense_light_status
-    hide: true
+    optional: true
   - property: human_sense_ui_display_state
-    hide: true
+    optional: true
   - property: human_sensor_switch_exist
-    hide: true
+    optional: true
   - property: humanbody_sensor_switch_status
-    hide: true
+    optional: true
   - property: humdy_test_switch_state
-    hide: true
+    optional: true
   - property: humidity sensor_failure
     entity_category: diagnostic
     binary_sensor:
@@ -428,7 +428,7 @@ properties:
         0: false
         1: true
   - property: ice_machine_actual_temp
-    hide: true
+    optional: true
   - property: ice_make_room_alarm
     hide: true
     entity_category: diagnostic
@@ -438,14 +438,14 @@ properties:
         0: false
         1: true
   - property: ice_make_room_switch
-    hide: true
+    optional: true
   - property: ice_making_b_switch_status
     entity_category: config
     switch: {}
   - property: ice_making_fast_status
-    hide: true
+    optional: true
   - property: ice_making_full_status
-    hide: true
+    optional: true
   - property: ice_making_machine_failure
     hide: true
     entity_category: diagnostic
@@ -455,7 +455,7 @@ properties:
         0: false
         1: true
   - property: ice_making_normal_status
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
@@ -474,7 +474,7 @@ properties:
         0: false
         1: true
   - property: ice_room_actual_temp
-    hide: true
+    optional: true
   - property: ice_sensor_failure_flag
     hide: true
     entity_category: diagnostic
@@ -500,33 +500,33 @@ properties:
         0: false
         1: true
   - property: ion_preservation_switch
-    hide: true
+    optional: true
   - property: kettle_install_status
-    hide: true
+    optional: true
   - property: key_press_sound_volume
-    hide: true
+    optional: true
   - property: language_select
-    hide: true
+    optional: true
   - property: load_operation_status2
-    hide: true
+    optional: true
   - property: lock_fresh_mode
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: lock_key
-    hide: true
+    optional: true
   - property: low_humidity
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: humidity
       unit: "%"
       state_class: measurement
   - property: low_temperature
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: temperature
@@ -565,36 +565,36 @@ properties:
         0: false
         1: true
   - property: lumin_value_of_interior_light
-    hide: true
+    optional: true
   - property: mainboard_type
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: mainboard_version
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: market_mode_exist
-    hide: true
+    optional: true
   - property: measured_vibrations
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       state_class: measurement
   - property: medium_humidity
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: humidity
       unit: "%"
       state_class: measurement
   - property: medium_temperature
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: temperature
       unit: °C
       state_class: measurement
   - property: micro_water_supply_mode
-    hide: true
+    optional: true
   - property: mid_wine_area_b_evaporator_fault
     hide: true
     entity_category: diagnostic
@@ -628,29 +628,29 @@ properties:
         0: false
         1: true
   - property: mode_key
-    hide: true
+    optional: true
   - property: model_type
-    hide: true
+    optional: true
   - property: monitor
-    hide: true
+    optional: true
   - property: monitor_set
-    hide: true
+    optional: true
   - property: monitor_set_act
-    hide: true
+    optional: true
   - property: night_mode_end_hour
-    hide: true
+    optional: true
   - property: night_mode_light_dark_level
-    hide: true
+    optional: true
   - property: night_mode_screen_dark_level
-    hide: true
+    optional: true
   - property: night_mode_start_hour
-    hide: true
+    optional: true
   - property: night_mode_start_min
-    hide: true
+    optional: true
   - property: normal_sound_size
-    hide: true
+    optional: true
   - property: not_active
-    hide: true
+    optional: true
   - property: open_freeze_door_alarm
     entity_category: diagnostic
     binary_sensor:
@@ -680,23 +680,23 @@ properties:
         0: false
         1: true
   - property: pairing
-    hide: true
+    optional: true
   - property: pairing_active
-    hide: true
+    optional: true
   - property: party_mode_switch_status
-    hide: true
+    optional: true
   - property: power_one_tenths_value
-    hide: true
+    optional: true
   - property: power_value
-    hide: true
+    optional: true
     sensor:
       state_class: measurement
   - property: power_voltage
-    hide: true
+    optional: true
     sensor:
       state_class: measurement
   - property: quiet_mode_status
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
@@ -724,9 +724,9 @@ properties:
       unit: "%"
       state_class: measurement
   - property: ref_light
-    hide: true
+    optional: true
   - property: refi_temp_2_degree_above_starting_point
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       device_class: heat
@@ -766,9 +766,9 @@ properties:
         0: false
         1: true
   - property: refr_key
-    hide: true
+    optional: true
   - property: refr_room
-    hide: true
+    optional: true
   - property: refr_room_open
     entity_category: diagnostic
     binary_sensor:
@@ -839,11 +839,11 @@ properties:
         0: false
         1: true
   - property: refrigerator_freeze_swith
-    hide: true
+    optional: true
   - property: refrigerator_freeze_swith_state
-    hide: true
+    optional: true
   - property: refrigerator_key
-    hide: true
+    optional: true
   - property: refrigerator_max_temperature
     sensor:
       read_only: true
@@ -857,18 +857,18 @@ properties:
       unit: °C
       state_class: measurement
   - property: refrigerator_poweroff_ad
-    hide: true
+    optional: true
   - property: refrigerator_poweron_ad
-    hide: true
+    optional: true
   - property: refrigerator_real_temperature
     sensor:
       device_class: temperature
       unit: °C
       state_class: measurement
   - property: refrigerator_room
-    hide: true
+    optional: true
   - property: refrigerator_room_open
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       device_class: door
@@ -912,37 +912,37 @@ properties:
         0: false
         1: true
   - property: rgb_atmosphere_mode_b_value
-    hide: true
+    optional: true
   - property: rgb_atmosphere_mode_g_value
-    hide: true
+    optional: true
   - property: rgb_atmosphere_mode_r_value
-    hide: true
+    optional: true
   - property: rgb_function_mode_b_value
-    hide: true
+    optional: true
   - property: rgb_function_mode_g_value
-    hide: true
+    optional: true
   - property: rgb_function_mode_r_value
-    hide: true
+    optional: true
   - property: rgb_light_atmosphere_brightness
-    hide: true
+    optional: true
   - property: rgb_light_atmosphere_on_time
-    hide: true
+    optional: true
   - property: rgb_light_function_brightness
-    hide: true
+    optional: true
   - property: rgb_light_function_on_time
-    hide: true
+    optional: true
   - property: rgb_light_normal_brightness
-    hide: true
+    optional: true
   - property: rgb_light_normal_on_time
-    hide: true
+    optional: true
   - property: rgb_light_state
-    hide: true
+    optional: true
   - property: rgb_normal_mode_b_value
-    hide: true
+    optional: true
   - property: rgb_normal_mode_g_value
-    hide: true
+    optional: true
   - property: rgb_normal_mode_r_value
-    hide: true
+    optional: true
   - property: right_free_sensor_failure
     hide: true
     entity_category: diagnostic
@@ -952,12 +952,12 @@ properties:
         0: false
         1: true
   - property: run_status_flag_5
-    hide: true
+    optional: true
   - property: running_status
-    hide: true
+    optional: true
     entity_category: diagnostic
   - property: running_status3
-    hide: true
+    optional: true
   - property: rx_failure
     hide: true
     entity_category: diagnostic
@@ -967,14 +967,14 @@ properties:
         0: false
         1: true
   - property: sabbath_mode_status
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: sabbath_mode_switch_status
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
@@ -984,91 +984,91 @@ properties:
     entity_category: config
     switch: {}
   - property: screen_display_brightness
-    hide: true
+    optional: true
   - property: screen_display_lock
-    hide: true
+    optional: true
   - property: screen_to_clock_time
-    hide: true
+    optional: true
   - property: screen_to_standby_time
-    hide: true
+    optional: true
   - property: second_ice_maker_full_status
-    hide: true
+    optional: true
   - property: second_ice_maker_init_fault
-    hide: true
+    optional: true
   - property: second_ice_maker_sensor_fault
-    hide: true
+    optional: true
   - property: sensor_failure_status
-    hide: true
+    optional: true
   - property: sensor_failure_status2
-    hide: true
+    optional: true
   - property: sf_mode
     entity_category: config
     switch: {}
   - property: sf_sr_mutex_mode
-    hide: true
+    optional: true
   - property: shelf_light_a_state
-    hide: true
+    optional: true
   - property: shelf_light_atmosphere_brightness
-    hide: true
+    optional: true
   - property: shelf_light_atmosphere_mode_brightness
-    hide: true
+    optional: true
   - property: shelf_light_b_state
-    hide: true
+    optional: true
   - property: shelf_light_c_state
-    hide: true
+    optional: true
   - property: shelf_light_function_mode_brightness
-    hide: true
+    optional: true
   - property: shelf_light_function_on_time
-    hide: true
+    optional: true
   - property: shelf_light_normal_on_time
-    hide: true
+    optional: true
   - property: show_mode
-    hide: true
+    optional: true
   - property: special_space
-    hide: true
+    optional: true
   - property: sr_mode
     entity_category: config
     switch: {}
   - property: standby_mode_state
-    hide: true
+    optional: true
   - property: standby_mode_valid
-    hide: true
+    optional: true
   - property: status_fan_c_switch
-    hide: true
+    optional: true
   - property: status_fan_f_switch
-    hide: true
+    optional: true
   - property: status_fan_ln_switch
-    hide: true
+    optional: true
   - property: status_fan_r_switch
-    hide: true
+    optional: true
   - property: status_heater_c_switch
-    hide: true
+    optional: true
   - property: status_heater_f_switch
-    hide: true
+    optional: true
   - property: status_heater_r_switch
-    hide: true
+    optional: true
   - property: super_water_supply_mode
-    hide: true
+    optional: true
   - property: temp_auto_ctrl_mode_exist
-    hide: true
+    optional: true
   - property: temp_auto_ctrl_mode_state
-    hide: true
+    optional: true
   - property: temperature_room_judge
-    hide: true
+    optional: true
     entity_category: diagnostic
     sensor:
       device_class: temperature
       unit: °C
       state_class: measurement
   - property: temperature_unit
-    hide: true
+    optional: true
     entity_category: diagnostic
     select:
       options:
         0: celsius
         1: fahrenheit
   - property: theme_color
-    hide: true
+    optional: true
   - property: tx_failure
     hide: true
     entity_category: diagnostic
@@ -1078,11 +1078,11 @@ properties:
         0: false
         1: true
   - property: unfreeze_run_status
-    hide: true
+    optional: true
   - property: unfreeze_switch_status
-    hide: true
+    optional: true
   - property: unpair_all_users
-    hide: true
+    optional: true
   - property: up_wine_area_a_evaporator_fault
     hide: true
     entity_category: diagnostic
@@ -1116,18 +1116,18 @@ properties:
         0: false
         1: true
   - property: user_debacilli_mode
-    hide: true
+    optional: true
   - property: uv_steri_status
-    hide: true
+    optional: true
   - property: vacuum_on_off_status
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       options:
         0: false
         1: true
   - property: var_room_open_2
-    hide: true
+    optional: true
   - property: var_room_over_temp_alarm
     hide: true
     entity_category: diagnostic
@@ -1145,11 +1145,11 @@ properties:
         0: false
         1: true
   - property: vari_fan_speed
-    hide: true
+    optional: true
   - property: vari_key
-    hide: true
+    optional: true
   - property: vari_room
-    hide: true
+    optional: true
   - property: vari_room_open
     entity_category: diagnostic
     binary_sensor:
@@ -1158,7 +1158,7 @@ properties:
         0: false
         1: true
   - property: vari_temp_2_degree_above_starting_point
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       device_class: heat
@@ -1190,7 +1190,7 @@ properties:
         0: false
         1: true
   - property: variable_temperature_space
-    hide: true
+    optional: true
   - property: variation_door_open_time
     entity_category: diagnostic
     sensor:
@@ -1212,9 +1212,9 @@ properties:
       unit: °C
       state_class: measurement
   - property: variation_poweroff_ad
-    hide: true
+    optional: true
   - property: variation_poweron_ad
-    hide: true
+    optional: true
   - property: variation_real_temperature
     entity_category: diagnostic
     sensor:
@@ -1234,7 +1234,7 @@ properties:
       device_class: temperature
       unit: °C
   - property: vibration_alarm
-    hide: true
+    optional: true
     entity_category: diagnostic
     binary_sensor:
       device_class: vibration
@@ -1250,55 +1250,55 @@ properties:
         0: false
         1: true
   - property: water_box_alarm_switch_state
-    hide: true
+    optional: true
   - property: water_box_lack_status
-    hide: true
+    optional: true
   - property: water_box_mode_status
-    hide: true
+    optional: true
   - property: water_fill_actual_temp
-    hide: true
+    optional: true
   - property: water_filter_surplus_time
-    hide: true
+    optional: true
   - property: water_filter_time_reset
-    hide: true
+    optional: true
   - property: water_heat_switch
-    hide: true
+    optional: true
   - property: water_tank_install_state
-    hide: true
+    optional: true
   - property: wet_and_dry_space
-    hide: true
+    optional: true
   - property: wifi_fault_flag
-    hide: true
+    optional: true
   - property: wifi_handshake_fault_flag
-    hide: true
+    optional: true
   - property: wifi_next_sendtime
-    hide: true
+    optional: true
   - property: wifi_rx_fault_flag
-    hide: true
+    optional: true
   - property: wifi_setting
-    hide: true
+    optional: true
   - property: wifi_tx_fault_flag
-    hide: true
+    optional: true
   - property: wild_vegetable_heat_switch
-    hide: true
+    optional: true
   - property: will_fresh_light_status
-    hide: true
+    optional: true
   - property: will_fress_light_exist
-    hide: true
+    optional: true
   - property: will_light_market_mode_state
-    hide: true
+    optional: true
   - property: will_light_mode_exist
-    hide: true
+    optional: true
   - property: will_light_mode_state
-    hide: true
+    optional: true
   - property: will_light_switch_state
-    hide: true
+    optional: true
   - property: wine_area_switch_status
-    hide: true
+    optional: true
   - property: wine_b_switch__area
-    hide: true
+    optional: true
   - property: wine_light
-    hide: true
+    optional: true
   - property: wine_sensor_failure_flag
     hide: true
     entity_category: diagnostic
@@ -1308,6 +1308,6 @@ properties:
         0: false
         1: true
   - property: work_mode1
-    hide: true
+    optional: true
   - property: work_mode2
-    hide: true
+    optional: true


### PR DESCRIPTION
Flip 220 `hide: true` properties to `optional: true` so they register disabled-by-default. Existing entities preserve their stored state in the entity registry — only fresh installs and newly-discovered properties see the new defaults.

Flipped:
- Diagnostic mode/state flags (`*_status`, `*_mode_status`, `*_setting_status`, etc.)
- Numbered/parallel zone diagnostics (`fast_store_*`, `freeze_poweroff_ad`, `freeze_poweron_ad`, `cool_*`, `dbd_clean_mode`, etc.)
- Display, RGB lighting, sound, key-press, and night-mode settings
- Pairing, OTA, hardpairing, sensor-failure (non-problem-class)
- Wine-area / shelf-light / kettle / commodity-inspection housekeeping

Kept `hide: true` (63):
- ~55 problem-class hardware failure / fault alarms across refrigerator/freezer/variable/wine-zone components, so safety alerts surface without an opt-in step.
- `child_lock_switch_exist`, `child_lock_switch_status` so safety automations still have access.
- `daily_energy_consumption` — energy total kept loaded so energy-monitoring automations have immediate access.
- `real_humidity`, `real_humidity_b`, `real_humidity_c`, `refrigerator_sensor_real_temperature`, `variation_temperature` — live measurement readings kept loaded for automations; hidden from the default UI to reduce dashboard clutter.

Override file `026-1b0610z0049j.yaml`: drop `hide: true` from `variation_max_temperature` and `variation_min_temperature` so the range-bound number entities are visible by default for this variant.