### PR TITLE
Improve mappings for washing machine (027) and remove duplicate entries

### DIFF
--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -148,397 +148,550 @@ properties:
   binary_sensor: {}
 - property: ADS_Dirtiness_setting_status
   # Sample value: 2
+  optional: true
 - property: ADS_Settings_Current_Program_Detergent_setting_status
   # Sample value: 2
+  optional: true
 - property: ADS_Settings_Current_Program_Softener_setting_status
   # Sample value: 2
+  optional: true
 - property: Adapt_sense_setting_status
   # Sample value: 2
+  optional: true
 - property: Add_on_program_download_ID
   # Sample value: 254
+  optional: true
 - property: Add_on_program_download_status
   # Sample value: 1
+  optional: true
 - property: Add_program_to_device
   # Sample value: 0
+  optional: true
 - property: Air_dry_function_status
   # Sample value: 0
+  optional: true
 - property: Air_shower_setting_status
   # Sample value: 0
+  optional: true
 - property: Alarm_1
   # Sample value: 1
+  optional: true
 - property: Alarm_10
   # Sample value: 1
+  optional: true
 - property: Alarm_11
   # Sample value: 1
+  optional: true
 - property: Alarm_12
   # Sample value: 1
+  optional: true
 - property: Alarm_13
   # Sample value: 1
+  optional: true
 - property: Alarm_14
   # Sample value: 1
+  optional: true
 - property: Alarm_15
   # Sample value: 1
+  optional: true
 - property: Alarm_16
   # Sample value: 1
+  optional: true
 - property: Alarm_17
   # Sample value: 0
+  optional: true
 - property: Alarm_18
   # Sample value: 0
+  optional: true
 - property: Alarm_19
   # Sample value: 0
+  optional: true
 - property: Alarm_2
   # Sample value: 1
+  optional: true
 - property: Alarm_20
   # Sample value: 0
+  optional: true
 - property: Alarm_21
   # Sample value: 0
+  optional: true
 - property: Alarm_22
   # Sample value: 0
+  optional: true
 - property: Alarm_3
   # Sample value: 1
+  optional: true
 - property: Alarm_4
   # Sample value: 1
+  optional: true
 - property: Alarm_5
   # Sample value: 1
+  optional: true
 - property: Alarm_6
   # Sample value: 0
+  optional: true
 - property: Alarm_7
   # Sample value: 0
+  optional: true
 - property: Alarm_8
   # Sample value: 0
+  optional: true
 - property: Alarm_9
   # Sample value: 1
+  optional: true
 - property: Auto_Super_rinse_setting_status
   # Sample value: 0
+  optional: true
 - property: Auto_dose_Compartment1_amount_setting
   # Sample value: 0
+  optional: true
 - property: Auto_dose_Compartment1_status_102
   # Sample value: 0
+  optional: true
 - property: Auto_dose_Compartment1_tank_amount
   # Sample value: 0
+  optional: true
 - property: Auto_dose_Compartment2_amount_setting
   # Sample value: 0
+  optional: true
 - property: Auto_dose_Compartment2_status_102
   # Sample value: 0
+  optional: true
 - property: Auto_dose_Compartment2_tank_amount
   # Sample value: 0
+  optional: true
 - property: Auto_dose_drawer_status
   # Sample value: 0
+  optional: true
 - property: Auto_dose_system_setting_status
   # Sample value: 0
+  optional: true
 - property: Brightness_setting
   # Sample value: 0
+  optional: true
 - property: Can_upload_WiFi_program
   # Sample value: 2
+  optional: true
 - property: Child_lock_setting_status
   # Sample value: 2
-- property: Child_lock_status_status
-  # Sample value: 1
+  optional: true
 - property: Color_sensor_setting_status
   # Sample value: 0
+  optional: true
 - property: Compartment1_type_setting_status
   # Sample value: 0
+  optional: true
 - property: Compartment2_type_setting_status
   # Sample value: 0
-- property: Current_temperature
-  # Sample value: 255
+  optional: true
 - property: Current_washing_program_phase_2
   # Sample value: 1
+  optional: true
 - property: Current_washing_program_phase_status
   # Sample value: 15
+  optional: true
 - property: Current_water_level
   # Sample value: 65535
+  optional: true
 - property: Darhcdq
   # Sample value: 65535
-- property: Delaystart_delayend_remaining_time_in_minutes
-  # Sample value: 65535
+  optional: true
 - property: Delaystart_delayend_timestamp_status
   # Sample value: 16679/02/18T23:47:45
+  optional: true
 - property: Demo_mode_status
   # Sample value: 0
+  optional: true
 - property: Detergent_amount_status
   # Sample value: 0
+  optional: true
 - property: Detergent_indicator
   # Sample value: 0
+  optional: true
 - property: Dose_assist_recommended_detergent_quantity_unit_status
   # Sample value: 1
+  optional: true
 - property: Dose_assist_recommended_low_concenatration_detergent_quantity
   # Sample value: 65535
+  optional: true
 - property: Dose_assist_status
   # Sample value: 0
+  optional: true
 - property: Drum_light_setting_status
   # Sample value: 0
+  optional: true
 - property: Eco_score_type
   # Sample value: 0
+  optional: true
 - property: Error_0
   # Sample value: 1
+  optional: true
 - property: Error_1
   # Sample value: 1
+  optional: true
 - property: Error_10
   # Sample value: 1
+  optional: true
 - property: Error_11
   # Sample value: 1
+  optional: true
 - property: Error_12
   # Sample value: 1
+  optional: true
 - property: Error_12_1
   # Sample value: 1
+  optional: true
 - property: Error_12_10
   # Sample value: 1
+  optional: true
 - property: Error_12_11
   # Sample value: 1
+  optional: true
 - property: Error_12_12
   # Sample value: 1
+  optional: true
 - property: Error_12_13
   # Sample value: 1
+  optional: true
 - property: Error_12_14
   # Sample value: 1
+  optional: true
 - property: Error_12_15
   # Sample value: 1
+  optional: true
 - property: Error_12_16
   # Sample value: 1
+  optional: true
 - property: Error_12_17
   # Sample value: 0
+  optional: true
 - property: Error_12_18
   # Sample value: 1
+  optional: true
 - property: Error_12_2
   # Sample value: 1
+  optional: true
 - property: Error_12_3
   # Sample value: 1
+  optional: true
 - property: Error_12_4
   # Sample value: 1
+  optional: true
 - property: Error_12_5
   # Sample value: 1
+  optional: true
 - property: Error_12_6
   # Sample value: 1
+  optional: true
 - property: Error_12_7
   # Sample value: 1
+  optional: true
 - property: Error_12_8
   # Sample value: 1
+  optional: true
 - property: Error_12_9
   # Sample value: 1
+  optional: true
 - property: Error_13
   # Sample value: 1
+  optional: true
 - property: Error_13_1
   # Sample value: 1
+  optional: true
 - property: Error_13_2
   # Sample value: 1
+  optional: true
 - property: Error_13_3
   # Sample value: 1
+  optional: true
 - property: Error_14
   # Sample value: 0
+  optional: true
 - property: Error_15
   # Sample value: 1
+  optional: true
 - property: Error_16
   # Sample value: 0
+  optional: true
 - property: Error_17
   # Sample value: 0
+  optional: true
 - property: Error_18
   # Sample value: 0
+  optional: true
 - property: Error_19
   # Sample value: 0
+  optional: true
 - property: Error_2
   # Sample value: 1
+  optional: true
 - property: Error_20
   # Sample value: 0
+  optional: true
 - property: Error_21
   # Sample value: 0
+  optional: true
 - property: Error_22
   # Sample value: 1
+  optional: true
 - property: Error_23
   # Sample value: 1
+  optional: true
 - property: Error_24
   # Sample value: 1
+  optional: true
 - property: Error_25
   # Sample value: 0
+  optional: true
 - property: Error_26
   # Sample value: 0
+  optional: true
 - property: Error_27
   # Sample value: 0
+  optional: true
 - property: Error_28
   # Sample value: 0
+  optional: true
 - property: Error_29
   # Sample value: 0
+  optional: true
 - property: Error_3
   # Sample value: 1
+  optional: true
 - property: Error_30
   # Sample value: 0
+  optional: true
 - property: Error_31
   # Sample value: 0
+  optional: true
 - property: Error_32
   # Sample value: 0
+  optional: true
 - property: Error_33
   # Sample value: 0
+  optional: true
 - property: Error_34
   # Sample value: 0
+  optional: true
 - property: Error_35
   # Sample value: 0
+  optional: true
 - property: Error_36
   # Sample value: 1
+  optional: true
 - property: Error_37
   # Sample value: 1
+  optional: true
 - property: Error_38
   # Sample value: 0
+  optional: true
 - property: Error_38_1
   # Sample value: 0
+  optional: true
 - property: Error_39
   # Sample value: 0
+  optional: true
 - property: Error_4
   # Sample value: 0
+  optional: true
 - property: Error_40
   # Sample value: 1
+  optional: true
 - property: Error_41
   # Sample value: 1
+  optional: true
 - property: Error_42
   # Sample value: 1
+  optional: true
 - property: Error_43
   # Sample value: 1
+  optional: true
 - property: Error_44
   # Sample value: 1
+  optional: true
 - property: Error_45
   # Sample value: 0
+  optional: true
 - property: Error_46
   # Sample value: 0
+  optional: true
 - property: Error_47
   # Sample value: 0
+  optional: true
 - property: Error_48
   # Sample value: 1
+  optional: true
 - property: Error_49
   # Sample value: 1
+  optional: true
 - property: Error_5
   # Sample value: 0
+  optional: true
 - property: Error_50
   # Sample value: 0
+  optional: true
 - property: Error_51
   # Sample value: 0
+  optional: true
 - property: Error_52
   # Sample value: 0
+  optional: true
 - property: Error_6
   # Sample value: 1
+  optional: true
 - property: Error_7
   # Sample value: 1
+  optional: true
 - property: Error_7_1
   # Sample value: 1
+  optional: true
 - property: Error_7_2
   # Sample value: 0
+  optional: true
 - property: Error_8
   # Sample value: 1
+  optional: true
 - property: Error_89
   # Sample value: 1
+  optional: true
 - property: Error_9
   # Sample value: 1
+  optional: true
 - property: Error_90
   # Sample value: 1
+  optional: true
 - property: Error_9_1
   # Sample value: 0
-- property: Extra_rinse_status
-  # Sample value: 0
+  optional: true
 - property: Fota
   # Sample value: 4
+  optional: true
 - property: HardPairingStatus
   # Sample value: 0
+  optional: true
 - property: Language_setting
   # Sample value: 0
+  optional: true
 - property: Liquid_unit_setting_status
   # Sample value: 0
+  optional: true
 - property: Logo_setting_status
   # Sample value: 0
+  optional: true
 - property: Max_RPM_allowed_stat
   # Sample value: 0
+  optional: true
 - property: Night_start_setting_status_102
   # Sample value: 0
+  optional: true
 - property: No_sound_status
   # Sample value: 1
+  optional: true
 - property: Number_of_rinses
   # Sample value: 254
+  optional: true
 - property: Power_save_status
   # Sample value: 0
+  optional: true
 - property: Remote_control_mode_monitoring
   # Sample value: 1
+  optional: true
 - property: Remote_control_monitoring_set_commands
   # Sample value: 1
+  optional: true
 - property: Remote_control_monitoring_set_commands_actions
   # Sample value: 0
-- property: Selected_program_Disinfection
-  # Sample value: 0
+  optional: true
 - property: Selected_program_Eco_Disinfection
   # Sample value: 0
+  optional: true
 - property: Selected_program_Eco_Small_load
   # Sample value: 0
+  optional: true
 - property: Selected_program_Eco_score
   # Sample value: 0
+  optional: true
 - property: Selected_program_Green_leaves_AntiCrease
   # Sample value: 0
+  optional: true
 - property: Selected_program_Green_leaves_Entry_steam
   # Sample value: 0
+  optional: true
 - property: Selected_program_Green_leaves_Prewash
   # Sample value: 0
+  optional: true
 - property: Selected_program_Intensive_mode
   # Sample value: 0
+  optional: true
 - property: Selected_program_Night_mode
   # Sample value: 0
+  optional: true
 - property: Selected_program_Small_load_status
   # Sample value: 0
+  optional: true
 - property: Selected_program_Super_rinse
   # Sample value: 0
+  optional: true
 - property: Selected_program_Water_add
   # Sample value: 0
-- property: Selected_program_anticrease_status
-  # Sample value: 1
-- property: Selected_program_entry_steam_status
-  # Sample value: 1
+  optional: true
 - property: Selected_program_load_status
   # Sample value: 0
+  optional: true
 - property: Selected_program_mode2_status
   # Sample value: 0
-- property: Selected_program_mode_status
-  # Sample value: 4
-- property: Selected_program_prewash_status
-  # Sample value: 1
-- property: Selected_program_rinse_hold_status
-  # Sample value: 1
-- property: Selected_program_set_temperature_status
-  # Sample value: 4
-- property: Selected_program_washing_spin_speed_rpm_status
-  # Sample value: 8
-- property: Selected_program_water_pluse_status
-  # Sample value: 1
+  optional: true
 - property: Session_pairing_active
   # Sample value: 0
+  optional: true
 - property: Session_pairing_status
   # Sample value: 0
+  optional: true
 - property: Smart_sync_setting_status
   # Sample value: 0
+  optional: true
 - property: Soft_pairing_status
   # Sample value: 0
+  optional: true
 - property: Softener_amount_status
   # Sample value: 0
+  optional: true
 - property: Softener_indicator
   # Sample value: 0
+  optional: true
 - property: Sound_setting_status
   # Sample value: 3
+  optional: true
 - property: Stain_program_Set_clothes_type_status
   # Sample value: 0
+  optional: true
 - property: Stain_program_Set_stain_status
   # Sample value: 0
-- property: StopAddGoAllowed
-  # Sample value: 2
-- property: Stopaddgo_status
-  # Sample value: 1
+  optional: true
 - property: Temperature_unit_setting_status
   # Sample value: 0
+  optional: true
 - property: Time_program_Set_time_status
   # Sample value: 0
+  optional: true
 - property: Time_save_status
   # Sample value: 0
+  optional: true
 - property: Turbidity_sensor_setting_status
   # Sample value: 0
+  optional: true
 - property: Units_setting_status
   # Sample value: 0
+  optional: true
 - property: View_size_setting_status
   # Sample value: 0
+  optional: true
 - property: Volume_setting
   # Sample value: 0
+  optional: true
 - property: Water_hardness_setting_status
   # Sample value: 2
+  optional: true
 - property: Weight_unit_setting_status
   # Sample value: 0
+  optional: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2588,9 +2588,6 @@
       "child_lock_setting_status": {
         "name": "Child lock setting"
       },
-      "child_lock_status_status": {
-        "name": "Child lock status status"
-      },
       "childlock_flag": {
         "name": "Child lock flag"
       },
@@ -3608,9 +3605,6 @@
       },
       "error_read_out_3_status": {
         "name": "Error read out 3 status"
-      },
-      "extra_rinse_status": {
-        "name": "Extra rinse status"
       },
       "extra_soft": {
         "name": "Extra soft"
@@ -4782,12 +4776,6 @@
       "selected_program": {
         "name": "Selected program"
       },
-      "selected_program_anticrease_status": {
-        "name": "Selected program anti-crease status"
-      },
-      "selected_program_disinfection": {
-        "name": "Selected program disinfection"
-      },
       "selected_program_dry_function": {
         "name": "Selected program dry function"
       },
@@ -4802,9 +4790,6 @@
       },
       "selected_program_eco_small_load": {
         "name": "Selected program eco small load"
-      },
-      "selected_program_entry_steam_status": {
-        "name": "Selected program entry steam status"
       },
       "selected_program_extra_drying_function": {
         "name": "Selected program extra drying function"
@@ -4889,14 +4874,8 @@
       "selected_program_night_mode": {
         "name": "Selected program night mode"
       },
-      "selected_program_prewash_status": {
-        "name": "Selected program prewash status"
-      },
       "selected_program_remaining_time_in_minutes": {
         "name": "Remaining time of selected program"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Selected program rinse hold status"
       },
       "selected_program_set_temperature_status": {
         "name": "Temperature",
@@ -4951,9 +4930,6 @@
       },
       "selected_program_water_add": {
         "name": "Selected program water add"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Selected program water pulse status"
       },
       "selected_programduration_inminutes": {
         "name": "Duration of selected program"
@@ -7031,12 +7007,6 @@
       },
       "steri_puri_cycle_flag": {
         "name": "Steri puri cycle flag"
-      },
-      "stopaddgo_status": {
-        "name": "Stop add go status"
-      },
-      "stopaddgoallowed": {
-        "name": "Stop add go allowed"
       },
       "stoprunning_flag": {
         "name": "Stop running flag"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2588,9 +2588,6 @@
       "child_lock_setting_status": {
         "name": "Child lock setting"
       },
-      "child_lock_status_status": {
-        "name": "Child lock status status"
-      },
       "childlock_flag": {
         "name": "Child lock flag"
       },
@@ -3608,9 +3605,6 @@
       },
       "error_read_out_3_status": {
         "name": "Error read out 3 status"
-      },
-      "extra_rinse_status": {
-        "name": "Extra rinse status"
       },
       "extra_soft": {
         "name": "Extra soft"
@@ -4782,12 +4776,6 @@
       "selected_program": {
         "name": "Selected program"
       },
-      "selected_program_anticrease_status": {
-        "name": "Selected program anti-crease status"
-      },
-      "selected_program_disinfection": {
-        "name": "Selected program disinfection"
-      },
       "selected_program_dry_function": {
         "name": "Selected program dry function"
       },
@@ -4802,9 +4790,6 @@
       },
       "selected_program_eco_small_load": {
         "name": "Selected program eco small load"
-      },
-      "selected_program_entry_steam_status": {
-        "name": "Selected program entry steam status"
       },
       "selected_program_extra_drying_function": {
         "name": "Selected program extra drying function"
@@ -4889,14 +4874,8 @@
       "selected_program_night_mode": {
         "name": "Selected program night mode"
       },
-      "selected_program_prewash_status": {
-        "name": "Selected program prewash status"
-      },
       "selected_program_remaining_time_in_minutes": {
         "name": "Remaining time of selected program"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Selected program rinse hold status"
       },
       "selected_program_set_temperature_status": {
         "name": "Temperature",
@@ -4951,9 +4930,6 @@
       },
       "selected_program_water_add": {
         "name": "Selected program water add"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Selected program water pulse status"
       },
       "selected_programduration_inminutes": {
         "name": "Duration of selected program"
@@ -7031,12 +7007,6 @@
       },
       "steri_puri_cycle_flag": {
         "name": "Steri puri cycle flag"
-      },
-      "stopaddgo_status": {
-        "name": "Stop add go status"
-      },
-      "stopaddgoallowed": {
-        "name": "Stop add go allowed"
       },
       "stoprunning_flag": {
         "name": "Stop running flag"


### PR DESCRIPTION
Two fixes for `027.yaml`:

1. Remove 15 duplicate property entries near the bottom of the file that were silently overriding properly-mapped versions at the top. Because `dictionaries.py` overwrites `raw_entries[name]` last-write- wins, these unmapped duplicates downgraded their counterparts to the default `Sensor({})` at runtime — losing device class, options, icon, and the `diagnostic` entity_category. The bug was introduced in PR #412.

   Affected: `Child_lock_status_status`, `Current_temperature`, `Delaystart_delayend_remaining_time_in_minutes`, `Extra_rinse_status`, `Selected_program_Disinfection`, `Selected_program_anticrease_status`, `Selected_program_entry_steam_status`, `Selected_program_mode_status`, `Selected_program_prewash_status`, `Selected_program_rinse_hold_status`, `Selected_program_set_temperature_status`, `Selected_program_washing_spin_speed_rpm_status`, `Selected_program_water_pluse_status`, `StopAddGoAllowed`, `Stopaddgo_status`.

2. Mark 183 skeleton properties (no platform definition) as `optional: true` so they register disabled-by-default instead of surfacing as raw `Sensor({})` integers. Covers numbered `Alarm_*` and `Error_*` slots, settings, auto-dose / detergent / softener internals, pairing/remote-control diagnostics, FOTA, and `Selected_program_*` sub-flags.

`strings.json` and translations regenerated: stale `sensor.*` entries from the previously-masked properties move to their proper `binary_sensor.*` / `sensor.*` slots with translated states.