### PR TITLE
Add portable AC (006) feature codes 202 and 203

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -3,6 +3,8 @@
 |----------------------|--------------------------|------------------|------------------------|
 | AP10TW1RLR-N         | Portable air conditioner | 006              | 200                    |
 |                      | Portable air conditioner | 006              | 201                    |
+|                      | Portable air conditioner | 006              | 202                    |
+|                      | Portable air conditioner | 006              | 203                    |
 |                      | Dehumidifier             | 007              | 400                    |
 |                      | Dehumidifier             | 007              | 406                    |
 |                      | Air conditioner          | 008              | 301                    |

--- a/custom_components/connectlife/data_dictionaries/006-202.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-202.yaml
@@ -1,0 +1,9 @@
+# Portable air conditioner — cool-only (no heat mode)
+properties:
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto

--- a/custom_components/connectlife/data_dictionaries/006-203.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-203.yaml
@@ -1,0 +1,1 @@
+# Portable air conditioner — uses default mappings


### PR DESCRIPTION
## Summary
- Add `006-202.yaml` (cool-only override, like `006-200`)
- Add `006-203.yaml` (uses base defaults, like `006-201`)
- List both feature codes in `DEVICES.md`

These two files were intended for #506 but were left untracked at commit time.