### PR TITLE
Improve mappings for hood (012)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/012.yaml
+++ b/custom_components/connectlife/data_dictionaries/012.yaml
@@ -1,123 +1,437 @@
+# Hood
 properties:
-  - property: ActiveModeLightBrightness
-    # Sample value: 0
-  - property: ActiveModeLightColorTemperature
-    # Sample value: 0
-  - property: ActiveModeLightStatus
-    # Sample value: 0
-  - property: ActiveModeMotorLevel
-    # Sample value: 0
-  - property: ActiveModeMotorLevelStatus
-    # Sample value: 0
-  - property: ActiveModeStatus
-    # Sample value: 0
-  - property: AlarmCleanAirEnded
-    # Sample value: 1
-  - property: AlarmGreaseFilter
-    # Sample value: 2
-  - property: AlarmRecirculationFilter1
-    # Sample value: 1
-  - property: AlarmRecirculationFilter2
-    # Sample value: 1
-  - property: AlarmTimerEnded
-    # Sample value: 1
-  - property: AmbientLightBrightness
-    # Sample value: 0
-  - property: AmbientLightColorTemperature
-    # Sample value: 0
-  - property: AmbientLightStatus
-    # Sample value: 0
-  - property: CirculationModeStatus
-    # Sample value: 1
-  - property: CleanAirActivePassedHours
-    # Sample value: 0
-  - property: CleanAirActiveTotalHours
-    # Sample value: 24
-  - property: CleanAirDurationOfCycleInMinutes
-    # Sample value: 10
-  - property: CleanAirMotorLevel
-    # Sample value: 1
-  - property: CleanAirRunCycleEveryNumberOfMinutes
-    # Sample value: 0
-  - property: CleanAirStartTime
-    # Sample value: 0002/11/30T00:00:00
-  - property: CleanAirStatus
-    # Sample value: 1
+  # Top-level operating state
   - property: DeviceStatus
-    # Sample value: 1
-  - property: FotaStatus
-    # Sample value: 0
-  - property: GreaseFilterCleaningIntervalInHours
-    # Sample value: 30
-  - property: GreaseFilterStatus
-    # Sample value: 2
-  - property: GreaseFilterUsedHours
-    # Sample value: 145
-  - property: HardPairingStatus
-    # Sample value: 0
-  - property: LightBrightness
-    number:
-      unit: "%"
-    icon: mdi:lightbulb-on-outline
-  - property: LightColorTemperature
-    number:
-      unit: "%"
-    icon: mdi:lightbulb-variant-outline
-  - property: LightStatus
-  - property: MotorLevel
-    select:
+    icon: mdi:range-hood
+    sensor:
+      device_class: enum
+      read_only: true
       options:
-        0: "0"
-        1: "1"
-        2: "2"
-        3: "3"
-        4: "4"
-        5: "5"
-  - property: ProximitySensor
-    # Sample value: 0
-  - property: ProximitySensorReactionTime
-    # Sample value: 0
-  - property: ProximitySensorSensitivity
-    # Sample value: 0
-  - property: ProximitySensorStatus
-    # Sample value: 0
-  - property: RFPairingStatus
-    # Sample value: 0
-  - property: RecirculationFilter1LifetimeInHours
-    # Sample value: 120
-  - property: RecirculationFilter1Status
-    # Sample value: 1
-  - property: RecirculationFilter1Type
-    # Sample value: 2
-  - property: RecirculationFilter1UsedHours
-    # Sample value: 0
-  - property: RecirculationFilter2LifetimeInHours
-    # Sample value: 0
-  - property: RecirculationFilter2Status
-    # Sample value: 1
-  - property: RecirculationFilter2Type
-    # Sample value: 1
-  - property: RecirculationFilter2UsedHours
-    # Sample value: 0
-  - property: RemoteControlMonitoringSetCommands
-    # Sample value: 2
-  - property: RemoteControlMonitoringSetCommandsActions
-    # Sample value: 0
-  - property: SessionPairing
-    # Sample value: 0
-  - property: SessionPairingActive
-    # Sample value: 0
-  - property: SessionPairingConfirmation
-    # Sample value: 0
-  - property: SoftPairing
-    # Sample value: 0
-  - property: TimerEndTime
-    # Sample value: 0002/11/30T00:00:00
-  - property: TimerPausedTime
-    # Sample value: 0002/11/30T00:00:00
-  - property: TimerPausedTotalSeconds
-    # Sample value: 0
-  - property: TimerStartTime
-    # Sample value: 0002/11/30T00:00:00
+        0: not_available
+        1: idle
+        2: service
+        3: production
+        4: running
+        5: reserved
+  - property: MotorLevel
+    icon: mdi:fan
+    sensor:
+      read_only: true
+      state_class: measurement
+  - property: LightStatus
+    icon: mdi:lightbulb
+    binary_sensor:
+      device_class: light
+      options:
+        0: false
+        1: false
+        2: true
+        3: false
+  - property: LightBrightness
+    icon: mdi:lightbulb-on
+    sensor:
+      read_only: true
+      unit: "%"
+      state_class: measurement
+  - property: LightColorTemperature
+    icon: mdi:thermometer
+    sensor:
+      read_only: true
+      unit: "%"
+      state_class: measurement
+  - property: CirculationModeStatus
+    icon: mdi:weather-windy
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: exhaust
+        2: recirculation
+        3: reserved
   - property: TimerStatus
-    # Sample value: 5
+    icon: mdi:timer
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: not_active
+        2: running
+        3: paused
+        4: stopped
+        5: ended
+        6: reserved
+  - property: TimerStartTime
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: timestamp
+      read_only: true
+  - property: TimerEndTime
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: timestamp
+      read_only: true
+  - property: TimerPausedTime
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: timestamp
+      read_only: true
+  - property: TimerPausedTotalSeconds
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: s
+      read_only: true
+
+  # Top-level alarms (problem class)
+  - property: AlarmGreaseFilter
+    hide: true
+    entity_category: diagnostic
+    icon: mdi:filter-variant-remove
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: false
+        2: true
+        3: false
+  - property: AlarmRecirculationFilter1
+    hide: true
+    entity_category: diagnostic
+    icon: mdi:filter-variant-remove
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: false
+        2: true
+        3: false
+  - property: AlarmRecirculationFilter2
+    hide: true
+    entity_category: diagnostic
+    icon: mdi:filter-variant-remove
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: false
+        2: true
+        3: false
+
+  # Event notifications
+  - property: AlarmCleanAirEnded
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: false
+        1: false
+        2: true
+        3: false
+  - property: AlarmTimerEnded
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: false
+        1: false
+        2: true
+        3: false
+
+  # Per-mode mirrors (active mode + ambient lighting)
+  - property: ActiveModeStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: not_active
+        2: active
+        3: reserved
+  - property: ActiveModeLightStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: "off"
+        2: "on"
+        3: reserved
+  - property: ActiveModeLightBrightness
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      unit: "%"
+      state_class: measurement
+  - property: ActiveModeLightColorTemperature
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      unit: "%"
+      state_class: measurement
+  - property: ActiveModeMotorLevel
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: ActiveModeMotorLevelStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: "off"
+        2: "on"
+        3: reserved
+  - property: AmbientLightStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: "off"
+        2: "on"
+        3: reserved
+  - property: AmbientLightBrightness
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      unit: "%"
+      state_class: measurement
+  - property: AmbientLightColorTemperature
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+      unit: "%"
+      state_class: measurement
+
+  # Clean air mode
+  - property: CleanAirStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: not_active
+        2: active
+        3: reserved
+  - property: CleanAirActivePassedHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+  - property: CleanAirActiveTotalHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+  - property: CleanAirDurationOfCycleInMinutes
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
+  - property: CleanAirMotorLevel
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: CleanAirRunCycleEveryNumberOfMinutes
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: min
+      read_only: true
+  - property: CleanAirStartTime
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: timestamp
+      read_only: true
+
+  # Grease filter housekeeping
+  - property: GreaseFilterStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: not_active
+        2: active
+        3: reserved
+  - property: GreaseFilterCleaningIntervalInHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+  - property: GreaseFilterUsedHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+
+  # Recirculation filter housekeeping
+  - property: RecirculationFilter1Status
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: RecirculationFilter1Type
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: RecirculationFilter1LifetimeInHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+  - property: RecirculationFilter1UsedHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+  - property: RecirculationFilter2Status
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: RecirculationFilter2Type
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: RecirculationFilter2LifetimeInHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+  - property: RecirculationFilter2UsedHours
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
+      read_only: true
+
+  # Proximity sensor
+  - property: ProximitySensorStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_available
+        1: not_active
+        2: active
+        3: reserved
+  - property: ProximitySensor
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: ProximitySensorReactionTime
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: ProximitySensorSensitivity
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+
+  # Pairing
+  - property: HardPairingStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: enum
+      read_only: true
+      options:
+        0: not_active
+        1: pairing_active
+        2: unpair_all_users
+        3: reserved
+  - property: SoftPairing
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: SessionPairing
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: SessionPairingActive
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: SessionPairingConfirmation
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: RFPairingStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+
+  # Remote control monitoring
+  - property: RemoteControlMonitoringSetCommands
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+  - property: RemoteControlMonitoringSetCommandsActions
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true
+
+  # Firmware over the air
+  - property: FotaStatus
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      read_only: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -291,6 +291,9 @@
       "alarmchild_lockon": {
         "name": "Alarmchild lockon"
       },
+      "alarmcleanairended": {
+        "name": "Alarm clean air ended"
+      },
       "alarmcleantank": {
         "name": "Alarm clean tank"
       },
@@ -315,6 +318,9 @@
       "alarmfilltank": {
         "name": "Alarm fill tank"
       },
+      "alarmgreasefilter": {
+        "name": "Alarm grease filter"
+      },
       "alarmincreased_power_consumption": {
         "name": "Alarm increased power consumption"
       },
@@ -335,6 +341,12 @@
       },
       "alarmprobe_lost_connection": {
         "name": "Alarmprobe lost connection"
+      },
+      "alarmrecirculationfilter1": {
+        "name": "Alarm recirculation filter 1"
+      },
+      "alarmrecirculationfilter2": {
+        "name": "Alarm recirculation filter 2"
       },
       "alarmremotestartpowerfailure": {
         "name": "Alarm remote start power failure"
@@ -362,6 +374,9 @@
       },
       "alarmtanklevel1": {
         "name": "Alarm tank level 1"
+      },
+      "alarmtimerended": {
+        "name": "Alarm timer ended"
       },
       "ali_wifi_fault_flag": {
         "name": "WiFi fault"
@@ -791,6 +806,9 @@
       },
       "light": {
         "name": "Light"
+      },
+      "lightstatus": {
+        "name": "Light status"
       },
       "lock_fresh_mode": {
         "name": "Lock fresh mode"
@@ -1666,12 +1684,6 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin function set time"
       },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
       "refrigerator_max_temperature": {
         "name": "Refrigerator max temperature"
       },
@@ -1822,9 +1834,6 @@
           "english": "English",
           "simplified_chinese": "Simplified chinese"
         }
-      },
-      "motorlevel": {
-        "name": "Motor level"
       },
       "notification_volumen_setting_status": {
         "name": "Notification volume",
@@ -2233,16 +2242,30 @@
         "name": "Active mode light color temperature"
       },
       "activemodelightstatus": {
-        "name": "Active mode light status"
+        "name": "Active mode light status",
+        "state": {
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "activemodemotorlevel": {
         "name": "Active mode motor level"
       },
       "activemodemotorlevelstatus": {
-        "name": "Active mode motor level status"
+        "name": "Active mode motor level status",
+        "state": {
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "activemodestatus": {
-        "name": "Active mode status"
+        "name": "Active mode status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "adapt_sense_setting_status": {
         "name": "Adapt sense setting status"
@@ -2367,21 +2390,6 @@
       "alarm_sound_volume": {
         "name": "Alarm sound volume"
       },
-      "alarmcleanairended": {
-        "name": "Alarm clean air ended"
-      },
-      "alarmgreasefilter": {
-        "name": "Alarm grease filter"
-      },
-      "alarmrecirculationfilter1": {
-        "name": "Alarm recirculation filter 1"
-      },
-      "alarmrecirculationfilter2": {
-        "name": "Alarm recirculation filter 2"
-      },
-      "alarmtimerended": {
-        "name": "Alarm timer ended"
-      },
       "almost_finished_notification_setting": {
         "name": "Almost finished notification setting"
       },
@@ -2398,7 +2406,11 @@
         "name": "Ambient light color temperature"
       },
       "ambientlightstatus": {
-        "name": "Ambient light status"
+        "name": "Ambient light status",
+        "state": {
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "ancreae_mux": {
         "name": "An creae mux"
@@ -2604,7 +2616,13 @@
         "name": "Circulation mode"
       },
       "circulationmodestatus": {
-        "name": "Circulation mode status"
+        "name": "Circulation mode status",
+        "state": {
+          "exhaust": "Exhaust",
+          "not_available": "Not available",
+          "recirculation": "Recirculation",
+          "reserved": "Reserved"
+        }
       },
       "clean_mode_switch_status": {
         "name": "Clean mode switch status"
@@ -2628,7 +2646,13 @@
         "name": "Clean air start time"
       },
       "cleanairstatus": {
-        "name": "Clean air status"
+        "name": "Clean air status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "coldwash": {
         "name": "Cold wash"
@@ -2959,7 +2983,15 @@
         }
       },
       "devicestatus": {
-        "name": "Device status"
+        "name": "Device status",
+        "state": {
+          "idle": "Idle",
+          "not_available": "Not available",
+          "production": "Production",
+          "reserved": "Reserved",
+          "running": "Running",
+          "service": "Service"
+        }
       },
       "display_brightness_setting_status": {
         "name": "Display brightness"
@@ -3815,7 +3847,13 @@
         "name": "Grease filter cleaning interval in hours"
       },
       "greasefilterstatus": {
-        "name": "Grease filter status"
+        "name": "Grease filter status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "greasefilterusedhours": {
         "name": "Grease filter used hours"
@@ -3837,6 +3875,7 @@
         "state": {
           "active": "Active",
           "not_active": "Not active",
+          "pairing_active": "Pairing active",
           "reserved": "Reserved",
           "unpair_all_users": "Unpair all users"
         }
@@ -4023,6 +4062,12 @@
       "lidopenflag": {
         "name": "Lid open flag"
       },
+      "lightbrightness": {
+        "name": "Light brightness"
+      },
+      "lightcolortemperature": {
+        "name": "Light color temperature"
+      },
       "lights_duration_setting": {
         "name": "Lights duration setting"
       },
@@ -4031,9 +4076,6 @@
       },
       "lightscolor_temperature_setting": {
         "name": "Lights color temperature setting"
-      },
-      "lightstatus": {
-        "name": "Light status"
       },
       "liquid_unit_setting_status": {
         "name": "Liquid unit setting status"
@@ -4153,6 +4195,9 @@
         "name": "Motor"
       },
       "motor_level": {
+        "name": "Motor level"
+      },
+      "motorlevel": {
         "name": "Motor level"
       },
       "navigation_sound_setting": {
@@ -4384,7 +4429,13 @@
         "name": "Proximity sensor sensitivity"
       },
       "proximitysensorstatus": {
-        "name": "Proximity sensor status"
+        "name": "Proximity sensor status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "pumcleanflag": {
         "name": "Pump clean flag"
@@ -7189,7 +7240,16 @@
         "name": "Timer start time"
       },
       "timerstatus": {
-        "name": "Timer status"
+        "name": "Timer status",
+        "state": {
+          "ended": "Ended",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "paused": "Paused",
+          "reserved": "Reserved",
+          "running": "Running",
+          "stopped": "Stopped"
+        }
       },
       "timezone": {
         "name": "Timezone"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1229,12 +1229,6 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin Zeiteinstellung"
       },
-      "lightbrightness": {
-        "name": "Lichthelligkeit"
-      },
-      "lightcolortemperature": {
-        "name": "Lichtfarbtemperatur"
-      },
       "refrigerator_max_temperature": {
         "name": "Maximale K\u00fchlschranktemperatur"
       },
@@ -1377,9 +1371,6 @@
           "english": "Englisch",
           "simplified_chinese": "Vereinfachtes Chinesisch"
         }
-      },
-      "motorlevel": {
-        "name": "Motorleistung"
       },
       "notification_volumen_setting_status": {
         "name": "Benachrichtigungslautst\u00e4rke",

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -291,6 +291,9 @@
       "alarmchild_lockon": {
         "name": "Alarmchild lockon"
       },
+      "alarmcleanairended": {
+        "name": "Alarm clean air ended"
+      },
       "alarmcleantank": {
         "name": "Alarm clean tank"
       },
@@ -315,6 +318,9 @@
       "alarmfilltank": {
         "name": "Alarm fill tank"
       },
+      "alarmgreasefilter": {
+        "name": "Alarm grease filter"
+      },
       "alarmincreased_power_consumption": {
         "name": "Alarm increased power consumption"
       },
@@ -335,6 +341,12 @@
       },
       "alarmprobe_lost_connection": {
         "name": "Alarmprobe lost connection"
+      },
+      "alarmrecirculationfilter1": {
+        "name": "Alarm recirculation filter 1"
+      },
+      "alarmrecirculationfilter2": {
+        "name": "Alarm recirculation filter 2"
       },
       "alarmremotestartpowerfailure": {
         "name": "Alarm remote start power failure"
@@ -362,6 +374,9 @@
       },
       "alarmtanklevel1": {
         "name": "Alarm tank level 1"
+      },
+      "alarmtimerended": {
+        "name": "Alarm timer ended"
       },
       "ali_wifi_fault_flag": {
         "name": "WiFi fault"
@@ -791,6 +806,9 @@
       },
       "light": {
         "name": "Light"
+      },
+      "lightstatus": {
+        "name": "Light status"
       },
       "lock_fresh_mode": {
         "name": "Lock fresh mode"
@@ -1666,12 +1684,6 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin function set time"
       },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
       "refrigerator_max_temperature": {
         "name": "Refrigerator max temperature"
       },
@@ -1822,9 +1834,6 @@
           "english": "English",
           "simplified_chinese": "Simplified chinese"
         }
-      },
-      "motorlevel": {
-        "name": "Motor level"
       },
       "notification_volumen_setting_status": {
         "name": "Notification volume",
@@ -2233,16 +2242,30 @@
         "name": "Active mode light color temperature"
       },
       "activemodelightstatus": {
-        "name": "Active mode light status"
+        "name": "Active mode light status",
+        "state": {
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "activemodemotorlevel": {
         "name": "Active mode motor level"
       },
       "activemodemotorlevelstatus": {
-        "name": "Active mode motor level status"
+        "name": "Active mode motor level status",
+        "state": {
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "activemodestatus": {
-        "name": "Active mode status"
+        "name": "Active mode status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "adapt_sense_setting_status": {
         "name": "Adapt sense setting status"
@@ -2367,21 +2390,6 @@
       "alarm_sound_volume": {
         "name": "Alarm sound volume"
       },
-      "alarmcleanairended": {
-        "name": "Alarm clean air ended"
-      },
-      "alarmgreasefilter": {
-        "name": "Alarm grease filter"
-      },
-      "alarmrecirculationfilter1": {
-        "name": "Alarm recirculation filter 1"
-      },
-      "alarmrecirculationfilter2": {
-        "name": "Alarm recirculation filter 2"
-      },
-      "alarmtimerended": {
-        "name": "Alarm timer ended"
-      },
       "almost_finished_notification_setting": {
         "name": "Almost finished notification setting"
       },
@@ -2398,7 +2406,11 @@
         "name": "Ambient light color temperature"
       },
       "ambientlightstatus": {
-        "name": "Ambient light status"
+        "name": "Ambient light status",
+        "state": {
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "ancreae_mux": {
         "name": "An creae mux"
@@ -2604,7 +2616,13 @@
         "name": "Circulation mode"
       },
       "circulationmodestatus": {
-        "name": "Circulation mode status"
+        "name": "Circulation mode status",
+        "state": {
+          "exhaust": "Exhaust",
+          "not_available": "Not available",
+          "recirculation": "Recirculation",
+          "reserved": "Reserved"
+        }
       },
       "clean_mode_switch_status": {
         "name": "Clean mode switch status"
@@ -2628,7 +2646,13 @@
         "name": "Clean air start time"
       },
       "cleanairstatus": {
-        "name": "Clean air status"
+        "name": "Clean air status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "coldwash": {
         "name": "Cold wash"
@@ -2959,7 +2983,15 @@
         }
       },
       "devicestatus": {
-        "name": "Device status"
+        "name": "Device status",
+        "state": {
+          "idle": "Idle",
+          "not_available": "Not available",
+          "production": "Production",
+          "reserved": "Reserved",
+          "running": "Running",
+          "service": "Service"
+        }
       },
       "display_brightness_setting_status": {
         "name": "Display brightness"
@@ -3815,7 +3847,13 @@
         "name": "Grease filter cleaning interval in hours"
       },
       "greasefilterstatus": {
-        "name": "Grease filter status"
+        "name": "Grease filter status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "greasefilterusedhours": {
         "name": "Grease filter used hours"
@@ -3837,6 +3875,7 @@
         "state": {
           "active": "Active",
           "not_active": "Not active",
+          "pairing_active": "Pairing active",
           "reserved": "Reserved",
           "unpair_all_users": "Unpair all users"
         }
@@ -4023,6 +4062,12 @@
       "lidopenflag": {
         "name": "Lid open flag"
       },
+      "lightbrightness": {
+        "name": "Light brightness"
+      },
+      "lightcolortemperature": {
+        "name": "Light color temperature"
+      },
       "lights_duration_setting": {
         "name": "Lights duration setting"
       },
@@ -4031,9 +4076,6 @@
       },
       "lightscolor_temperature_setting": {
         "name": "Lights color temperature setting"
-      },
-      "lightstatus": {
-        "name": "Light status"
       },
       "liquid_unit_setting_status": {
         "name": "Liquid unit setting status"
@@ -4153,6 +4195,9 @@
         "name": "Motor"
       },
       "motor_level": {
+        "name": "Motor level"
+      },
+      "motorlevel": {
         "name": "Motor level"
       },
       "navigation_sound_setting": {
@@ -4384,7 +4429,13 @@
         "name": "Proximity sensor sensitivity"
       },
       "proximitysensorstatus": {
-        "name": "Proximity sensor status"
+        "name": "Proximity sensor status",
+        "state": {
+          "active": "Active",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "reserved": "Reserved"
+        }
       },
       "pumcleanflag": {
         "name": "Pump clean flag"
@@ -7189,7 +7240,16 @@
         "name": "Timer start time"
       },
       "timerstatus": {
-        "name": "Timer status"
+        "name": "Timer status",
+        "state": {
+          "ended": "Ended",
+          "not_active": "Not active",
+          "not_available": "Not available",
+          "paused": "Paused",
+          "reserved": "Reserved",
+          "running": "Running",
+          "stopped": "Stopped"
+        }
       },
       "timezone": {
         "name": "Timezone"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1330,12 +1330,6 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin-instellingstijd"
       },
-      "lightbrightness": {
-        "name": "Lichthelderheid"
-      },
-      "lightcolortemperature": {
-        "name": "Kleurtemperatuur verlichting"
-      },
       "refrigerator_max_temperature": {
         "name": "Koelkast max temperatuur"
       },
@@ -1481,9 +1475,6 @@
           "english": "Engels",
           "simplified_chinese": "Vereenvoudigd Chinees"
         }
-      },
-      "motorlevel": {
-        "name": "Motorniveau"
       },
       "notification_volumen_setting_status": {
         "name": "Meldingsvolume",


### PR DESCRIPTION
Replace skeleton entries with proper platform definitions for all 56 properties. Previously every property fell through to the default `Sensor({})` — raw integers with no device class, no enum translation, no units.

- 7 top-level state entities visible by default (`DeviceStatus`, `MotorLevel`, `LightStatus`, `LightBrightness`, `LightColorTemperature`, `CirculationModeStatus`, `TimerStatus`).
- 3 problem-class filter alarms kept `hide: true` so faults surface without an opt-in step.
- 46 diagnostics, per-mode mirrors, filter/timer housekeeping, pairing and FOTA marked `optional: true`.
- Standard "0:not_available, 1:not_active, 2:active, 3:reserved" status fields map to `binary_sensor` with options `{0: false, 1: false, 2: true, 3: false}`.
- `strings.json` and translations regenerated.