### PR TITLE
Mark entities unavailable when device is offline

### DIFF
--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -78,4 +78,3 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
             else:
                 self._attr_is_on = None
                 _LOGGER.warning("Unknown value %d for %s", value, self.status)
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1

--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -270,7 +270,6 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
                 self._attr_preset_mode = preset_mode
 
         self._attr_hvac_mode = hvac_mode if is_on else HVACMode.OFF
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
 
     def get_temperature_limit(self, temperature_map: dict[str, int]) -> int | None:
         if temperature_map and self._attr_temperature_unit in temperature_map:

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -61,6 +61,18 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
                 if CONF_DISABLE_BEEP in device:
                     self._disable_beep = device[CONF_DISABLE_BEEP]
 
+    @property
+    def available(self) -> bool:
+        # CoordinatorEntity.available only checks last_update_success, so
+        # _attr_available is ignored. Combine both with the device's
+        # offline_state (1 == online) so unplugged devices show as
+        # unavailable in HA.
+        return (
+            super().available
+            and self.device_id in self.coordinator.data
+            and self.coordinator.data[self.device_id].offline_state == 1
+        )
+
     @callback
     @abstractmethod
     def update_state(self):

--- a/custom_components/connectlife/humidifier.py
+++ b/custom_components/connectlife/humidifier.py
@@ -133,7 +133,6 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
                         _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
                 else:
                     setattr(self, f"_attr_{target}", value)
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
 
     async def async_set_humidity(self, humidity):
         """Set new target humidity."""

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -84,7 +84,6 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
         if self.status in self.coordinator.data[self.device_id].status_list:
             value = self.coordinator.data[self.device_id].status_list[self.status]
             self._attr_native_value = value
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -146,11 +146,9 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
                     if self.multiplier is not None:
                         value *= self.multiplier
                     self._attr_native_value = value
-                self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
                 return
             elif self.status not in status_list:
                 self._attr_native_value = None
-                self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
                 return
         if self.status in status_list:
             value = status_list[self.status]
@@ -175,7 +173,6 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
                 if self.multiplier is not None and value is not None:
                     value *= self.multiplier  # type: ignore[operator]
                 self._attr_native_value = value
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
 
     async def async_set_value(self, value: int) -> None:
         """Set value for this sensor."""
@@ -212,12 +209,24 @@ class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], S
         """Initialize the energy sensor."""
         super().__init__(energy_coordinator)
         self._device_id = appliance.device_id
+        self._appliance_coordinator = appliance_coordinator
         self._attr_unique_id = f"{appliance.device_id}-daily_energy_kwh"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, appliance.device_id)},
         )
         appliance_coordinator.add_entity(self._attr_unique_id, Platform.SENSOR)
         self._update_native_value()
+
+    @property
+    def available(self) -> bool:
+        appliance = self._appliance_coordinator.data.get(self._device_id)
+        return (
+            super().available
+            and appliance is not None
+            and appliance.offline_state == 1
+            and self.coordinator.data is not None
+            and self.coordinator.data.get(self._device_id) is not None
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -228,9 +237,6 @@ class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], S
     def _update_native_value(self) -> None:
         """Update native value from energy coordinator data."""
         if self.coordinator.data and self._device_id in self.coordinator.data:
-            value = self.coordinator.data[self._device_id]
-            self._attr_native_value = value
-            self._attr_available = value is not None
+            self._attr_native_value = self.coordinator.data[self._device_id]
         else:
             self._attr_native_value = None
-            self._attr_available = False

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -83,7 +83,6 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
             else:
                 self._attr_is_on = None
                 _LOGGER.warning("Unknown value %s for %s", str(value), self.status)
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
 
     async def async_turn_off(self, **kwargs):
         """Turn off."""

--- a/custom_components/connectlife/water_heater.py
+++ b/custom_components/connectlife/water_heater.py
@@ -205,8 +205,6 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
             elif CURRENT_OPERATION not in self.target_map:
                 self._attr_current_operation = STATE_ON
 
-        self._attr_available = self.coordinator.data[self.device_id].offline_state == 1
-
     def get_temperature_limit(self, temperature_map: dict[str, int]) -> int | None:
         if temperature_map and self._attr_temperature_unit in temperature_map:
             return temperature_map[self._attr_temperature_unit]


### PR DESCRIPTION
## Summary
- `CoordinatorEntity.available` is a property returning `coordinator.last_update_success`, so all the `self._attr_available = ... offline_state == 1` lines across the platform files were no-ops. Entities stayed available as long as the cloud responded, regardless of the device's actual offline state.
- Override `available` on `ConnectLifeEntity` to AND `super().available` with `offline_state == 1` (and presence in `coordinator.data`), then drop the dead assignments in each platform's `update_state`.
- `ConnectLifeEnergySensor` uses the separate energy coordinator, so it gets its own `available` override that consults the appliance coordinator for offline state.

Closes #483