### PR TITLE
Add zone-presence flags for hob (020)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/020.yaml
+++ b/custom_components/connectlife/data_dictionaries/020.yaml
@@ -167,6 +167,13 @@ properties:
   - property: SL1_Power_level_max
     # Sample value: 13
     optional: true
+  - property: SL1_Present
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL1_Status
     optional: true
     binary_sensor:
@@ -254,6 +261,13 @@ properties:
   - property: SL2_Power_level_max
     # Sample value: 13
     optional: true
+  - property: SL2_Present
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL2_Status
     optional: true
     binary_sensor:
@@ -341,6 +355,13 @@ properties:
   - property: SL3_Power_level_max
     # Sample value: 13
     optional: true
+  - property: SL3_Present
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL3_Status
     optional: true
     binary_sensor:
@@ -428,6 +449,13 @@ properties:
   - property: SL4_Power_level_max
     # Sample value: 13
     optional: true
+  - property: SL4_Present
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL4_Status
     optional: true
     binary_sensor:
@@ -515,6 +543,13 @@ properties:
   - property: SL5_Power_level_max
     # Sample value: 13
     optional: true
+  - property: SL5_Present
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL5_Status
     optional: true
     binary_sensor:
@@ -602,6 +637,13 @@ properties:
   - property: SL6_Power_level_max
     # Sample value: 13
     optional: true
+  - property: SL6_Present
+    optional: true
+    entity_category: diagnostic
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: SL6_Status
     optional: true
     binary_sensor:

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1320,6 +1320,9 @@
       "sl1_pot_detected": {
         "name": "Zone 1 pot detected"
       },
+      "sl1_present": {
+        "name": "Zone 1 present"
+      },
       "sl1_residual_heat_signal": {
         "name": "Zone 1 residual heat"
       },
@@ -1400,6 +1403,9 @@
       },
       "sl2_pot_detected": {
         "name": "Zone 2 pot detected"
+      },
+      "sl2_present": {
+        "name": "Zone 2 present"
       },
       "sl2_residual_heat_signal": {
         "name": "Zone 2 residual heat"
@@ -1482,6 +1488,9 @@
       "sl3_pot_detected": {
         "name": "Zone 3 pot detected"
       },
+      "sl3_present": {
+        "name": "Zone 3 present"
+      },
       "sl3_residual_heat_signal": {
         "name": "Zone 3 residual heat"
       },
@@ -1562,6 +1571,9 @@
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot detected"
+      },
+      "sl4_present": {
+        "name": "Zone 4 present"
       },
       "sl4_residual_heat_signal": {
         "name": "Zone 4 residual heat"
@@ -1644,6 +1656,9 @@
       "sl5_pot_detected": {
         "name": "Zone 5 pot detected"
       },
+      "sl5_present": {
+        "name": "Zone 5 present"
+      },
       "sl5_residual_heat_signal": {
         "name": "Zone 5 residual heat"
       },
@@ -1724,6 +1739,9 @@
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot detected"
+      },
+      "sl6_present": {
+        "name": "Zone 6 present"
       },
       "sl6_residual_heat_signal": {
         "name": "Zone 6 residual heat"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1320,6 +1320,9 @@
       "sl1_pot_detected": {
         "name": "Zone 1 pot detected"
       },
+      "sl1_present": {
+        "name": "Zone 1 present"
+      },
       "sl1_residual_heat_signal": {
         "name": "Zone 1 residual heat"
       },
@@ -1400,6 +1403,9 @@
       },
       "sl2_pot_detected": {
         "name": "Zone 2 pot detected"
+      },
+      "sl2_present": {
+        "name": "Zone 2 present"
       },
       "sl2_residual_heat_signal": {
         "name": "Zone 2 residual heat"
@@ -1482,6 +1488,9 @@
       "sl3_pot_detected": {
         "name": "Zone 3 pot detected"
       },
+      "sl3_present": {
+        "name": "Zone 3 present"
+      },
       "sl3_residual_heat_signal": {
         "name": "Zone 3 residual heat"
       },
@@ -1562,6 +1571,9 @@
       },
       "sl4_pot_detected": {
         "name": "Zone 4 pot detected"
+      },
+      "sl4_present": {
+        "name": "Zone 4 present"
       },
       "sl4_residual_heat_signal": {
         "name": "Zone 4 residual heat"
@@ -1644,6 +1656,9 @@
       "sl5_pot_detected": {
         "name": "Zone 5 pot detected"
       },
+      "sl5_present": {
+        "name": "Zone 5 present"
+      },
       "sl5_residual_heat_signal": {
         "name": "Zone 5 residual heat"
       },
@@ -1724,6 +1739,9 @@
       },
       "sl6_pot_detected": {
         "name": "Zone 6 pot detected"
+      },
+      "sl6_present": {
+        "name": "Zone 6 present"
       },
       "sl6_residual_heat_signal": {
         "name": "Zone 6 residual heat"


### PR DESCRIPTION
## Summary
- Add `SL1_Present` through `SL6_Present` as binary sensors. These reflect zone-slot topology (which slots correspond to real zones on the hob) and are distinct from the existing `SL{n}_Pot_detected` (dynamic pan detection).
- Mark them `optional: true` + `entity_category: diagnostic` since the value is static for a given hob — useful for verifying topology, not day-to-day monitoring.
- Display names use the "Zone N present" pattern to match `SL{n}_Pot_detected` / `SL{n}_Residual_heat_signal`.
