### PR TITLE
Mark tumble dryer (032) diagnostics, error slots, and alarm slots as optional

### DIFF
--- a/custom_components/connectlife/data_dictionaries/032.yaml
+++ b/custom_components/connectlife/data_dictionaries/032.yaml
@@ -3,62 +3,62 @@ properties:
   - property: AdaptTech_setting
     # Example value: 2
   - property: Alarm_1
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_2
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_3
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_4
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_5
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_6
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_7
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_8
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_9
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_10
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_11
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Alarm_12
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
@@ -90,9 +90,9 @@ properties:
   - property: Bundling_sensor_setting_status
     # Example value: 0
   - property: Child_Lock_status
-    binary_sensor: 
+    binary_sensor:
   - property: Condensed_watermode
-    hide: true
+    optional: true
   - property: Current_programphase
     # 1 device off, 3 and 4 program is running no info in app what that means
     icon: mdi:state-machine
@@ -107,8 +107,8 @@ properties:
       device_class: duration
       unit: min
   - property: DelayStart_DelayEnd_mode
-    binary_sensor: 
-    hide: true
+    binary_sensor:
+    optional: true
   - property: DelayStart_DelayEnd_remaining_timein_minutes
     sensor:
       device_class: duration
@@ -127,121 +127,121 @@ properties:
         1: off
         2: on
   - property: Error_0
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_1
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_2
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_3
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_4
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_5
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_6
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_7
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_8
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_9
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_10
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_11
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_12
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_13
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_14
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_15
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: Error_16
-    hide: true
+    optional: true
     icon: mdi:tumble-dryer-alert
     binary_sensor:
       device_class: problem
   - property: ExtraDry_setting
-    sensor: 
+    sensor:
   - property: Float_switch
-    binary_sensor: 
+    binary_sensor:
   - property: Fota
-    hide: true
+    optional: true
   - property: HardPairingStatus
-    hide: true
+    optional: true
   - property: Humidity_sensor
-    binary_sensor: 
-    hide: true
+    binary_sensor:
+    optional: true
   - property: Logo_setting_status
-    hide: true
+    optional: true
   - property: NTC_sensor_1
-    hide: true
+    optional: true
   - property: NTC_sensor_2
-    hide: true
+    optional: true
   - property: Reed_switch
-    binary_sensor: 
-    hide: true
+    binary_sensor:
+    optional: true
   - property: Remote_control_mode_monitoring
-    binary_sensor: 
-    hide: true
+    binary_sensor:
+    optional: true
   - property: Remote_control_monitoring_set_commands
-    hide: true
+    optional: true
   - property: Remote_control_monitoring_set_commands_actions
-    hide: true
+    optional: true
   - property: Selected_program_AntiCrease_status
-    binary_sensor: 
+    binary_sensor:
   - property: Selected_program_ExtraDry_status
-    binary_sensor: 
+    binary_sensor:
   - property: Selected_program_ID
     icon: mdi:selection-ellipse-arrow-inside
     sensor:
@@ -264,9 +264,9 @@ properties:
         14: remote
         255: none
   - property: Selected_program_SteamFinish
-    binary_sensor: 
+    binary_sensor:
   - property: Selected_program_mode_status
-    hide: true
+    optional: true
     # Example value: 1
   - property: Selected_programduration_inminutes
     sensor:
@@ -278,16 +278,16 @@ properties:
       unit: min
   - property: Session_pairing_active
     binary_sensor:
-    hide: true
+    optional: true
   - property: Session_pairing_setting
-    hide: true
+    optional: true
   - property: Soft_pairing_setting
-    hide: true
+    optional: true
   - property: Sound_settings
-    hide: true
+    optional: true
     # Example value: 3
   - property: UTC_DateTime_BDC_DelayStart_DelayEnd_timestamp
-    hide: true
+    optional: true
     sensor:
       device_class: timestamp
   - property: Washer_to_Dryer_available_for_hours_v
@@ -297,10 +297,10 @@ properties:
     hide: true
     # Example value: 254
   - property: Washer_to_Dryersetting_status
-    hide: true
+    optional: true
     # Example value: 0
   - property: Washer_to_dryerwizard_trigger_status
-    hide: true
+    optional: true
     # Example value: 1
   - property: Water_level_switch
     binary_sensor:


### PR DESCRIPTION
Flip 49 `hide: true` properties to `optional: true` so they register disabled-by-default. Existing entities preserve their stored state in the entity registry — only fresh installs and newly-discovered properties see the new defaults.

Flipped:
- 12 numbered `Alarm_*` slots and 17 numbered `Error_*` slots (problem-class but per-slot — covered by higher-level state)
- Pairing diagnostics (`HardPairingStatus`, `Session_pairing_*`, `Soft_pairing_setting`)
- Remote-control monitoring (`Remote_control_mode_monitoring`, `Remote_control_monitoring_set_commands*`)
- Internal sensors (`NTC_sensor_1`, `NTC_sensor_2`, `Humidity_sensor`, `Reed_switch`)
- Settings (`Logo_setting_status`, `Sound_settings`, `Selected_program_mode_status`, `Condensed_watermode`, `DelayStart_DelayEnd_mode`)
- `Fota`, `UTC_DateTime_BDC_DelayStart_DelayEnd_timestamp`
- `Washer_to_Dryersetting_status`, `Washer_to_dryerwizard_trigger_status`

Kept `hide: true` (4):
- `Door_status` — top-level state kept loaded so safety/automation consumers still have access.
- `Washer_to_Dryer_available_for_hours_v`, `Washer_to_Dryer_program_ID` — washer→dryer linkage state kept loaded for cross-device automations.
- `Water_level_switch` — water-level state kept loaded for fault-detection automations.