### PR TITLE
Add Actions and Water_tank for oven (023)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/023.yaml
+++ b/custom_components/connectlife/data_dictionaries/023.yaml
@@ -1,5 +1,13 @@
 # Oven
 properties:
+  - property: Actions
+    select:
+      options:
+        1: stop
+        2: start
+        3: pause
+        6: steamer_water_tank_door_open
+        7: direct_steam
   - property: Alarm_alarm_time_reached
     icon: mdi:alarm
     binary_sensor:
@@ -417,3 +425,9 @@ properties:
     sensor:
       device_class: duration
       unit: min
+  - property: Water_tank
+    sensor:
+      device_class: enum
+      options:
+        3051: not_detected
+        3052: present

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2006,10 +2006,12 @@
         "state": {
           "add_duration": "Add duration",
           "add_gratin": "Add gratin",
+          "direct_steam": "Direct steam",
           "none": "None",
           "pause": "Pause",
           "start": "Start",
           "steam_shot": "Steam shot",
+          "steamer_water_tank_door_open": "Open steamer water tank door",
           "stop": "Stop",
           "stop_finish": "Stop finish"
         }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2006,10 +2006,12 @@
         "state": {
           "add_duration": "Add duration",
           "add_gratin": "Add gratin",
+          "direct_steam": "Direct steam",
           "none": "None",
           "pause": "Pause",
           "start": "Start",
           "steam_shot": "Steam shot",
+          "steamer_water_tank_door_open": "Open steamer water tank door",
           "stop": "Stop",
           "stop_finish": "Stop finish"
         }


### PR DESCRIPTION
## Summary
- Add `Actions` as a writable select with options `stop`/`start`/`pause`/`steamer_water_tank_door_open`/`direct_steam` (values 1, 2, 3, 6, 7).
- Add `Water_tank` as an enum sensor with options `not_detected` (3051) / `present` (3052), matching the convention used by 013.
