### PR TITLE
Mark tumble dryer (030) diagnostics and drying-wizard internals as optional

### DIFF
--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -2,19 +2,19 @@
 properties:
   - property: Actions
     # Sample value: 0
-    hide: true
+    optional: true
   - property: AntiCrease
     icon: mdi:iron
     switch:
   - property: ApplicationPermissions
     # Sample value: 2
-    hide: true
+    optional: true
   - property: Aromatherapy
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Auxiliary_heat
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Child_lock
     icon: mdi:lock
     entity_category: config
@@ -42,7 +42,7 @@ properties:
       max_value: 24
   - property: DelayEndTime_Minute
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Door_status
     unavailable: 0
     binary_sensor:
@@ -53,7 +53,7 @@ properties:
     icon: mdi:door
   - property: DownLight_LightTime
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Drum_Light
     icon: mdi:lightbulb
     entity_category: config
@@ -67,73 +67,73 @@ properties:
         3: high
   - property: Dry_Level_show
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesDryLevel
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesDryLevel1
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesDryTarget
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesDryTarget1
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesMaterialCharacteristics
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesMaterialCharacteristics_first
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesMaterialCharacteristics_second
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothesMaterialCharacteristics_third
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_eighth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_eleventh
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_fifth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_first
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_fourth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_ninth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_second
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_seventh
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_sixth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_tenth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_third
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_thirteenth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: DryingWizzard_ClothingType_twelfth
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Electricit_consumption
     icon: mdi:lightning-bolt
     sensor:
@@ -227,13 +227,13 @@ properties:
     icon: mdi:timer
   - property: Session_pairing_commond
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Session_pairing_states
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Sound_setting
     # Sample value: 0
-    hide: true
+    optional: true
   - property: StandardElectricitConsumption
     hide: true
     entity_category: diagnostic
@@ -251,7 +251,7 @@ properties:
     hide: true
   - property: SteamEngineLackWaterState
     # Sample value: 0
-    hide: true
+    optional: true
   - property: Store_Dry_Time
     # Sample value: 235
     hide: true
@@ -273,10 +273,10 @@ properties:
     hide: true
   - property: delay_close_dryer_time
     # Sample value: 0
-    hide: true
+    optional: true
   - property: delay_time_hour_min
     # Sample value: 4
-    hide: true
+    optional: true
   - property: dry_time
     icon: mdi:timer
     select:
@@ -305,7 +305,7 @@ properties:
       state_class: total_increasing
   - property: error_code
     # Sample value: 0
-    hide: true
+    optional: true
   - property: machine_status
     icon: mdi:tumble-dryer
     sensor:
@@ -321,25 +321,25 @@ properties:
     switch:
   - property: parse_lib_ver
     # Sample value: 20241030
-    hide: true
+    optional: true
   - property: selected_program
     hide: true
     entity_category: diagnostic
   - property: stoprunning_flag
     # Sample value: 0
-    hide: true
+    optional: true
   - property: support_preheat_state
     # Sample value: 1
-    hide: true
+    optional: true
   - property: temperature
     # Sample value: 2
-    hide: true
+    optional: true
   - property: timezone
     # Sample value: 0
-    hide: true
+    optional: true
   - property: washing_machine_type
     # Sample value: 0
-    hide: true
+    optional: true
   - property: washing_machine_type_kg
     # Sample value: 0
-    hide: true
+    optional: true


### PR DESCRIPTION
Flip 43 `hide: true` properties to `optional: true` so they register disabled-by-default. Existing entities preserve their stored state in the entity registry — only fresh installs and newly-discovered properties see the new defaults.

Flipped:
- All `DryingWizzard_*` per-load wizard mirrors (clothing type, material characteristics, dry level/target, etc.)
- `Session_pairing_*`, pairing diagnostics
- Settings (`Sound_setting`, `Aromatherapy`, `Auxiliary_heat`, `DownLight_LightTime`, `Dry_Level_show`, `timezone`, etc.)
- `Actions`, `ApplicationPermissions`, `error_code`, `parse_lib_ver`, `support_preheat_state`, `stoprunning_flag`, `SteamEngineLackWaterState`
- Time/temperature internals (`DelayEndTime_Minute`, `delay_close_dryer_time`, `delay_time_hour_min`, `temperature`)
- Type identifiers (`washing_machine_type`, `washing_machine_type_kg`)

Kept `hide: true` (12):
- `StandardElectricitConsumption` — energy total kept loaded so energy-monitoring automations have immediate access; hidden from the default UI to reduce dashboard clutter.
- `Steam`, `UV_Sterilization` — cycle features kept loaded for automations.
- `Store_Dry_Time`, `Wear_Dry_Time`, `currrent_dry_level_time`, `default_dry_level` — cycle timing/levels kept loaded for cycle automations.
- `drying_linkage_order`, `drying_linkage_preheat_time`, `drying_linkage_programid`, `drying_washing_linkage_state` — washer→dryer linkage state kept loaded for cross-device automations.
- `selected_program` — active program kept loaded for automations.