### PR TITLE
Improve mappings for hood (012)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/012.yaml
+++ b/custom_components/connectlife/data_dictionaries/012.yaml
@@ -17,38 +17,35 @@ properties:
     icon: mdi:fan
     sensor:
       read_only: true
-      state_class: measurement
   - property: LightStatus
     icon: mdi:lightbulb
-    binary_sensor:
-      device_class: light
-      options:
-        0: false
-        1: false
-        2: true
-        3: false
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: LightSetting
+        adjust: 1
   - property: LightBrightness
     icon: mdi:lightbulb-on
     sensor:
       read_only: true
       unit: "%"
-      state_class: measurement
   - property: LightColorTemperature
     icon: mdi:thermometer
     sensor:
       read_only: true
       unit: "%"
-      state_class: measurement
   - property: CirculationModeStatus
     icon: mdi:weather-windy
-    sensor:
-      device_class: enum
-      read_only: true
+    unavailable: 0
+    select:
       options:
-        0: not_available
         1: exhaust
         2: recirculation
-        3: reserved
+      command:
+        name: CirculationModeSetting
+        adjust: 1
   - property: TimerStatus
     icon: mdi:timer
     sensor:
@@ -62,6 +59,14 @@ properties:
         4: stopped
         5: ended
         6: reserved
+  - property: TimerSetting
+    icon: mdi:timer-cog
+    select:
+      options:
+        0: not_active
+        1: start
+        2: pause
+        3: stop
   - property: TimerStartTime
     optional: true
     entity_category: diagnostic
@@ -87,6 +92,7 @@ properties:
       device_class: duration
       unit: s
       read_only: true
+      state_class: total_increasing
 
   # Top-level alarms (problem class)
   - property: AlarmGreaseFilter
@@ -146,40 +152,34 @@ properties:
   # Per-mode mirrors (active mode + ambient lighting)
   - property: ActiveModeStatus
     optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: not_active
-        2: active
-        3: reserved
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: ActiveModeSetting
+        adjust: 1
   - property: ActiveModeLightStatus
     optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: "off"
-        2: "on"
-        3: reserved
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: ActiveModeLightSetting
+        adjust: 1
   - property: ActiveModeLightBrightness
     optional: true
     entity_category: diagnostic
     sensor:
       read_only: true
       unit: "%"
-      state_class: measurement
   - property: ActiveModeLightColorTemperature
     optional: true
     entity_category: diagnostic
     sensor:
       read_only: true
       unit: "%"
-      state_class: measurement
   - property: ActiveModeMotorLevel
     optional: true
     entity_category: diagnostic
@@ -187,53 +187,45 @@ properties:
       read_only: true
   - property: ActiveModeMotorLevelStatus
     optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: "off"
-        2: "on"
-        3: reserved
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: ActiveModeMotorLevelSetting
+        adjust: 1
   - property: AmbientLightStatus
     optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: "off"
-        2: "on"
-        3: reserved
+    unavailable: 0
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: AmbientLightSetting
+        adjust: 1
   - property: AmbientLightBrightness
     optional: true
     entity_category: diagnostic
     sensor:
       read_only: true
       unit: "%"
-      state_class: measurement
   - property: AmbientLightColorTemperature
     optional: true
     entity_category: diagnostic
     sensor:
       read_only: true
       unit: "%"
-      state_class: measurement
 
   # Clean air mode
   - property: CleanAirStatus
-    optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: not_active
-        2: active
-        3: reserved
+    unavailable: 0
+    icon: mdi:air-filter
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: CleanAirActive
+        adjust: 1
   - property: CleanAirActivePassedHours
     optional: true
     entity_category: diagnostic
@@ -241,6 +233,7 @@ properties:
       device_class: duration
       unit: h
       read_only: true
+      state_class: total_increasing
   - property: CleanAirActiveTotalHours
     optional: true
     entity_category: diagnostic
@@ -248,6 +241,7 @@ properties:
       device_class: duration
       unit: h
       read_only: true
+      state_class: total_increasing
   - property: CleanAirDurationOfCycleInMinutes
     optional: true
     entity_category: diagnostic
@@ -277,15 +271,14 @@ properties:
   # Grease filter housekeeping
   - property: GreaseFilterStatus
     optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: not_active
-        2: active
-        3: reserved
+    unavailable: 0
+    icon: mdi:filter-variant
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: GreaseFilterTimerActive
+        adjust: 1
   - property: GreaseFilterCleaningIntervalInHours
     optional: true
     entity_category: diagnostic
@@ -293,6 +286,21 @@ properties:
       device_class: duration
       unit: h
       read_only: true
+  - property: GreaseFilterSetLifetimeInHours
+    optional: true
+    entity_category: config
+    icon: mdi:filter-cog
+    number:
+      device_class: duration
+      unit: h
+  - property: GreaseFilterResetCounter
+    optional: true
+    entity_category: config
+    icon: mdi:filter-remove
+    select:
+      options:
+        0: not_active
+        1: reset
   - property: GreaseFilterUsedHours
     optional: true
     entity_category: diagnostic
@@ -300,6 +308,7 @@ properties:
       device_class: duration
       unit: h
       read_only: true
+      state_class: total_increasing
 
   # Recirculation filter housekeeping
   - property: RecirculationFilter1Status
@@ -326,6 +335,7 @@ properties:
       device_class: duration
       unit: h
       read_only: true
+      state_class: total_increasing
   - property: RecirculationFilter2Status
     optional: true
     entity_category: diagnostic
@@ -350,19 +360,26 @@ properties:
       device_class: duration
       unit: h
       read_only: true
+      state_class: total_increasing
 
   # Proximity sensor
   - property: ProximitySensorStatus
     optional: true
-    entity_category: diagnostic
-    sensor:
-      device_class: enum
-      read_only: true
-      options:
-        0: not_available
-        1: not_active
-        2: active
-        3: reserved
+    unavailable: 0
+    icon: mdi:motion-sensor
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: ProximitySensorSetting
+        adjust: 1
+  - property: ProximitySensorSetAvalibility
+    optional: true
+    entity_category: config
+    icon: mdi:motion-sensor
+    switch:
+      "off": 0
+      "on": 1
   - property: ProximitySensor
     optional: true
     entity_category: diagnostic

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1032,9 +1032,6 @@
       "light": {
         "name": "Light"
       },
-      "lightstatus": {
-        "name": "Light status"
-      },
       "lock_fresh_mode": {
         "name": "Lock fresh mode"
       },
@@ -1954,6 +1951,9 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin function set time"
       },
+      "greasefiltersetlifetimeinhours": {
+        "name": "Grease filter lifetime"
+      },
       "programoptiontimestartdelayhour": {
         "name": "Start delay hours"
       },
@@ -2022,6 +2022,13 @@
           "level_3": "Level 3",
           "level_4": "Level 4",
           "level_5": "Level 5"
+        }
+      },
+      "circulationmodestatus": {
+        "name": "Circulation mode",
+        "state": {
+          "exhaust": "Exhaust",
+          "recirculation": "Recirculation"
         }
       },
       "condensewatermode": {
@@ -2133,6 +2140,13 @@
           "low": "Low",
           "mid": "Mid",
           "mute": "Mute"
+        }
+      },
+      "greasefilterresetcounter": {
+        "name": "Reset grease filter counter",
+        "state": {
+          "not_active": "Not active",
+          "reset": "Reset"
         }
       },
       "language_status": {
@@ -2556,6 +2570,15 @@
           "time": "Time"
         }
       },
+      "timersetting": {
+        "name": "Timer action",
+        "state": {
+          "not_active": "Not active",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
       "volume": {
         "name": "Volume",
         "state": {
@@ -2594,31 +2617,8 @@
       "activemodelightcolortemperature": {
         "name": "Active mode light color temperature"
       },
-      "activemodelightstatus": {
-        "name": "Active mode light status",
-        "state": {
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
-      },
       "activemodemotorlevel": {
         "name": "Active mode motor level"
-      },
-      "activemodemotorlevelstatus": {
-        "name": "Active mode motor level status",
-        "state": {
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
-      },
-      "activemodestatus": {
-        "name": "Active mode status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "adapt_sense_setting_status": {
         "name": "Adapt sense setting status"
@@ -2757,13 +2757,6 @@
       },
       "ambientlightcolortemperature": {
         "name": "Ambient light color temperature"
-      },
-      "ambientlightstatus": {
-        "name": "Ambient light status",
-        "state": {
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "ancreae_mux": {
         "name": "An creae mux"
@@ -2980,15 +2973,6 @@
       "circulation_mode": {
         "name": "Circulation mode"
       },
-      "circulationmodestatus": {
-        "name": "Circulation mode status",
-        "state": {
-          "exhaust": "Exhaust",
-          "not_available": "Not available",
-          "recirculation": "Recirculation",
-          "reserved": "Reserved"
-        }
-      },
       "clean_mode_switch_status": {
         "name": "Clean mode switch status"
       },
@@ -3009,15 +2993,6 @@
       },
       "cleanairstarttime": {
         "name": "Clean air start time"
-      },
-      "cleanairstatus": {
-        "name": "Clean air status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "cleancondensefilter": {
         "name": "Clean condenser filter"
@@ -4356,15 +4331,6 @@
       "greasefiltercleaningintervalinhours": {
         "name": "Grease filter cleaning interval in hours"
       },
-      "greasefilterstatus": {
-        "name": "Grease filter status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
-      },
       "greasefilterusedhours": {
         "name": "Grease filter used hours"
       },
@@ -4979,15 +4945,6 @@
       },
       "proximitysensorsensitivity": {
         "name": "Proximity sensor sensitivity"
-      },
-      "proximitysensorstatus": {
-        "name": "Proximity sensor status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "pumcleanflag": {
         "name": "Pump clean flag"
@@ -8293,6 +8250,15 @@
       }
     },
     "switch": {
+      "activemodelightstatus": {
+        "name": "Active mode light"
+      },
+      "activemodemotorlevelstatus": {
+        "name": "Active mode motor"
+      },
+      "activemodestatus": {
+        "name": "Active mode"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptive sense setting"
       },
@@ -8301,6 +8267,9 @@
       },
       "allergymodeenable": {
         "name": "Allergy mode"
+      },
+      "ambientlightstatus": {
+        "name": "Ambient light"
       },
       "anticrease": {
         "name": "Anti-crease"
@@ -8350,6 +8319,9 @@
       "childlockenabled": {
         "name": "Child lock"
       },
+      "cleanairstatus": {
+        "name": "Clean air"
+      },
       "coldwash": {
         "name": "Cold wash"
       },
@@ -8376,6 +8348,9 @@
       },
       "fota_cmd": {
         "name": "Firmware update"
+      },
+      "greasefilterstatus": {
+        "name": "Grease filter timer"
       },
       "heater2enable": {
         "name": "Auxiliary heater"
@@ -8404,6 +8379,9 @@
       "key_sound": {
         "name": "Key sound"
       },
+      "lightstatus": {
+        "name": "Light"
+      },
       "mute": {
         "name": "Mute"
       },
@@ -8421,6 +8399,12 @@
       },
       "programoptionanticrease": {
         "name": "Anti-crease"
+      },
+      "proximitysensorsetavalibility": {
+        "name": "Proximity sensor available"
+      },
+      "proximitysensorstatus": {
+        "name": "Proximity sensor"
       },
       "save_mode": {
         "name": "Save mode"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1032,9 +1032,6 @@
       "light": {
         "name": "Light"
       },
-      "lightstatus": {
-        "name": "Light status"
-      },
       "lock_fresh_mode": {
         "name": "Lock fresh mode"
       },
@@ -1954,6 +1951,9 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin function set time"
       },
+      "greasefiltersetlifetimeinhours": {
+        "name": "Grease filter lifetime"
+      },
       "programoptiontimestartdelayhour": {
         "name": "Start delay hours"
       },
@@ -2022,6 +2022,13 @@
           "level_3": "Level 3",
           "level_4": "Level 4",
           "level_5": "Level 5"
+        }
+      },
+      "circulationmodestatus": {
+        "name": "Circulation mode",
+        "state": {
+          "exhaust": "Exhaust",
+          "recirculation": "Recirculation"
         }
       },
       "condensewatermode": {
@@ -2133,6 +2140,13 @@
           "low": "Low",
           "mid": "Mid",
           "mute": "Mute"
+        }
+      },
+      "greasefilterresetcounter": {
+        "name": "Reset grease filter counter",
+        "state": {
+          "not_active": "Not active",
+          "reset": "Reset"
         }
       },
       "language_status": {
@@ -2556,6 +2570,15 @@
           "time": "Time"
         }
       },
+      "timersetting": {
+        "name": "Timer action",
+        "state": {
+          "not_active": "Not active",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
       "volume": {
         "name": "Volume",
         "state": {
@@ -2594,31 +2617,8 @@
       "activemodelightcolortemperature": {
         "name": "Active mode light color temperature"
       },
-      "activemodelightstatus": {
-        "name": "Active mode light status",
-        "state": {
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
-      },
       "activemodemotorlevel": {
         "name": "Active mode motor level"
-      },
-      "activemodemotorlevelstatus": {
-        "name": "Active mode motor level status",
-        "state": {
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
-      },
-      "activemodestatus": {
-        "name": "Active mode status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "adapt_sense_setting_status": {
         "name": "Adapt sense setting status"
@@ -2757,13 +2757,6 @@
       },
       "ambientlightcolortemperature": {
         "name": "Ambient light color temperature"
-      },
-      "ambientlightstatus": {
-        "name": "Ambient light status",
-        "state": {
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "ancreae_mux": {
         "name": "An creae mux"
@@ -2980,15 +2973,6 @@
       "circulation_mode": {
         "name": "Circulation mode"
       },
-      "circulationmodestatus": {
-        "name": "Circulation mode status",
-        "state": {
-          "exhaust": "Exhaust",
-          "not_available": "Not available",
-          "recirculation": "Recirculation",
-          "reserved": "Reserved"
-        }
-      },
       "clean_mode_switch_status": {
         "name": "Clean mode switch status"
       },
@@ -3009,15 +2993,6 @@
       },
       "cleanairstarttime": {
         "name": "Clean air start time"
-      },
-      "cleanairstatus": {
-        "name": "Clean air status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "cleancondensefilter": {
         "name": "Clean condenser filter"
@@ -4356,15 +4331,6 @@
       "greasefiltercleaningintervalinhours": {
         "name": "Grease filter cleaning interval in hours"
       },
-      "greasefilterstatus": {
-        "name": "Grease filter status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
-      },
       "greasefilterusedhours": {
         "name": "Grease filter used hours"
       },
@@ -4979,15 +4945,6 @@
       },
       "proximitysensorsensitivity": {
         "name": "Proximity sensor sensitivity"
-      },
-      "proximitysensorstatus": {
-        "name": "Proximity sensor status",
-        "state": {
-          "active": "Active",
-          "not_active": "Not active",
-          "not_available": "Not available",
-          "reserved": "Reserved"
-        }
       },
       "pumcleanflag": {
         "name": "Pump clean flag"
@@ -8293,6 +8250,15 @@
       }
     },
     "switch": {
+      "activemodelightstatus": {
+        "name": "Active mode light"
+      },
+      "activemodemotorlevelstatus": {
+        "name": "Active mode motor"
+      },
+      "activemodestatus": {
+        "name": "Active mode"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptive sense setting"
       },
@@ -8301,6 +8267,9 @@
       },
       "allergymodeenable": {
         "name": "Allergy mode"
+      },
+      "ambientlightstatus": {
+        "name": "Ambient light"
       },
       "anticrease": {
         "name": "Anti-crease"
@@ -8350,6 +8319,9 @@
       "childlockenabled": {
         "name": "Child lock"
       },
+      "cleanairstatus": {
+        "name": "Clean air"
+      },
       "coldwash": {
         "name": "Cold wash"
       },
@@ -8376,6 +8348,9 @@
       },
       "fota_cmd": {
         "name": "Firmware update"
+      },
+      "greasefilterstatus": {
+        "name": "Grease filter timer"
       },
       "heater2enable": {
         "name": "Auxiliary heater"
@@ -8404,6 +8379,9 @@
       "key_sound": {
         "name": "Key sound"
       },
+      "lightstatus": {
+        "name": "Light"
+      },
       "mute": {
         "name": "Mute"
       },
@@ -8421,6 +8399,12 @@
       },
       "programoptionanticrease": {
         "name": "Anti-crease"
+      },
+      "proximitysensorsetavalibility": {
+        "name": "Proximity sensor available"
+      },
+      "proximitysensorstatus": {
+        "name": "Proximity sensor"
       },
       "save_mode": {
         "name": "Save mode"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -807,9 +807,6 @@
       "light": {
         "name": "Verlichting"
       },
-      "lightstatus": {
-        "name": "Verlichting status"
-      },
       "lock_fresh_mode": {
         "name": "Vershoudmodus vergrendeling"
       },
@@ -1684,6 +1681,9 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin-instellingstijd"
       },
+      "greasefiltersetlifetimeinhours": {
+        "name": "Vetfilter levensduur"
+      },
       "refrigerator_max_temperature": {
         "name": "Koelkast max temperatuur"
       },
@@ -1740,6 +1740,13 @@
       },
       "brightness": {
         "name": "Helderheid"
+      },
+      "circulationmodestatus": {
+        "name": "Circulatiemodus",
+        "state": {
+          "exhaust": "Afvoer",
+          "recirculation": "Recirculatie"
+        }
       },
       "cooking_intensity": {
         "name": "Kookintensiteit"
@@ -1826,6 +1833,13 @@
           "low": "Laag",
           "mid": "Midden",
           "mute": "Stil"
+        }
+      },
+      "greasefilterresetcounter": {
+        "name": "Vetfiltertelling resetten",
+        "state": {
+          "not_active": "Niet actief",
+          "reset": "Resetten"
         }
       },
       "language_status": {
@@ -2210,6 +2224,15 @@
           "not_set": "Niet ingesteld"
         }
       },
+      "timersetting": {
+        "name": "Timeractie",
+        "state": {
+          "not_active": "Niet actief",
+          "pause": "Pauze",
+          "start": "Start",
+          "stop": "Stop"
+        }
+      },
       "volume": {
         "name": "Volume"
       },
@@ -2241,31 +2264,8 @@
       "activemodelightcolortemperature": {
         "name": "Kleurtemperatuur verlichting actieve modus"
       },
-      "activemodelightstatus": {
-        "name": "Status verlichting actieve modus",
-        "state": {
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
-      },
       "activemodemotorlevel": {
         "name": "Motorniveau actieve modus"
-      },
-      "activemodemotorlevelstatus": {
-        "name": "Status motorniveau actieve modus",
-        "state": {
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
-      },
-      "activemodestatus": {
-        "name": "Actieve modus",
-        "state": {
-          "active": "Actief",
-          "not_active": "Niet actief",
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
       },
       "adapt_sense_setting_status": {
         "name": "Adapt Sense-instelling"
@@ -2404,13 +2404,6 @@
       },
       "ambientlightcolortemperature": {
         "name": "Kleurtemperatuur sfeerverlichting"
-      },
-      "ambientlightstatus": {
-        "name": "Sfeerverlichting status",
-        "state": {
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
       },
       "ancreae_mux": {
         "name": "An creae mux"
@@ -2612,15 +2605,6 @@
       "circulation_mode": {
         "name": "Circulatiemodus"
       },
-      "circulationmodestatus": {
-        "name": "Circulatiemodus status",
-        "state": {
-          "exhaust": "Afvoer",
-          "not_available": "Niet beschikbaar",
-          "recirculation": "Recirculatie",
-          "reserved": "Gereserveerd"
-        }
-      },
       "clean_mode_switch_status": {
         "name": "Reinigingsmodus schakelaar status"
       },
@@ -2641,15 +2625,6 @@
       },
       "cleanairstarttime": {
         "name": "Starttijd schone lucht"
-      },
-      "cleanairstatus": {
-        "name": "Status schone lucht",
-        "state": {
-          "active": "Actief",
-          "not_active": "Niet actief",
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
       },
       "coldwash": {
         "name": "Koude was"
@@ -3840,15 +3815,6 @@
       "greasefiltercleaningintervalinhours": {
         "name": "Vetfilter reinigingsinterval in uren"
       },
-      "greasefilterstatus": {
-        "name": "Vetfilter status",
-        "state": {
-          "active": "Actief",
-          "not_active": "Niet actief",
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
-      },
       "greasefilterusedhours": {
         "name": "Vetfilter gebruikte uren"
       },
@@ -4421,15 +4387,6 @@
       },
       "proximitysensorsensitivity": {
         "name": "Nabijheidssensor gevoeligheid"
-      },
-      "proximitysensorstatus": {
-        "name": "Nabijheidssensor status",
-        "state": {
-          "active": "Actief",
-          "not_active": "Niet actief",
-          "not_available": "Niet beschikbaar",
-          "reserved": "Gereserveerd"
-        }
       },
       "pumcleanflag": {
         "name": "Pomp schoonmaken"
@@ -7668,8 +7625,20 @@
       }
     },
     "switch": {
+      "activemodelightstatus": {
+        "name": "Verlichting actieve modus"
+      },
+      "activemodemotorlevelstatus": {
+        "name": "Motor actieve modus"
+      },
+      "activemodestatus": {
+        "name": "Actieve modus"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptive sense instelling"
+      },
+      "ambientlightstatus": {
+        "name": "Sfeerverlichting"
       },
       "anticrease": {
         "name": "Anti-kreuk"
@@ -7716,6 +7685,9 @@
       "child_lock": {
         "name": "Kinderbeveiliging"
       },
+      "cleanairstatus": {
+        "name": "Schone lucht"
+      },
       "crisp_function_status": {
         "name": "Crisp-functie"
       },
@@ -7733,6 +7705,9 @@
       },
       "fota_cmd": {
         "name": "Firmware update"
+      },
+      "greasefilterstatus": {
+        "name": "Vetfiltertimer"
       },
       "hide_setting": {
         "name": "Instelling verbergen"
@@ -7755,6 +7730,9 @@
       "key_sound": {
         "name": "Toetsgeluid"
       },
+      "lightstatus": {
+        "name": "Verlichting"
+      },
       "mute": {
         "name": "Stil"
       },
@@ -7769,6 +7747,12 @@
       },
       "prewash": {
         "name": "Voorwas"
+      },
+      "proximitysensorsetavalibility": {
+        "name": "Nabijheidssensor beschikbaar"
+      },
+      "proximitysensorstatus": {
+        "name": "Nabijheidssensor"
       },
       "save_mode": {
         "name": "Spaarstand"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -807,9 +807,6 @@
       "light": {
         "name": "Lys"
       },
-      "lightstatus": {
-        "name": "Lysstatus"
-      },
       "lock_fresh_mode": {
         "name": "Ferskl\u00e5smodus"
       },
@@ -1684,6 +1681,9 @@
       "gratin_function_set_time_in_seconds": {
         "name": "Innstilt tid for gratineringsfunksjon"
       },
+      "greasefiltersetlifetimeinhours": {
+        "name": "Fettfilterlevetid"
+      },
       "refrigerator_max_temperature": {
         "name": "Maks kj\u00f8leskapstemperatur"
       },
@@ -1740,6 +1740,13 @@
       },
       "brightness": {
         "name": "Lysstyrke"
+      },
+      "circulationmodestatus": {
+        "name": "Sirkulasjonsmodus",
+        "state": {
+          "exhaust": "Avtrekk",
+          "recirculation": "Resirkulering"
+        }
       },
       "cooking_intensity": {
         "name": "Kokeintensitet"
@@ -1826,6 +1833,13 @@
           "low": "Lav",
           "mid": "Middels",
           "mute": "Lydl\u00f8s"
+        }
+      },
+      "greasefilterresetcounter": {
+        "name": "Tilbakestill fettfiltertelling",
+        "state": {
+          "not_active": "Ikke aktiv",
+          "reset": "Tilbakestill"
         }
       },
       "language_status": {
@@ -2210,6 +2224,15 @@
           "not_set": "Ikke satt"
         }
       },
+      "timersetting": {
+        "name": "Timerhandling",
+        "state": {
+          "not_active": "Ikke aktiv",
+          "pause": "Pause",
+          "start": "Start",
+          "stop": "Stopp"
+        }
+      },
       "volume": {
         "name": "Volum"
       },
@@ -2241,31 +2264,8 @@
       "activemodelightcolortemperature": {
         "name": "Fargetemperatur i aktiv modus"
       },
-      "activemodelightstatus": {
-        "name": "Lysstatus i aktiv modus",
-        "state": {
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
-      },
       "activemodemotorlevel": {
         "name": "Motorniv\u00e5 i aktiv modus"
-      },
-      "activemodemotorlevelstatus": {
-        "name": "Status for motorniv\u00e5 i aktiv modus",
-        "state": {
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
-      },
-      "activemodestatus": {
-        "name": "Aktiv modus-status",
-        "state": {
-          "active": "Aktiv",
-          "not_active": "Ikke aktiv",
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
       },
       "adapt_sense_setting_status": {
         "name": "Status for tilpasset sansing"
@@ -2404,13 +2404,6 @@
       },
       "ambientlightcolortemperature": {
         "name": "Fargetemperatur for omgivelseslys"
-      },
-      "ambientlightstatus": {
-        "name": "Status for omgivelseslys",
-        "state": {
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
       },
       "ancreae_mux": {
         "name": "An creae mux"
@@ -2612,15 +2605,6 @@
       "circulation_mode": {
         "name": "Sirkulasjonsmodus"
       },
-      "circulationmodestatus": {
-        "name": "Status for sirkulasjonsmodus",
-        "state": {
-          "exhaust": "Avtrekk",
-          "not_available": "Ikke tilgjengelig",
-          "recirculation": "Resirkulering",
-          "reserved": "Reservert"
-        }
-      },
       "clean_mode_switch_status": {
         "name": "Bryterstatus for rensmodus"
       },
@@ -2641,15 +2625,6 @@
       },
       "cleanairstarttime": {
         "name": "Starttid for ren luft"
-      },
-      "cleanairstatus": {
-        "name": "Status for ren luft",
-        "state": {
-          "active": "Aktiv",
-          "not_active": "Ikke aktiv",
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
       },
       "coldwash": {
         "name": "Kaldvask"
@@ -3840,15 +3815,6 @@
       "greasefiltercleaningintervalinhours": {
         "name": "Rengj\u00f8ringsintervall for fettfilter (timer)"
       },
-      "greasefilterstatus": {
-        "name": "Status for fettfilter",
-        "state": {
-          "active": "Aktiv",
-          "not_active": "Ikke aktiv",
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
-      },
       "greasefilterusedhours": {
         "name": "Brukte timer for fettfilter"
       },
@@ -4421,15 +4387,6 @@
       },
       "proximitysensorsensitivity": {
         "name": "F\u00f8lsomhet for n\u00e6rhetssensor"
-      },
-      "proximitysensorstatus": {
-        "name": "Status for n\u00e6rhetssensor",
-        "state": {
-          "active": "Aktiv",
-          "not_active": "Ikke aktiv",
-          "not_available": "Ikke tilgjengelig",
-          "reserved": "Reservert"
-        }
       },
       "pumcleanflag": {
         "name": "Pumperensflagg"
@@ -7668,8 +7625,20 @@
       }
     },
     "switch": {
+      "activemodelightstatus": {
+        "name": "Lys i aktiv modus"
+      },
+      "activemodemotorlevelstatus": {
+        "name": "Motor i aktiv modus"
+      },
+      "activemodestatus": {
+        "name": "Aktiv modus"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptiv sansingsinnstilling"
+      },
+      "ambientlightstatus": {
+        "name": "Omgivelseslys"
       },
       "anticrease": {
         "name": "Anti-kr\u00f8ll"
@@ -7716,6 +7685,9 @@
       "child_lock": {
         "name": "Barnesikring"
       },
+      "cleanairstatus": {
+        "name": "Ren luft"
+      },
       "crisp_function_status": {
         "name": "Status for spr\u00f8-funksjon"
       },
@@ -7733,6 +7705,9 @@
       },
       "fota_cmd": {
         "name": "Fastvareoppdatering"
+      },
+      "greasefilterstatus": {
+        "name": "Fettfiltertimer"
       },
       "hide_setting": {
         "name": "Skjul innstilling"
@@ -7755,6 +7730,9 @@
       "key_sound": {
         "name": "Tastelyd"
       },
+      "lightstatus": {
+        "name": "Lys"
+      },
       "mute": {
         "name": "Lydl\u00f8s"
       },
@@ -7769,6 +7747,12 @@
       },
       "prewash": {
         "name": "Forvask"
+      },
+      "proximitysensorsetavalibility": {
+        "name": "N\u00e6rhetssensor tilgjengelig"
+      },
+      "proximitysensorstatus": {
+        "name": "N\u00e6rhetssensor"
       },
       "save_mode": {
         "name": "Sparemodus"


### PR DESCRIPTION
## Summary
- Convert read-only `*Status` sensors with writable `*Setting` counterparts into switches/selects that redirect writes via `command.name` (`Light`, `ActiveMode*`, `AmbientLight`, `CleanAir`, `GreaseFilter`, `ProximitySensor`, `CirculationMode`). `unavailable: 0` skips entities on hoods that don't support the feature.
- Add new writable entities: `TimerSetting` (action select), `GreaseFilterSetLifetimeInHours` (number), `GreaseFilterResetCounter` (select), `ProximitySensorSetAvalibility` (switch).
- Add `state_class: total_increasing` to filter/timer counters so HA can compute long-term statistics across resets; drop `state_class: measurement` from setpoint/preset sensors that don't represent fluctuating measurements.
- Make `CleanAirStatus` visible by default. Tidy English display names; restore Dutch/Norwegian translations on the new platform keys.