### PR TITLE
Improve mappings for window AC (008)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -7,8 +7,18 @@
 |                      | Portable air conditioner | 006              | 203                    |
 |                      | Dehumidifier             | 007              | 400                    |
 |                      | Dehumidifier             | 007              | 406                    |
+|                      | Air conditioner          | 008              | 300                    |
 |                      | Air conditioner          | 008              | 301                    |
+|                      | Air conditioner          | 008              | 302                    |
+|                      | Air conditioner          | 008              | 303                    |
 |                      | Air conditioner          | 008              | 304                    |
+|                      | Air conditioner          | 008              | 305                    |
+|                      | Air conditioner          | 008              | 306                    |
+|                      | Air conditioner          | 008              | 307                    |
+|                      | Air conditioner          | 008              | 308                    |
+|                      | Air conditioner          | 008              | 309                    |
+|                      | Air conditioner          | 008              | 310                    |
+|                      | Air conditioner          | 008              | 311                    |
 | AWUS1225TW           | Air conditioner          | 008              | 399                    |
 |                      | Air conditioner          | 009              | 100                    |
 |                      | Air conditioner          | 009              | 101                    |

--- a/custom_components/connectlife/data_dictionaries/008-300.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-300.yaml
@@ -1,0 +1,1 @@
+# Window air conditioner — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/008-301.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-301.yaml
@@ -6,8 +6,3 @@ properties:
         2: low
         3: medium
         4: high
-  - property: t_temp
-    climate:
-      max_value:
-        celsius: 30
-        fahrenheit: 86

--- a/custom_components/connectlife/data_dictionaries/008-302.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-302.yaml
@@ -1,0 +1,10 @@
+# Window air conditioner — heat-supporting
+properties:
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        1: heat
+        2: cool
+        3: dry
+        5: eco

--- a/custom_components/connectlife/data_dictionaries/008-303.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-303.yaml
@@ -1,0 +1,10 @@
+# Window air conditioner — heat-supporting
+properties:
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        1: heat
+        2: cool
+        3: dry
+        5: eco

--- a/custom_components/connectlife/data_dictionaries/008-305.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-305.yaml
@@ -1,0 +1,1 @@
+# Window air conditioner — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/008-306.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-306.yaml
@@ -1,0 +1,1 @@
+# Window air conditioner — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/008-307.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-307.yaml
@@ -1,0 +1,1 @@
+# Window air conditioner — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/008-308.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-308.yaml
@@ -1,0 +1,10 @@
+# Window air conditioner — heat-supporting
+properties:
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        1: heat
+        2: cool
+        3: dry
+        5: eco

--- a/custom_components/connectlife/data_dictionaries/008-309.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-309.yaml
@@ -1,0 +1,10 @@
+# Window air conditioner — heat-supporting
+properties:
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        1: heat
+        2: cool
+        3: dry
+        5: eco

--- a/custom_components/connectlife/data_dictionaries/008-310.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-310.yaml
@@ -1,0 +1,1 @@
+# Window air conditioner — uses default mappings

--- a/custom_components/connectlife/data_dictionaries/008-311.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-311.yaml
@@ -1,0 +1,10 @@
+# Window air conditioner — heat-supporting
+properties:
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        1: heat
+        2: cool
+        3: dry
+        5: eco

--- a/custom_components/connectlife/data_dictionaries/008-399.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-399.yaml
@@ -7,8 +7,3 @@ properties:
         5: low
         7: medium
         9: high
-  - property: t_temp
-    climate:
-      max_value:
-        celsius: 30
-        fahrenheit: 86

--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -1,5 +1,12 @@
 # Window air conditioner
 properties:
+  - property: f-filter
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    icon: mdi:air-filter
   - property: f_e_arkgrille
     binary_sensor:
       device_class: problem
@@ -210,6 +217,20 @@ properties:
       read_only: true
     optional: true
     entity_category: diagnostic
+  - property: f_power_consumption
+    sensor:
+      device_class: energy
+      unit: kWh
+      read_only: true
+      state_class: total_increasing
+    icon: mdi:lightning-bolt
+  - property: f_power_display
+    sensor:
+      device_class: power
+      unit: W
+      read_only: true
+      state_class: measurement
+    icon: mdi:lightning-bolt
   - property: f_temp_in
     icon: mdi:thermometer
     climate:
@@ -218,6 +239,7 @@ properties:
     sensor:
       device_class: voltage
       unit: V
+      state_class: measurement
     optional: true
     entity_category: diagnostic
   - property: measured_grid_voltage
@@ -234,6 +256,16 @@ properties:
         1: on
     optional: true
     entity_category: diagnostic
+  - property: t_dal
+    switch:
+      device_class: switch
+    optional: true
+  - property: t_demand_response
+    switch:
+      device_class: switch
+    optional: true
+  - property: t_device_info
+    disable: true
   - property: t_dimmer
     switch:
       device_class: switch
@@ -257,6 +289,12 @@ properties:
         4: high
   - property: t_fan_speed_s
     disable: true
+  - property: t_fanspeedCV
+    number:
+      min_value: 0
+      max_value: 100
+      unit: "%"
+    icon: mdi:fan
   - property: t_power
     climate:
       target: is_on
@@ -268,6 +306,10 @@ properties:
     switch:
       device_class: switch
     icon: mdi:run-fast
+  - property: t_talr
+    switch:
+      device_class: switch
+    optional: true
   - property: t_temp
     climate:
       target: target_temperature
@@ -275,8 +317,8 @@ properties:
         celsius: 16
         fahrenheit: 61
       max_value:
-        celsius: 32
-        fahrenheit: 90
+        celsius: 30
+        fahrenheit: 86
   - property: t_temp_type
     climate:
       target: temperature_unit


### PR DESCRIPTION
## Summary

Add subtype overlays for the full set of window AC feature codes and expand the base mapping with properties used across the family.

### Added feature codes
- `008-300`, `008-305`, `008-306`, `008-307`, `008-310` — placeholders that inherit base defaults
- `008-302`, `008-303`, `008-308`, `008-309`, `008-311` — heat-supporting overrides for `t_work_mode`

### Default `008.yaml` changes
- Add `f-filter` (binary sensor, problem class)
- Add `f_power_consumption` (energy, kWh) and `f_power_display` (power, W)
- Add `t_dal`, `t_demand_response`, `t_talr` as optional switches
- Add `t_device_info` (disabled)
- Add `t_fanspeedCV` (number 0-100%)
- Lower `t_temp` max from 32 to 30 °C (90 to 86 °F)
- Add `state_class: measurement` to `f_votage`

### Simplified
- `008-301`: drop now-redundant `t_temp` override
- `008-399`: drop now-redundant `t_temp` override