### PR TITLE
Map t_fanspeedcv lowercase variant on AC (009)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -306,6 +306,12 @@ properties:
       max_value: 100
       unit: "%"
     icon: mdi:fan
+  - property: t_fanspeedcv
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:fan
   - property: t_fresh_air
     switch:
       device_class: switch


### PR DESCRIPTION
## Summary
Some 009 firmwares expose the variable fan speed property in lowercase (`t_fanspeedcv`) while others use mixed case (`t_fanspeedCV`). The existing mapping only handled mixed case, so devices reporting lowercase got no entity for variable fan speed.

This adds a second mapping for the lowercase form. A device only ever reports one case, so only one entity is created per appliance. The integration's translation key lookup is already lowercased, so both share the existing `t_fanspeedcv` translation ("Variable fan speed").

## Evidence
- Mixed case (`t_fanspeedCV`) confirmed on 009-104 in #331
- Lowercase (`t_fanspeedcv`) seen on 009-106, 009-109, and 006-200 dumps

## Test plan
- [ ] `uv run python -m scripts.validate_mappings` succeeds
- [ ] Devices reporting `t_fanspeedcv` now expose a Variable fan speed number entity
- [ ] Devices reporting `t_fanspeedCV` continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)