### PR TITLE
Improve mappings for washing machine (027)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -102,7 +102,7 @@
 |                          | Refrigerator             | 026              | 1b0610z0049j                |
 |                          | Refrigerator             | 026              | 1b0628z0075j                |
 | RS818N4TIE1              | Refrigerator             | 026              | 1b0628z0146j                |
-|                          | Washing machine          | 027              | 000                         |
+| Gorenje W-WaveEn-22      | Washing machine          | 027              | 000                         |
 | WPAM14A2T                | Washing machine          | 027              | washing-machine-wm22-b2plus |
 | WPNA84A2TSWIFI           | Washing machine          | 027              | washing-machine-wm22        |
 | DH3S80-DVW006            | Tumble dryer             | 030              | 1wk080140v0w                |

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -102,6 +102,7 @@
 |                          | Refrigerator             | 026              | 1b0610z0049j                |
 |                          | Refrigerator             | 026              | 1b0628z0075j                |
 | RS818N4TIE1              | Refrigerator             | 026              | 1b0628z0146j                |
+|                          | Washing machine          | 027              | 000                         |
 | WPAM14A2T                | Washing machine          | 027              | washing-machine-wm22-b2plus |
 | WPNA84A2TSWIFI           | Washing machine          | 027              | washing-machine-wm22        |
 | DH3S80-DVW006            | Tumble dryer             | 030              | 1wk080140v0w                |

--- a/custom_components/connectlife/data_dictionaries/027-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/027-000.yaml
@@ -1,0 +1,2 @@
+# Gorenje washing machine (W-WaveEn-22)
+# Uses default mappings

--- a/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22-b2plus.yaml
+++ b/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22-b2plus.yaml
@@ -1,16 +1,27 @@
 # Washing Machine Gorenje WPAM14A2T (WM22 B2 Plus)
-# Override program mode and spin speed options to match what this variant
-# reports (observed by the original contributor in PR #268).
+# Override program mode and spin speed to read-only sensors with the option
+# labels observed by the original contributor in PR #268. Writes via the base
+# command + adjust:1 can't be trusted on this variant: the write encoding is
+# unverified, and the observed labels don't line up with the spec write enum
+# (e.g. picking "0_rpm" with adjust:1 would write 700 RPM per spec).
 properties:
   - property: Selected_program_mode_status
-    select:
+    icon: 'mdi:tshirt-crew'
+    sensor:
+      read_only: true
+      device_class: enum
       options:
+        0: not_available
         1: normal
         3: fast
         4: extra_fast
   - property: Selected_program_washing_spin_speed_rpm_status
-    select:
+    icon: 'mdi:reload'
+    sensor:
+      read_only: true
+      device_class: enum
       options:
+        0: not_available
         1: no_spin
         4: 0_rpm
         5: 800_rpm

--- a/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22-b2plus.yaml
+++ b/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22-b2plus.yaml
@@ -1,2 +1,20 @@
 # Washing Machine Gorenje WPAM14A2T (WM22 B2 Plus)
-# Uses default mappings
+# Override program mode and spin speed options to match what this variant
+# reports (observed by the original contributor in PR #268).
+properties:
+  - property: Selected_program_mode_status
+    select:
+      options:
+        1: normal
+        3: fast
+        4: extra_fast
+  - property: Selected_program_washing_spin_speed_rpm_status
+    select:
+      options:
+        1: no_spin
+        4: 0_rpm
+        5: 800_rpm
+        6: 400_rpm
+        7: 1000_rpm
+        8: 1200_rpm
+        9: 1400_rpm

--- a/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22.yaml
+++ b/custom_components/connectlife/data_dictionaries/027-washing-machine-wm22.yaml
@@ -1,2 +1,9 @@
 # Washing machine WPNA84A2TSWIFI/PL
-# Uses default mappings
+# Override delay start/end status options to match what this variant reports
+# (only values 1 and 3 observed in PR #218).
+properties:
+  - property: Delaystart_delayend_mode_status
+    select:
+      options:
+        1: "off"
+        3: "on"

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -413,6 +413,7 @@ properties:
       4: white_detergent
       5: black_detergent
       6: sensitive_detergent
+      7: other_rinse_agent
     command:
       name: Compartment2_type_setting
       adjust: 1

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -19,12 +19,15 @@ properties:
     unit: min
 - property: Delaystart_delayend_mode_status
   icon: 'mdi:timer'
-  sensor:
-    read_only: true
-    device_class: enum
+  unavailable: 0
+  select:
     options:
-      1: "off"
-      3: "on"
+      1: not_active
+      2: delay_start
+      3: delay_end
+    command:
+      name: Delaystart_delayend_mode
+      adjust: 1
 - property: Delaystart_delayend_remaining_time_in_minutes
   icon: 'mdi:update'
   sensor:
@@ -101,14 +104,16 @@ properties:
       name: Selected_program_id
 - property: Selected_program_mode_status
   icon: 'mdi:tshirt-crew'
-  sensor:
-    read_only: true
-    device_class: enum
+  unavailable: 0
+  select:
     options:
-      0: not_available
       1: normal
-      3: fast
-      4: extra_fast
+      2: intensive
+      3: time_care_1
+      4: time_care_2
+    command:
+      name: Selected_program_mode
+      adjust: 1
 - property: Selected_program_prewash_status
   unavailable: 0
   switch:
@@ -146,18 +151,21 @@ properties:
       adjust: 1
 - property: Selected_program_washing_spin_speed_rpm_status
   icon: 'mdi:reload'
-  sensor:
-    read_only: true
-    device_class: enum
+  unavailable: 0
+  select:
     options:
-      0: not_available
-      1: no_spin
-      4: 0_rpm
+      1: 0_rpm
+      3: 600_rpm
+      4: 700_rpm
       5: 800_rpm
       6: 400_rpm
       7: 1000_rpm
       8: 1200_rpm
       9: 1400_rpm
+      10: 1600_rpm
+    command:
+      name: Selected_program_washing_spin_speed_rpm
+      adjust: 1
 - property: Selected_program_water_pluse_status
   unavailable: 0
   switch:

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -42,9 +42,21 @@ properties:
       2: closed
       3: locked
 - property: Extra_rinse_status
-  binary_sensor: {}
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Extra_rinse
+      adjust: 1
 - property: Selected_program_anticrease_status
-  binary_sensor: {}
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Selected_program_anticrease
+      adjust: 1
 - property: Selected_program_Disinfection
   binary_sensor: {}
 - property: Selected_program_duration_in_minutes
@@ -54,13 +66,17 @@ properties:
     device_class: duration
     unit: min
 - property: Selected_program_entry_steam_status
-  binary_sensor: {}
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Selected_program_entry_steam
+      adjust: 1
 - property: Selected_program_id_status
   icon: 'mdi:tshirt-crew'
-  sensor:
-    read_only: true
-    device_class: enum
-    unknown_value: 255
+  unavailable: 0
+  select:
     options:
       0: eco_40_60
       1: white_cotton
@@ -80,6 +96,8 @@ properties:
       15: draining
       16: rinsing_softening
       17: down_feathers
+    command:
+      name: Selected_program_id
 - property: Selected_program_mode_status
   icon: 'mdi:tshirt-crew'
   sensor:
@@ -91,7 +109,13 @@ properties:
       3: fast
       4: extra_fast
 - property: Selected_program_prewash_status
-  binary_sensor: {}
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Selected_program_prewash
+      adjust: 1
 - property: Selected_program_remaining_time_in_minutes
   icon: 'mdi:clock-end'
   sensor:
@@ -99,19 +123,26 @@ properties:
     device_class: duration
     unit: min
 - property: Selected_program_rinse_hold_status
-  binary_sensor: {}
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Selected_program_rinse_hold
+      adjust: 1
 - property: Selected_program_set_temperature_status
   icon: 'mdi:thermometer'
-  sensor:
-    read_only: true
-    device_class: enum
+  unavailable: 0
+  select:
     options:
-      0: not_available
       1: cold
       2: 20_c
       3: 30_c
       4: 40_c
       5: 60_c
+    command:
+      name: Selected_program_set_temperature
+      adjust: 1
 - property: Selected_program_washing_spin_speed_rpm_status
   icon: 'mdi:reload'
   sensor:
@@ -127,7 +158,13 @@ properties:
       8: 1200_rpm
       9: 1400_rpm
 - property: Selected_program_water_pluse_status
-  binary_sensor: {}
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Selected_program_water_pluse
+      adjust: 1
 - property: Status
   icon: 'mdi:washing-machine'
   sensor:
@@ -149,6 +186,15 @@ properties:
 - property: ADS_Dirtiness_setting_status
   # Sample value: 2
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: low
+      2: medium
+      3: high
+    command:
+      name: ADS_Dirtiness_setting
+      adjust: 1
 - property: ADS_Settings_Current_Program_Detergent_setting_status
   # Sample value: 2
   optional: true
@@ -158,6 +204,14 @@ properties:
 - property: Adapt_sense_setting_status
   # Sample value: 2
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Adapt_sense_setting
+      adjust: 1
+  entity_category: config
 - property: Add_on_program_download_ID
   # Sample value: 254
   optional: true
@@ -173,6 +227,14 @@ properties:
 - property: Air_shower_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Air_shower_setting
+      adjust: 1
+  entity_category: config
 - property: Alarm_1
   # Sample value: 1
   optional: true
@@ -242,6 +304,14 @@ properties:
 - property: Auto_Super_rinse_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Auto_Super_rinse_setting
+      adjust: 1
+  entity_category: config
 - property: Auto_dose_Compartment1_amount_setting
   # Sample value: 0
   optional: true
@@ -266,6 +336,14 @@ properties:
 - property: Auto_dose_system_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Auto_dose_system_setting
+      adjust: 1
+  entity_category: config
 - property: Brightness_setting
   # Sample value: 0
   optional: true
@@ -275,15 +353,58 @@ properties:
 - property: Child_lock_setting_status
   # Sample value: 2
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Child_lock_setting
+      adjust: 1
+  entity_category: config
 - property: Color_sensor_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Color_sensor_setting
+      adjust: 1
+  entity_category: config
 - property: Compartment1_type_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: detergent
+      2: softener
+      3: color_detergent
+      4: white_detergent
+      5: black_detergent
+      6: sensitive_detergent
+    command:
+      name: Compartment1_type_setting
+      adjust: 1
+  entity_category: config
 - property: Compartment2_type_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: detergent
+      2: softener
+      3: color_detergent
+      4: white_detergent
+      5: black_detergent
+      6: sensitive_detergent
+      7: other_rinse_agent
+    command:
+      name: Compartment2_type_setting
+      adjust: 1
+  entity_category: config
 - property: Current_washing_program_phase_2
   # Sample value: 1
   optional: true
@@ -302,9 +423,28 @@ properties:
 - property: Demo_mode_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Demo_mode
+      adjust: 1
+  entity_category: config
 - property: Detergent_amount_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: "off"
+      2: auto
+      3: '1'
+      4: '2'
+      5: '3'
+    command:
+      name: Detergent_amount
+      adjust: 1
 - property: Detergent_indicator
   # Sample value: 0
   optional: true
@@ -317,9 +457,25 @@ properties:
 - property: Dose_assist_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Dose_assist
+      adjust: 1
+  entity_category: config
 - property: Drum_light_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Drum_Light_setting
+      adjust: 1
+  entity_category: config
 - property: Eco_score_type
   # Sample value: 0
   optional: true
@@ -575,24 +731,78 @@ properties:
 - property: Liquid_unit_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: ml
+      2: tbs
+    command:
+      name: Liquid_unit_setting
+      adjust: 1
+  entity_category: config
 - property: Logo_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Logo_setting
+      adjust: 1
+  entity_category: config
 - property: Max_RPM_allowed_stat
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: 0_rpm
+      2: 400_rpm
+      3: 600_rpm
+      4: 700_rpm
+      5: 800_rpm
+      6: 900_rpm
+      7: 1000_rpm
+      8: 1100_rpm
+      9: 1200_rpm
+      10: 1300_rpm
+      11: 1400_rpm
+      12: 1500_rpm
+      13: 1600_rpm
+      14: 1700_rpm
+      15: 1800_rpm
+    command:
+      name: Max_RPM_allowed
+      adjust: 1
+  entity_category: config
 - property: Night_start_setting_status_102
   # Sample value: 0
   optional: true
 - property: No_sound_status
   # Sample value: 1
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: No_sound
+      adjust: 1
+  entity_category: config
 - property: Number_of_rinses
   # Sample value: 254
   optional: true
 - property: Power_save_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Power_save
+      adjust: 1
 - property: Remote_control_mode_monitoring
   # Sample value: 1
   optional: true
@@ -629,6 +839,13 @@ properties:
 - property: Selected_program_Small_load_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Selected_program_Small_load
+      adjust: 1
 - property: Selected_program_Super_rinse
   # Sample value: 0
   optional: true
@@ -641,27 +858,78 @@ properties:
 - property: Selected_program_mode2_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: speed_mode
+      2: green_mode
+      3: night_mode
+    command:
+      name: Selected_program_mode2
+      adjust: 1
 - property: Session_pairing_active
   # Sample value: 0
   optional: true
 - property: Session_pairing_status
   # Sample value: 0
   optional: true
+  switch:
+    "off": 0
+    "on": 1
+    command:
+      name: Session_pairing_setting
+  entity_category: diagnostic
 - property: Smart_sync_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Smart_sync_setting
+      adjust: 1
+  entity_category: config
 - property: Soft_pairing_status
   # Sample value: 0
   optional: true
+  switch:
+    "off": 0
+    "on": 1
+    command:
+      name: Soft_pairing_setting
+  entity_category: diagnostic
 - property: Softener_amount_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: "off"
+      2: auto
+      3: '1'
+      4: '2'
+      5: '3'
+    command:
+      name: Softener_amount
+      adjust: 1
 - property: Softener_indicator
   # Sample value: 0
   optional: true
 - property: Sound_setting_status
   # Sample value: 3
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: '0'
+      2: '1'
+      3: '2'
+      4: '3'
+    command:
+      name: Sound_setting
+      adjust: 1
+  entity_category: config
 - property: Stain_program_Set_clothes_type_status
   # Sample value: 0
   optional: true
@@ -671,27 +939,88 @@ properties:
 - property: Temperature_unit_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: celsius
+      2: fahrenheit
+    command:
+      name: Temperature_unit_setting
+      adjust: 1
+  entity_category: config
 - property: Time_program_Set_time_status
   # Sample value: 0
   optional: true
 - property: Time_save_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Time_save
+      adjust: 1
 - property: Turbidity_sensor_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  switch:
+    "off": 1
+    "on": 2
+    command:
+      name: Turbidity_sensor_setting
+      adjust: 1
+  entity_category: config
 - property: Units_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: imperial
+      2: metric
+    command:
+      name: Units_setting
+      adjust: 1
+  entity_category: config
 - property: View_size_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: normal_text
+      2: big_text
+    command:
+      name: View_size_setting
+      adjust: 1
+  entity_category: config
 - property: Volume_setting
   # Sample value: 0
   optional: true
 - property: Water_hardness_setting_status
   # Sample value: 2
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: '1'
+      2: '2'
+      3: '3'
+    command:
+      name: Water_hardness_setting
+      adjust: 1
+  entity_category: config
 - property: Weight_unit_setting_status
   # Sample value: 0
   optional: true
+  unavailable: 0
+  select:
+    options:
+      1: kg
+      2: lbs
+    command:
+      name: Weight_unit_setting
+      adjust: 1
+  entity_category: config

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -78,7 +78,6 @@ properties:
       adjust: 1
 - property: Selected_program_id_status
   icon: 'mdi:tshirt-crew'
-  unavailable: 0
   select:
     unknown_value: 255
     options:
@@ -140,12 +139,15 @@ properties:
   icon: 'mdi:thermometer'
   unavailable: 0
   select:
+    unknown_value: 15
     options:
       1: cold
       2: 20_c
       3: 30_c
       4: 40_c
       5: 60_c
+      6: 90_c
+      7: 95_c
     command:
       name: Selected_program_set_temperature
       adjust: 1
@@ -399,7 +401,9 @@ properties:
   entity_category: config
 - property: Compartment2_type_setting_status
   # Sample value: 0
+  # NOTE: possible mixup of detergent/softener on read vs. write.
   optional: true
+  entity_category: config
   unavailable: 0
   select:
     options:
@@ -409,11 +413,9 @@ properties:
       4: white_detergent
       5: black_detergent
       6: sensitive_detergent
-      7: other_rinse_agent
     command:
       name: Compartment2_type_setting
       adjust: 1
-  entity_category: config
 - property: Current_washing_program_phase_2
   # Sample value: 1
   optional: true
@@ -805,6 +807,7 @@ properties:
 - property: Power_save_status
   # Sample value: 0
   optional: true
+  entity_category: config
   unavailable: 0
   switch:
     "off": 1

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -77,6 +77,7 @@ properties:
   icon: 'mdi:tshirt-crew'
   unavailable: 0
   select:
+    unknown_value: 255
     options:
       0: eco_40_60
       1: white_cotton

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -834,9 +834,6 @@
       "existing_sr_mode": {
         "name": "Existing SR mode"
       },
-      "extra_rinse_status": {
-        "name": "Extra rinse"
-      },
       "f-filter": {
         "name": "Filter"
       },
@@ -1221,23 +1218,11 @@
       "selected_program_disinfection": {
         "name": "Disinfection"
       },
-      "selected_program_entry_steam_status": {
-        "name": "Entry steam"
-      },
       "selected_program_extradry_status": {
         "name": "Extra dry"
       },
-      "selected_program_prewash_status": {
-        "name": "Prewash"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Rinse hold"
-      },
       "selected_program_steamfinish": {
         "name": "Steam finish"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Water pulse"
       },
       "session_pairing_active": {
         "name": "Session pairing active"
@@ -2016,6 +2001,14 @@
           "stop_finish": "Stop finish"
         }
       },
+      "ads_dirtiness_setting_status": {
+        "name": "Dirtiness",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Auto-dose quantity"
       },
@@ -2049,6 +2042,29 @@
         "state": {
           "exhaust": "Exhaust",
           "recirculation": "Recirculation"
+        }
+      },
+      "compartment1_type_setting_status": {
+        "name": "Compartment 1 type",
+        "state": {
+          "black_detergent": "Black detergent",
+          "color_detergent": "Color detergent",
+          "detergent": "Detergent",
+          "sensitive_detergent": "Sensitive detergent",
+          "softener": "Softener",
+          "white_detergent": "White detergent"
+        }
+      },
+      "compartment2_type_setting_status": {
+        "name": "Compartment 2 type",
+        "state": {
+          "black_detergent": "Black detergent",
+          "color_detergent": "Color detergent",
+          "detergent": "Detergent",
+          "other_rinse_agent": "Other rinse agent",
+          "sensitive_detergent": "Sensitive detergent",
+          "softener": "Softener",
+          "white_detergent": "White detergent"
         }
       },
       "condensewatermode": {
@@ -2099,6 +2115,16 @@
           "more": "More",
           "off": "Off",
           "standard": "Standard"
+        }
+      },
+      "detergent_amount_status": {
+        "name": "Detergent amount",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Off"
         }
       },
       "displaybrightness": {
@@ -2176,12 +2202,39 @@
           "simplified_chinese": "Simplified chinese"
         }
       },
+      "liquid_unit_setting_status": {
+        "name": "Liquid unit",
+        "state": {
+          "ml": "ml",
+          "tbs": "tbs"
+        }
+      },
       "load": {
         "name": "Load",
         "state": {
           "100_percent": "100 percent",
           "25_percent": "25 percent",
           "50_percent": "50 percent"
+        }
+      },
+      "max_rpm_allowed_stat": {
+        "name": "Max spin speed",
+        "state": {
+          "0_rpm": "0 RPM",
+          "1000_rpm": "1000 RPM",
+          "1100_rpm": "1100 RPM",
+          "1200_rpm": "1200 RPM",
+          "1300_rpm": "1300 RPM",
+          "1400_rpm": "1400 RPM",
+          "1500_rpm": "1500 RPM",
+          "1600_rpm": "1600 RPM",
+          "1700_rpm": "1700 RPM",
+          "1800_rpm": "1800 RPM",
+          "400_rpm": "400 RPM",
+          "600_rpm": "600 RPM",
+          "700_rpm": "700 RPM",
+          "800_rpm": "800 RPM",
+          "900_rpm": "900 RPM"
         }
       },
       "notification_volumen_setting_status": {
@@ -2294,20 +2347,38 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Program",
+        "name": "Selected program",
         "state": {
           "auto": "Auto",
+          "baby": "Baby",
           "clean": "Clean",
+          "color": "Color",
+          "down_feathers": "Down feathers",
+          "draining": "Draining",
+          "drum_cleaning": "Drum cleaning",
           "eco": "Eco",
+          "eco_40_60": "Eco 40 60",
+          "extra_hygiene": "Extra hygiene",
+          "fast_20": "Fast 20",
           "glass": "Glass",
           "hygiene": "Hygiene",
           "intensive": "Intensive",
+          "intensive_59_32": "Intensive 59 32",
+          "mix_synthetic": "Mix synthetic",
           "night": "Night",
+          "no_program_selected": "No program selected",
           "one_hour": "One hour",
+          "pet_hair_removal": "Pet hair removal",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rinse and hold",
+          "rinsing_softening": "Rinsing softening",
           "self_cleaning": "Self cleaning",
-          "time_program": "Time program"
+          "shirts": "Shirts",
+          "spinning_draining": "Spinning draining",
+          "sport": "Sport",
+          "time_program": "Time program",
+          "white_cotton": "White cotton",
+          "wool_manual": "Wool manual"
         }
       },
       "selected_program_mode": {
@@ -2318,6 +2389,24 @@
           "normal": "Normal",
           "not_available": "Not available",
           "speed": "Speed"
+        }
+      },
+      "selected_program_mode2_status": {
+        "name": "Eco mode",
+        "state": {
+          "green_mode": "Green",
+          "night_mode": "Night",
+          "speed_mode": "Speed"
+        }
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Temperature",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "cold": "Cold"
         }
       },
       "setmaxmotorspeed": {
@@ -2351,6 +2440,25 @@
           "more": "More",
           "off": "Off",
           "standard": "Standard"
+        }
+      },
+      "softener_amount_status": {
+        "name": "Softener amount",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Off"
+        }
+      },
+      "sound_setting_status": {
+        "name": "Volume",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
         }
       },
       "spin_speed_rpm": {
@@ -2562,6 +2670,13 @@
           "fahrenheit": "Fahrenheit"
         }
       },
+      "temperature_unit_setting_status": {
+        "name": "Temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
       "time_format": {
         "name": "Time format",
         "state": {
@@ -2599,6 +2714,20 @@
           "stop": "Stop"
         }
       },
+      "units_setting_status": {
+        "name": "Units",
+        "state": {
+          "imperial": "Imperial",
+          "metric": "Metric"
+        }
+      },
+      "view_size_setting_status": {
+        "name": "View size",
+        "state": {
+          "big_text": "Big text",
+          "normal_text": "Normal text"
+        }
+      },
       "volume": {
         "name": "Volume",
         "state": {
@@ -2621,9 +2750,19 @@
         "name": "Water hardness"
       },
       "water_hardness_setting_status": {
-        "name": "Water hardness setting status",
+        "name": "Water hardness",
         "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
           "not_set": "Not set"
+        }
+      },
+      "weight_unit_setting_status": {
+        "name": "Weight unit",
+        "state": {
+          "kg": "kg",
+          "lbs": "lbs"
         }
       }
     },
@@ -2639,9 +2778,6 @@
       },
       "activemodemotorlevel": {
         "name": "Active mode motor level"
-      },
-      "adapt_sense_setting_status": {
-        "name": "Adapt sense setting status"
       },
       "adapttech_setting": {
         "name": "Adapt tech setting"
@@ -2661,9 +2797,6 @@
       "add_water_flag": {
         "name": "Add water flag"
       },
-      "ads_dirtiness_setting_status": {
-        "name": "ADS dirtiness setting status"
-      },
       "ads_settings_current_program_detergent_setting_status": {
         "name": "ADS settings current program detergent setting status"
       },
@@ -2681,9 +2814,6 @@
       },
       "air_freshness": {
         "name": "Air freshness"
-      },
-      "air_shower_setting_status": {
-        "name": "Air shower setting status"
       },
       "airdryflag": {
         "name": "Air dry flag"
@@ -2842,14 +2972,8 @@
       "auto_dose_duration": {
         "name": "Auto-dose duration"
       },
-      "auto_dose_system_setting_status": {
-        "name": "Auto-dose system setting status"
-      },
       "auto_grease_filter_indication": {
         "name": "Auto grease filter"
-      },
-      "auto_super_rinse_setting_status": {
-        "name": "Auto super rinse setting status"
       },
       "auto_tower_up": {
         "name": "Tower auto-raise"
@@ -3023,17 +3147,8 @@
       "coldwash": {
         "name": "Cold wash"
       },
-      "color_sensor_setting_status": {
-        "name": "Color sensor setting status"
-      },
       "commodity_inspection": {
         "name": "Commodity inspection"
-      },
-      "compartment1_type_setting_status": {
-        "name": "Compartment 1 type setting status"
-      },
-      "compartment2_type_setting_status": {
-        "name": "Compartment 2 type setting status"
       },
       "compartment_inuse": {
         "name": "Compartment in use"
@@ -3318,9 +3433,6 @@
       "descale_status": {
         "name": "Descale status"
       },
-      "detergent_amount_status": {
-        "name": "Detergent amount status"
-      },
       "detergent_buynotifyswitch": {
         "name": "Detergent buy notify switch"
       },
@@ -3483,9 +3595,6 @@
       "dose_assist_recommended_low_concenatration_detergent_quantity": {
         "name": "Dose assist recommended low concentration detergent quantity"
       },
-      "dose_assist_status": {
-        "name": "Dose assist status"
-      },
       "dose_detergent_amount": {
         "name": "Dose detergent amount"
       },
@@ -3503,9 +3612,6 @@
       },
       "downloadprogram": {
         "name": "Download program"
-      },
-      "drum_light_setting_status": {
-        "name": "Drum light setting status"
       },
       "drumcleancycle_runsnumber": {
         "name": "Drum clean cycle runs number"
@@ -4585,9 +4691,6 @@
       "lightscolor_temperature_setting": {
         "name": "Lights color temperature setting"
       },
-      "liquid_unit_setting_status": {
-        "name": "Liquid unit setting status"
-      },
       "load_operation_status2": {
         "name": "Load operation status 2"
       },
@@ -4645,9 +4748,6 @@
       },
       "market_mode_exist": {
         "name": "Market mode exist"
-      },
-      "max_rpm_allowed_stat": {
-        "name": "Max RPM allowed status"
       },
       "maxtimeevent": {
         "name": "Max time event"
@@ -4764,9 +4864,6 @@
       },
       "no_autodoseswitch": {
         "name": "No auto-dose switch"
-      },
-      "no_sound_status": {
-        "name": "No sound status"
       },
       "normal_sound_size": {
         "name": "Normal sound size"
@@ -4887,9 +4984,6 @@
       },
       "power_save": {
         "name": "Power save"
-      },
-      "power_save_status": {
-        "name": "Power save status"
       },
       "power_value": {
         "name": "Power value"
@@ -5423,27 +5517,7 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Selected program",
-        "state": {
-          "baby": "Baby",
-          "color": "Color",
-          "down_feathers": "Down feathers",
-          "draining": "Draining",
-          "drum_cleaning": "Drum Cleaning",
-          "eco_40_60": "Eco 40-60",
-          "extra_hygiene": "Extra Hygiene",
-          "fast_20": "Fast 20'",
-          "intensive_59_32": "Intensive 59'/32'",
-          "mix_synthetic": "Mix/Synthetic",
-          "no_program_selected": "No program selected",
-          "pet_hair_removal": "Pet hair removal",
-          "rinsing_softening": "Rinsing & Softening",
-          "shirts": "Shirts",
-          "spinning_draining": "Spinning & Draining",
-          "sport": "Sport",
-          "white_cotton": "White Cotton",
-          "wool_manual": "Wool & Manual"
-        }
+        "name": "Selected program"
       },
       "selected_program_intensive_mode": {
         "name": "Selected program intensive mode"
@@ -5456,9 +5530,6 @@
       },
       "selected_program_mode": {
         "name": "Selected program mode"
-      },
-      "selected_program_mode2_status": {
-        "name": "Selected program mode 2 status"
       },
       "selected_program_mode_status": {
         "name": "Program mode",
@@ -5474,20 +5545,6 @@
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Remaining time of selected program"
-      },
-      "selected_program_set_temperature_status": {
-        "name": "Temperature",
-        "state": {
-          "20_c": "20 \u00b0C",
-          "30_c": "30 \u00b0C",
-          "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C",
-          "cold": "Cold",
-          "not_available": "Not available"
-        }
-      },
-      "selected_program_small_load_status": {
-        "name": "Selected program small load status"
       },
       "selected_program_storage_function": {
         "name": "Selected program storage function"
@@ -6540,17 +6597,11 @@
       "slotdry_flag1": {
         "name": "Slotdry flag 1"
       },
-      "smart_sync_setting_status": {
-        "name": "Smart sync setting status"
-      },
       "soft_pairing_setting": {
         "name": "Soft pairing setting"
       },
       "soft_pairing_status": {
         "name": "Soft pairing status"
-      },
-      "softener_amount_status": {
-        "name": "Softener amount status"
       },
       "softener_buynotifyswitch": {
         "name": "Softener buy notify switch"
@@ -6605,9 +6656,6 @@
       },
       "sound_setting": {
         "name": "Sound setting"
-      },
-      "sound_setting_status": {
-        "name": "Sound setting status"
       },
       "sound_settings": {
         "name": "Sound settings"
@@ -7732,9 +7780,6 @@
       "temperature_room_judge": {
         "name": "Temperature room judge"
       },
-      "temperature_unit_setting_status": {
-        "name": "Temperature unit setting status"
-      },
       "temperature_unit_status": {
         "name": "Temperature unit status"
       },
@@ -7780,9 +7825,6 @@
       },
       "time_program_set_time_status": {
         "name": "Time program set time status"
-      },
-      "time_save_status": {
-        "name": "Time save status"
       },
       "time_zone_setting": {
         "name": "Time zone setting"
@@ -7862,17 +7904,11 @@
       "totalprogramscycles": {
         "name": "Total program cycles"
       },
-      "turbidity_sensor_setting_status": {
-        "name": "Turbidity sensor setting status"
-      },
       "unfreeze_run_status": {
         "name": "Unfreeze run status"
       },
       "unfreeze_switch_status": {
         "name": "Unfreeze switch status"
-      },
-      "units_setting_status": {
-        "name": "Units setting status"
       },
       "unpair_all_users": {
         "name": "Unpair all users"
@@ -7933,9 +7969,6 @@
       },
       "variation_sensor_real_temperature": {
         "name": "Variation sensor real temperature"
-      },
-      "view_size_setting_status": {
-        "name": "View size setting status"
       },
       "volume_setting": {
         "name": "Volume setting"
@@ -8144,9 +8177,6 @@
       "water_hardness_setting": {
         "name": "Water hardness setting"
       },
-      "water_hardness_setting_status": {
-        "name": "Water hardness"
-      },
       "water_heat_switch": {
         "name": "Water heat switch"
       },
@@ -8192,9 +8222,6 @@
       },
       "weight_unit_setting": {
         "name": "Weight unit setting"
-      },
-      "weight_unit_setting_status": {
-        "name": "Weight unit setting status"
       },
       "wet_and_dry_space": {
         "name": "Wet and dry space"
@@ -8279,11 +8306,17 @@
       "activemodestatus": {
         "name": "Active mode"
       },
+      "adapt_sense_setting_status": {
+        "name": "Adapt sense"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptive sense setting"
       },
       "addclothes": {
         "name": "Add clothes"
+      },
+      "air_shower_setting_status": {
+        "name": "Air shower"
       },
       "allergymodeenable": {
         "name": "Allergy mode"
@@ -8321,8 +8354,14 @@
       "auto_dose_setting_status": {
         "name": "Auto-dose"
       },
+      "auto_dose_system_setting_status": {
+        "name": "Auto-dose system"
+      },
       "auto_fast_preheat": {
         "name": "Auto fast preheat"
+      },
+      "auto_super_rinse_setting_status": {
+        "name": "Auto super rinse"
       },
       "autodose": {
         "name": "Auto-dose"
@@ -8336,6 +8375,9 @@
       "child_lock": {
         "name": "Child lock"
       },
+      "child_lock_setting_status": {
+        "name": "Child lock"
+      },
       "childlockenabled": {
         "name": "Child lock"
       },
@@ -8345,22 +8387,37 @@
       "coldwash": {
         "name": "Cold wash"
       },
+      "color_sensor_setting_status": {
+        "name": "Color sensor"
+      },
       "crisp_function_status": {
         "name": "Crisp function status"
       },
       "demo_mode": {
         "name": "Demo mode"
       },
+      "demo_mode_status": {
+        "name": "Demo mode"
+      },
       "display_standby": {
         "name": "Display standby"
       },
+      "dose_assist_status": {
+        "name": "Dose assist"
+      },
       "drum_light": {
+        "name": "Drum light"
+      },
+      "drum_light_setting_status": {
         "name": "Drum light"
       },
       "drumvleanprogramwarning": {
         "name": "Drum clean program warning"
       },
       "extra_rinse": {
+        "name": "Extra rinse"
+      },
+      "extra_rinse_status": {
         "name": "Extra rinse"
       },
       "extrarinse": {
@@ -8402,6 +8459,9 @@
       "lightstatus": {
         "name": "Light"
       },
+      "logo_setting_status": {
+        "name": "Logo"
+      },
       "mute": {
         "name": "Mute"
       },
@@ -8411,8 +8471,14 @@
       "night_mode_status": {
         "name": "Night mode status"
       },
+      "no_sound_status": {
+        "name": "Mute"
+      },
       "odor_control_setting": {
         "name": "Odor control"
+      },
+      "power_save_status": {
+        "name": "Power save"
       },
       "prewash": {
         "name": "Prewash"
@@ -8429,6 +8495,27 @@
       "save_mode": {
         "name": "Save mode"
       },
+      "selected_program_anticrease_status": {
+        "name": "Anti-crease"
+      },
+      "selected_program_entry_steam_status": {
+        "name": "Entry steam"
+      },
+      "selected_program_prewash_status": {
+        "name": "Prewash"
+      },
+      "selected_program_rinse_hold_status": {
+        "name": "Rinse hold"
+      },
+      "selected_program_small_load_status": {
+        "name": "Small load"
+      },
+      "selected_program_water_pluse_status": {
+        "name": "Water pulse"
+      },
+      "session_pairing_status": {
+        "name": "Session pairing"
+      },
       "sf_mode": {
         "name": "SF mode"
       },
@@ -8437,6 +8524,12 @@
       },
       "showmeasuredtemperature": {
         "name": "Show measured temperature"
+      },
+      "smart_sync_setting_status": {
+        "name": "Smart sync"
+      },
+      "soft_pairing_status": {
+        "name": "Soft pairing"
       },
       "sound": {
         "name": "Sound"
@@ -8515,6 +8608,12 @@
       },
       "time_save": {
         "name": "Time save"
+      },
+      "time_save_status": {
+        "name": "Time save"
+      },
+      "turbidity_sensor_setting_status": {
+        "name": "Turbidity sensor"
       },
       "welcome": {
         "name": "Welcome"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1210,7 +1210,7 @@
         "name": "Sabbath mode switch status"
       },
       "selected_program_anticrease_status": {
-        "name": "Selected program anti crease status"
+        "name": "Anti-crease"
       },
       "selected_program_auto_door_open_function": {
         "name": "Selected program auto door open"
@@ -2056,11 +2056,12 @@
         }
       },
       "compartment2_type_setting_status": {
-        "name": "Compartment 2 type setting status",
+        "name": "Compartment 2 type",
         "state": {
           "black_detergent": "Black detergent",
           "color_detergent": "Color detergent",
           "detergent": "Detergent",
+          "other_rinse_agent": "Other rinse agent",
           "sensitive_detergent": "Sensitive detergent",
           "softener": "Softener",
           "white_detergent": "White detergent"
@@ -5598,14 +5599,14 @@
         "name": "Selected program UV function"
       },
       "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Selected program washing spin speed rpm status",
+        "name": "Spin speed",
         "state": {
-          "0_rpm": "0 rpm",
-          "1000_rpm": "1000 rpm",
-          "1200_rpm": "1200 rpm",
-          "1400_rpm": "1400 rpm",
-          "400_rpm": "400 rpm",
-          "800_rpm": "800 rpm",
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "400_rpm": "400",
+          "800_rpm": "800",
           "no_spin": "No spin",
           "not_available": "Not available"
         }

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2107,6 +2107,14 @@
           "none": "None"
         }
       },
+      "delaystart_delayend_mode_status": {
+        "name": "Delay start mode",
+        "state": {
+          "delay_end": "Delay end",
+          "delay_start": "Delay start",
+          "not_active": "Not active"
+        }
+      },
       "detergent": {
         "name": "Detergent",
         "state": {
@@ -2399,6 +2407,17 @@
           "speed_mode": "Speed"
         }
       },
+      "selected_program_mode_status": {
+        "name": "Program mode",
+        "state": {
+          "extra_fast": "Extra fast",
+          "fast": "Fast",
+          "intensive": "Intensive",
+          "normal": "Normal",
+          "time_care_1": "Time Care 1",
+          "time_care_2": "Time Care 2"
+        }
+      },
       "selected_program_set_temperature_status": {
         "name": "Temperature",
         "state": {
@@ -2407,6 +2426,21 @@
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
           "cold": "Cold"
+        }
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Spin speed",
+        "state": {
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "1600_rpm": "1600",
+          "400_rpm": "400",
+          "600_rpm": "600",
+          "700_rpm": "700",
+          "800_rpm": "800",
+          "no_spin": "No spin"
         }
       },
       "setmaxmotorspeed": {
@@ -3404,13 +3438,6 @@
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Delay start duration"
-      },
-      "delaystart_delayend_mode_status": {
-        "name": "Delay start status",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
       },
       "delaystart_delayend_remaining_time_in_minutes": {
         "name": "Delay start/end remaining time"
@@ -5532,13 +5559,7 @@
         "name": "Selected program mode"
       },
       "selected_program_mode_status": {
-        "name": "Program mode",
-        "state": {
-          "extra_fast": "Extra fast",
-          "fast": "Fast",
-          "normal": "Normal",
-          "not_available": "Not available"
-        }
+        "name": "Program mode"
       },
       "selected_program_night_mode": {
         "name": "Selected program night mode"
@@ -5569,19 +5590,6 @@
       },
       "selected_program_uv_function": {
         "name": "Selected program UV function"
-      },
-      "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Spin speed",
-        "state": {
-          "0_rpm": "0",
-          "1000_rpm": "1000",
-          "1200_rpm": "1200",
-          "1400_rpm": "1400",
-          "400_rpm": "400",
-          "800_rpm": "800",
-          "no_spin": "No spin",
-          "not_available": "Not available"
-        }
       },
       "selected_program_water_add": {
         "name": "Selected program water add"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1210,7 +1210,7 @@
         "name": "Sabbath mode switch status"
       },
       "selected_program_anticrease_status": {
-        "name": "Anti-crease"
+        "name": "Selected program anti crease status"
       },
       "selected_program_auto_door_open_function": {
         "name": "Selected program auto door open"
@@ -2056,12 +2056,11 @@
         }
       },
       "compartment2_type_setting_status": {
-        "name": "Compartment 2 type",
+        "name": "Compartment 2 type setting status",
         "state": {
           "black_detergent": "Black detergent",
           "color_detergent": "Color detergent",
           "detergent": "Detergent",
-          "other_rinse_agent": "Other rinse agent",
           "sensitive_detergent": "Sensitive detergent",
           "softener": "Softener",
           "white_detergent": "White detergent"
@@ -2112,7 +2111,9 @@
         "state": {
           "delay_end": "Delay end",
           "delay_start": "Delay start",
-          "not_active": "Not active"
+          "not_active": "Not active",
+          "off": "Off",
+          "on": "On"
         }
       },
       "detergent": {
@@ -2363,30 +2364,30 @@
           "color": "Color",
           "down_feathers": "Down feathers",
           "draining": "Draining",
-          "drum_cleaning": "Drum cleaning",
+          "drum_cleaning": "Drum Cleaning",
           "eco": "Eco",
-          "eco_40_60": "Eco 40 60",
-          "extra_hygiene": "Extra hygiene",
-          "fast_20": "Fast 20",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Extra Hygiene",
+          "fast_20": "Fast 20'",
           "glass": "Glass",
           "hygiene": "Hygiene",
           "intensive": "Intensive",
-          "intensive_59_32": "Intensive 59 32",
-          "mix_synthetic": "Mix synthetic",
+          "intensive_59_32": "Intensive 59'/32'",
+          "mix_synthetic": "Mix/Synthetic",
           "night": "Night",
           "no_program_selected": "No program selected",
           "one_hour": "One hour",
           "pet_hair_removal": "Pet hair removal",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rinse and hold",
-          "rinsing_softening": "Rinsing softening",
+          "rinsing_softening": "Rinsing & Softening",
           "self_cleaning": "Self cleaning",
           "shirts": "Shirts",
-          "spinning_draining": "Spinning draining",
+          "spinning_draining": "Spinning & Draining",
           "sport": "Sport",
           "time_program": "Time program",
-          "white_cotton": "White cotton",
-          "wool_manual": "Wool manual"
+          "white_cotton": "White Cotton",
+          "wool_manual": "Wool & Manual"
         }
       },
       "selected_program_mode": {
@@ -2410,8 +2411,6 @@
       "selected_program_mode_status": {
         "name": "Program mode",
         "state": {
-          "extra_fast": "Extra fast",
-          "fast": "Fast",
           "intensive": "Intensive",
           "normal": "Normal",
           "time_care_1": "Time Care 1",
@@ -2425,6 +2424,8 @@
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
+          "90_c": "90 \u00b0C",
+          "95_c": "95 \u00b0C",
           "cold": "Cold"
         }
       },
@@ -2439,8 +2440,7 @@
           "400_rpm": "400",
           "600_rpm": "600",
           "700_rpm": "700",
-          "800_rpm": "800",
-          "no_spin": "No spin"
+          "800_rpm": "800"
         }
       },
       "setmaxmotorspeed": {
@@ -5559,7 +5559,13 @@
         "name": "Selected program mode"
       },
       "selected_program_mode_status": {
-        "name": "Program mode"
+        "name": "Program mode",
+        "state": {
+          "extra_fast": "Extra fast",
+          "fast": "Fast",
+          "normal": "Normal",
+          "not_available": "Not available"
+        }
       },
       "selected_program_night_mode": {
         "name": "Selected program night mode"
@@ -5590,6 +5596,19 @@
       },
       "selected_program_uv_function": {
         "name": "Selected program UV function"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Selected program washing spin speed rpm status",
+        "state": {
+          "0_rpm": "0 rpm",
+          "1000_rpm": "1000 rpm",
+          "1200_rpm": "1200 rpm",
+          "1400_rpm": "1400 rpm",
+          "400_rpm": "400 rpm",
+          "800_rpm": "800 rpm",
+          "no_spin": "No spin",
+          "not_available": "Not available"
+        }
       },
       "selected_program_water_add": {
         "name": "Selected program water add"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1306,6 +1306,14 @@
           "none": "Keine"
         }
       },
+      "delaystart_delayend_mode_status": {
+        "name": "Startverz\u00f6gerung",
+        "state": {
+          "delay_end": "Endverz\u00f6gerung",
+          "delay_start": "Startverz\u00f6gerung",
+          "not_active": "Nicht aktiv"
+        }
+      },
       "detergent": {
         "name": "Waschmittel",
         "state": {
@@ -1505,6 +1513,17 @@
           "speed_mode": "Schnell"
         }
       },
+      "selected_program_mode_status": {
+        "name": "Programm Modus",
+        "state": {
+          "extra_fast": "Extra Schnell",
+          "fast": "Schnell",
+          "intensive": "Intensiv",
+          "normal": "Normal",
+          "time_care_1": "Time Care 1",
+          "time_care_2": "Time Care 2"
+        }
+      },
       "selected_program_set_temperature_status": {
         "name": "Programm Temperatur",
         "state": {
@@ -1513,6 +1532,21 @@
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
           "cold": "Kalt"
+        }
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Programm Schleuderdrehzahl",
+        "state": {
+          "0_rpm": "0 U/min",
+          "1000_rpm": "1000 U/min",
+          "1200_rpm": "1200 U/min",
+          "1400_rpm": "1400 U/min",
+          "1600_rpm": "1600 U/min",
+          "400_rpm": "400 U/min",
+          "600_rpm": "600 U/min",
+          "700_rpm": "700 U/min",
+          "800_rpm": "800 U/min",
+          "no_spin": "Kein Schleudern"
         }
       },
       "softener": {
@@ -1878,13 +1912,6 @@
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Verz\u00f6gerungsdauer"
-      },
-      "delaystart_delayend_mode_status": {
-        "name": "Startverz\u00f6gerung",
-        "state": {
-          "off": "Aus",
-          "on": "An"
-        }
       },
       "delaystart_delayend_remaining_time_in_minutes": {
         "name": "Startverz\u00f6gerung Gesamtlaufzeit Verbleibend"
@@ -2364,13 +2391,7 @@
         "name": "Programm"
       },
       "selected_program_mode_status": {
-        "name": "Programm Modus",
-        "state": {
-          "extra_fast": "Extra Schnell",
-          "fast": "Schnell",
-          "normal": "Normal",
-          "not_available": "Nicht verf\u00fcgbar"
-        }
+        "name": "Programm Modus"
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Programmdauer Verbleibend"
@@ -2380,19 +2401,6 @@
       },
       "selected_program_total_time_in_minutes": {
         "name": "Programmdauer Gesamt"
-      },
-      "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Programm Schleuderdrehzahl",
-        "state": {
-          "0_rpm": "0 U/min",
-          "1000_rpm": "1000 U/min",
-          "1200_rpm": "1200 U/min",
-          "1400_rpm": "1400 U/min",
-          "400_rpm": "400 U/min",
-          "800_rpm": "800 U/min",
-          "no_spin": "Kein Schleudern",
-          "not_available": "Nicht verf\u00fcgbar"
-        }
       },
       "selected_programduration_inminutes": {
         "name": "Programmdauer Gesamt"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -565,9 +565,6 @@
       "existing_sr_mode": {
         "name": "Aktueller SR-Modus"
       },
-      "extra_rinse_status": {
-        "name": "Programmoption Extra-Sp\u00fclung"
-      },
       "f_e_arkgrille": {
         "name": "Schutzalarm f\u00fcr Kabinengrill"
       },
@@ -871,23 +868,11 @@
       "selected_program_disinfection": {
         "name": "Programmoption Desinfektion"
       },
-      "selected_program_entry_steam_status": {
-        "name": "Programmoption Dampf"
-      },
       "selected_program_extradry_status": {
         "name": "Programmoption Extra Trocken"
       },
-      "selected_program_prewash_status": {
-        "name": "Programmoption Vorw\u00e4sche"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Programmoption Sp\u00fclstopp"
-      },
       "selected_program_steamfinish": {
         "name": "Programmoption Dampffinish"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Programmoption Wasser Plus"
       },
       "session_pairing_active": {
         "name": "Sitzungskopplung aktiv"
@@ -1259,6 +1244,14 @@
           "stop_finish": "Stopp / Fertig"
         }
       },
+      "ads_dirtiness_setting_status": {
+        "name": "Verschmutzung",
+        "state": {
+          "high": "Hoch",
+          "low": "Niedrig",
+          "medium": "Mittel"
+        }
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Automatische Dosierungsmenge"
       },
@@ -1369,6 +1362,9 @@
           "simplified_chinese": "Vereinfachtes Chinesisch"
         }
       },
+      "max_rpm_allowed_stat": {
+        "name": "Maximale Schleuderdrehzahl"
+      },
       "notification_volumen_setting_status": {
         "name": "Benachrichtigungslautst\u00e4rke",
         "state": {
@@ -1461,17 +1457,35 @@
         "name": "Programm",
         "state": {
           "auto": "Automatisch",
+          "baby": "Baby",
           "clean": "Reinigung",
+          "color": "Farbig",
+          "down_feathers": "Daunenfedern",
+          "draining": "Abpumpen",
+          "drum_cleaning": "Trommelreinigung",
           "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Extra Hygiene",
+          "fast_20": "Schnell 20'",
           "glass": "Glas",
           "hygiene": "Hygiene",
           "intensive": "Intensiv",
+          "intensive_59_32": "Intensiv 59'/32'",
+          "mix_synthetic": "Mix/Synthetik",
           "night": "Nacht",
+          "no_program_selected": "Kein Programm ausgew\u00e4hlt",
           "one_hour": "1 Stunde",
+          "pet_hair_removal": "Tierhaarentfernung",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Sp\u00fclen & Warten",
+          "rinsing_softening": "Sp\u00fclen & Weichsp\u00fclen",
           "self_cleaning": "Selbstreinigung",
-          "time_program": "Zeitprogramm"
+          "shirts": "Hemden",
+          "spinning_draining": "Schleudern & Abpumpen",
+          "sport": "Sport",
+          "time_program": "Zeitprogramm",
+          "white_cotton": "Wei\u00dfe Baumwolle",
+          "wool_manual": "Wolle & Manuell"
         }
       },
       "selected_program_mode": {
@@ -1483,6 +1497,24 @@
           "speed": "Schnell"
         }
       },
+      "selected_program_mode2_status": {
+        "name": "Eco-Modus",
+        "state": {
+          "green_mode": "Gr\u00fcn",
+          "night_mode": "Nacht",
+          "speed_mode": "Schnell"
+        }
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Programm Temperatur",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "cold": "Kalt"
+        }
+      },
       "softener": {
         "name": "Weichsp\u00fcler",
         "state": {
@@ -1490,6 +1522,15 @@
           "less": "Weniger",
           "more": "Mehr",
           "standard": "Standard"
+        }
+      },
+      "sound_setting_status": {
+        "name": "Lautst\u00e4rke",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
         }
       },
       "spin_speed_rpm": {
@@ -1704,6 +1745,9 @@
       "water_hardness_setting_status": {
         "name": "Wasserh\u00e4rte",
         "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
           "not_set": "Nicht eingestellt"
         }
       }
@@ -2317,27 +2361,7 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Programm",
-        "state": {
-          "baby": "Baby",
-          "color": "Farbig",
-          "down_feathers": "Daunenfedern",
-          "draining": "Abpumpen",
-          "drum_cleaning": "Trommelreinigung",
-          "eco_40_60": "Eco 40-60",
-          "extra_hygiene": "Extra Hygiene",
-          "fast_20": "Schnell 20'",
-          "intensive_59_32": "Intensiv 59'/32'",
-          "mix_synthetic": "Mix/Synthetik",
-          "no_program_selected": "Kein Programm ausgew\u00e4hlt",
-          "pet_hair_removal": "Tierhaarentfernung",
-          "rinsing_softening": "Sp\u00fclen & Weichsp\u00fclen",
-          "shirts": "Hemden",
-          "spinning_draining": "Schleudern & Abpumpen",
-          "sport": "Sport",
-          "white_cotton": "Wei\u00dfe Baumwolle",
-          "wool_manual": "Wolle & Manuell"
-        }
+        "name": "Programm"
       },
       "selected_program_mode_status": {
         "name": "Programm Modus",
@@ -2350,17 +2374,6 @@
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Programmdauer Verbleibend"
-      },
-      "selected_program_set_temperature_status": {
-        "name": "Programm Temperatur",
-        "state": {
-          "20_c": "20 \u00b0C",
-          "30_c": "30 \u00b0C",
-          "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C",
-          "cold": "Kalt",
-          "not_available": "Nicht verf\u00fcgbar"
-        }
       },
       "selected_program_total_running_time_in_minutes": {
         "name": "Programmdauer Gesamt"
@@ -3450,9 +3463,6 @@
       "water_consumption_in_running_program": {
         "name": "Wasserverbrauch im laufenden Programm"
       },
-      "water_hardness_setting_status": {
-        "name": "Wasserh\u00e4rte"
-      },
       "water_inlet_setting_status": {
         "name": "Wasserzulauf"
       },
@@ -3510,6 +3520,9 @@
       "extra_rinse": {
         "name": "Extra Sp\u00fclen"
       },
+      "extra_rinse_status": {
+        "name": "Programmoption Extra-Sp\u00fclung"
+      },
       "fota_cmd": {
         "name": "Firmwareaktualisierung"
       },
@@ -3543,6 +3556,9 @@
       "night_mode_status": {
         "name": "Nachtmodus"
       },
+      "no_sound_status": {
+        "name": "Stumm"
+      },
       "odor_control_setting": {
         "name": "Geruchskontrolle"
       },
@@ -3551,6 +3567,18 @@
       },
       "save_mode": {
         "name": "Sparmodus"
+      },
+      "selected_program_entry_steam_status": {
+        "name": "Programmoption Dampf"
+      },
+      "selected_program_prewash_status": {
+        "name": "Programmoption Vorw\u00e4sche"
+      },
+      "selected_program_rinse_hold_status": {
+        "name": "Programmoption Sp\u00fclstopp"
+      },
+      "selected_program_water_pluse_status": {
+        "name": "Programmoption Wasser Plus"
       },
       "sf_mode": {
         "name": "SF-Modus"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1273,6 +1273,28 @@
       "brightness": {
         "name": "Helligkeit"
       },
+      "compartment1_type_setting_status": {
+        "name": "Kammer 1 Typ",
+        "state": {
+          "black_detergent": "Waschmittel f\u00fcr Schwarze",
+          "color_detergent": "Waschmittel f\u00fcr Bunte",
+          "detergent": "Waschmittel",
+          "sensitive_detergent": "Waschmittel f\u00fcr Empfindliches",
+          "softener": "Weichsp\u00fcler",
+          "white_detergent": "Waschmittel f\u00fcr Wei\u00dfe"
+        }
+      },
+      "compartment2_type_setting_status": {
+        "name": "Kammer 2 Typ",
+        "state": {
+          "black_detergent": "Waschmittel f\u00fcr Schwarze",
+          "color_detergent": "Waschmittel f\u00fcr Bunte",
+          "detergent": "Waschmittel",
+          "sensitive_detergent": "Waschmittel f\u00fcr Empfindliches",
+          "softener": "Weichsp\u00fcler",
+          "white_detergent": "Waschmittel f\u00fcr Wei\u00dfe"
+        }
+      },
       "cooking_intensity": {
         "name": "Kochintensit\u00e4t"
       },
@@ -1311,7 +1333,9 @@
         "state": {
           "delay_end": "Endverz\u00f6gerung",
           "delay_start": "Startverz\u00f6gerung",
-          "not_active": "Nicht aktiv"
+          "not_active": "Nicht aktiv",
+          "off": "Aus",
+          "on": "An"
         }
       },
       "detergent": {
@@ -1321,6 +1345,16 @@
           "less": "Weniger",
           "more": "Mehr",
           "standard": "Standard"
+        }
+      },
+      "detergent_amount_status": {
+        "name": "Waschmittelmenge",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Aus"
         }
       },
       "dry_level": {
@@ -1368,6 +1402,13 @@
         "state": {
           "english": "Englisch",
           "simplified_chinese": "Vereinfachtes Chinesisch"
+        }
+      },
+      "liquid_unit_setting_status": {
+        "name": "Fl\u00fcssigkeitseinheit",
+        "state": {
+          "ml": "ml",
+          "tbs": "EL"
         }
       },
       "max_rpm_allowed_stat": {
@@ -1516,8 +1557,6 @@
       "selected_program_mode_status": {
         "name": "Programm Modus",
         "state": {
-          "extra_fast": "Extra Schnell",
-          "fast": "Schnell",
           "intensive": "Intensiv",
           "normal": "Normal",
           "time_care_1": "Time Care 1",
@@ -1531,6 +1570,8 @@
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
+          "90_c": "90 \u00b0C",
+          "95_c": "95 \u00b0C",
           "cold": "Kalt"
         }
       },
@@ -1545,8 +1586,7 @@
           "400_rpm": "400 U/min",
           "600_rpm": "600 U/min",
           "700_rpm": "700 U/min",
-          "800_rpm": "800 U/min",
-          "no_spin": "Kein Schleudern"
+          "800_rpm": "800 U/min"
         }
       },
       "softener": {
@@ -1556,6 +1596,16 @@
           "less": "Weniger",
           "more": "Mehr",
           "standard": "Standard"
+        }
+      },
+      "softener_amount_status": {
+        "name": "Weichsp\u00fclermenge",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Aus"
         }
       },
       "sound_setting_status": {
@@ -1749,6 +1799,13 @@
           "fahrenheit": "Fahrenheit"
         }
       },
+      "temperature_unit_setting_status": {
+        "name": "Temperatureinheit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
       "time_format": {
         "name": "Zeitformat",
         "state": {
@@ -1760,6 +1817,20 @@
         "name": "Zeitprogrammdauer",
         "state": {
           "not_set": "Nicht festgelegt"
+        }
+      },
+      "units_setting_status": {
+        "name": "Einheiten",
+        "state": {
+          "imperial": "Imperial",
+          "metric": "Metrisch"
+        }
+      },
+      "view_size_setting_status": {
+        "name": "Anzeigegr\u00f6\u00dfe",
+        "state": {
+          "big_text": "Gro\u00dfer Text",
+          "normal_text": "Normaler Text"
         }
       },
       "volume": {
@@ -1783,6 +1854,13 @@
           "2": "2",
           "3": "3",
           "not_set": "Nicht eingestellt"
+        }
+      },
+      "weight_unit_setting_status": {
+        "name": "Gewichtseinheit",
+        "state": {
+          "kg": "kg",
+          "lbs": "lbs"
         }
       }
     },

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -860,7 +860,7 @@
         "name": "Sabbatmodus-Schalterstatus"
       },
       "selected_program_anticrease_status": {
-        "name": "Programmoption Knitterschutz"
+        "name": "Programmoption Anti-Knitter"
       },
       "selected_program_auto_door_open_function": {
         "name": "Automatische T\u00fcr\u00f6ffnung"
@@ -1290,6 +1290,7 @@
           "black_detergent": "Waschmittel f\u00fcr Schwarze",
           "color_detergent": "Waschmittel f\u00fcr Bunte",
           "detergent": "Waschmittel",
+          "other_rinse_agent": "Anderes Sp\u00fclmittel",
           "sensitive_detergent": "Waschmittel f\u00fcr Empfindliches",
           "softener": "Weichsp\u00fcler",
           "white_detergent": "Waschmittel f\u00fcr Wei\u00dfe"
@@ -2469,7 +2470,13 @@
         "name": "Programm"
       },
       "selected_program_mode_status": {
-        "name": "Programm Modus"
+        "name": "Programm Modus",
+        "state": {
+          "extra_fast": "Extra Schnell",
+          "fast": "Schnell",
+          "normal": "Normal",
+          "not_available": "Nicht verf\u00fcgbar"
+        }
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Programmdauer Verbleibend"
@@ -2479,6 +2486,19 @@
       },
       "selected_program_total_time_in_minutes": {
         "name": "Programmdauer Gesamt"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Programm Schleuderdrehzahl",
+        "state": {
+          "0_rpm": "0 U/min",
+          "1000_rpm": "1000 U/min",
+          "1200_rpm": "1200 U/min",
+          "1400_rpm": "1400 U/min",
+          "400_rpm": "400 U/min",
+          "800_rpm": "800 U/min",
+          "no_spin": "Kein Schleudern",
+          "not_available": "Nicht verf\u00fcgbar"
+        }
       },
       "selected_programduration_inminutes": {
         "name": "Programmdauer Gesamt"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -834,9 +834,6 @@
       "existing_sr_mode": {
         "name": "Existing SR mode"
       },
-      "extra_rinse_status": {
-        "name": "Extra rinse"
-      },
       "f-filter": {
         "name": "Filter"
       },
@@ -1221,23 +1218,11 @@
       "selected_program_disinfection": {
         "name": "Disinfection"
       },
-      "selected_program_entry_steam_status": {
-        "name": "Entry steam"
-      },
       "selected_program_extradry_status": {
         "name": "Extra dry"
       },
-      "selected_program_prewash_status": {
-        "name": "Prewash"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Rinse hold"
-      },
       "selected_program_steamfinish": {
         "name": "Steam finish"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Water pulse"
       },
       "session_pairing_active": {
         "name": "Session pairing active"
@@ -2016,6 +2001,14 @@
           "stop_finish": "Stop finish"
         }
       },
+      "ads_dirtiness_setting_status": {
+        "name": "Dirtiness",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "medium": "Medium"
+        }
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Auto-dose quantity"
       },
@@ -2049,6 +2042,29 @@
         "state": {
           "exhaust": "Exhaust",
           "recirculation": "Recirculation"
+        }
+      },
+      "compartment1_type_setting_status": {
+        "name": "Compartment 1 type",
+        "state": {
+          "black_detergent": "Black detergent",
+          "color_detergent": "Color detergent",
+          "detergent": "Detergent",
+          "sensitive_detergent": "Sensitive detergent",
+          "softener": "Softener",
+          "white_detergent": "White detergent"
+        }
+      },
+      "compartment2_type_setting_status": {
+        "name": "Compartment 2 type",
+        "state": {
+          "black_detergent": "Black detergent",
+          "color_detergent": "Color detergent",
+          "detergent": "Detergent",
+          "other_rinse_agent": "Other rinse agent",
+          "sensitive_detergent": "Sensitive detergent",
+          "softener": "Softener",
+          "white_detergent": "White detergent"
         }
       },
       "condensewatermode": {
@@ -2099,6 +2115,16 @@
           "more": "More",
           "off": "Off",
           "standard": "Standard"
+        }
+      },
+      "detergent_amount_status": {
+        "name": "Detergent amount",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Off"
         }
       },
       "displaybrightness": {
@@ -2176,12 +2202,39 @@
           "simplified_chinese": "Simplified chinese"
         }
       },
+      "liquid_unit_setting_status": {
+        "name": "Liquid unit",
+        "state": {
+          "ml": "ml",
+          "tbs": "tbs"
+        }
+      },
       "load": {
         "name": "Load",
         "state": {
           "100_percent": "100 percent",
           "25_percent": "25 percent",
           "50_percent": "50 percent"
+        }
+      },
+      "max_rpm_allowed_stat": {
+        "name": "Max spin speed",
+        "state": {
+          "0_rpm": "0 RPM",
+          "1000_rpm": "1000 RPM",
+          "1100_rpm": "1100 RPM",
+          "1200_rpm": "1200 RPM",
+          "1300_rpm": "1300 RPM",
+          "1400_rpm": "1400 RPM",
+          "1500_rpm": "1500 RPM",
+          "1600_rpm": "1600 RPM",
+          "1700_rpm": "1700 RPM",
+          "1800_rpm": "1800 RPM",
+          "400_rpm": "400 RPM",
+          "600_rpm": "600 RPM",
+          "700_rpm": "700 RPM",
+          "800_rpm": "800 RPM",
+          "900_rpm": "900 RPM"
         }
       },
       "notification_volumen_setting_status": {
@@ -2294,20 +2347,38 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Program",
+        "name": "Selected program",
         "state": {
           "auto": "Auto",
+          "baby": "Baby",
           "clean": "Clean",
+          "color": "Color",
+          "down_feathers": "Down feathers",
+          "draining": "Draining",
+          "drum_cleaning": "Drum cleaning",
           "eco": "Eco",
+          "eco_40_60": "Eco 40 60",
+          "extra_hygiene": "Extra hygiene",
+          "fast_20": "Fast 20",
           "glass": "Glass",
           "hygiene": "Hygiene",
           "intensive": "Intensive",
+          "intensive_59_32": "Intensive 59 32",
+          "mix_synthetic": "Mix synthetic",
           "night": "Night",
+          "no_program_selected": "No program selected",
           "one_hour": "One hour",
+          "pet_hair_removal": "Pet hair removal",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rinse and hold",
+          "rinsing_softening": "Rinsing softening",
           "self_cleaning": "Self cleaning",
-          "time_program": "Time program"
+          "shirts": "Shirts",
+          "spinning_draining": "Spinning draining",
+          "sport": "Sport",
+          "time_program": "Time program",
+          "white_cotton": "White cotton",
+          "wool_manual": "Wool manual"
         }
       },
       "selected_program_mode": {
@@ -2318,6 +2389,24 @@
           "normal": "Normal",
           "not_available": "Not available",
           "speed": "Speed"
+        }
+      },
+      "selected_program_mode2_status": {
+        "name": "Eco mode",
+        "state": {
+          "green_mode": "Green",
+          "night_mode": "Night",
+          "speed_mode": "Speed"
+        }
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Temperature",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "cold": "Cold"
         }
       },
       "setmaxmotorspeed": {
@@ -2351,6 +2440,25 @@
           "more": "More",
           "off": "Off",
           "standard": "Standard"
+        }
+      },
+      "softener_amount_status": {
+        "name": "Softener amount",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Off"
+        }
+      },
+      "sound_setting_status": {
+        "name": "Volume",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
         }
       },
       "spin_speed_rpm": {
@@ -2562,6 +2670,13 @@
           "fahrenheit": "Fahrenheit"
         }
       },
+      "temperature_unit_setting_status": {
+        "name": "Temperature unit",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
       "time_format": {
         "name": "Time format",
         "state": {
@@ -2599,6 +2714,20 @@
           "stop": "Stop"
         }
       },
+      "units_setting_status": {
+        "name": "Units",
+        "state": {
+          "imperial": "Imperial",
+          "metric": "Metric"
+        }
+      },
+      "view_size_setting_status": {
+        "name": "View size",
+        "state": {
+          "big_text": "Big text",
+          "normal_text": "Normal text"
+        }
+      },
       "volume": {
         "name": "Volume",
         "state": {
@@ -2621,9 +2750,19 @@
         "name": "Water hardness"
       },
       "water_hardness_setting_status": {
-        "name": "Water hardness setting status",
+        "name": "Water hardness",
         "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
           "not_set": "Not set"
+        }
+      },
+      "weight_unit_setting_status": {
+        "name": "Weight unit",
+        "state": {
+          "kg": "kg",
+          "lbs": "lbs"
         }
       }
     },
@@ -2639,9 +2778,6 @@
       },
       "activemodemotorlevel": {
         "name": "Active mode motor level"
-      },
-      "adapt_sense_setting_status": {
-        "name": "Adapt sense setting status"
       },
       "adapttech_setting": {
         "name": "Adapt tech setting"
@@ -2661,9 +2797,6 @@
       "add_water_flag": {
         "name": "Add water flag"
       },
-      "ads_dirtiness_setting_status": {
-        "name": "ADS dirtiness setting status"
-      },
       "ads_settings_current_program_detergent_setting_status": {
         "name": "ADS settings current program detergent setting status"
       },
@@ -2681,9 +2814,6 @@
       },
       "air_freshness": {
         "name": "Air freshness"
-      },
-      "air_shower_setting_status": {
-        "name": "Air shower setting status"
       },
       "airdryflag": {
         "name": "Air dry flag"
@@ -2842,14 +2972,8 @@
       "auto_dose_duration": {
         "name": "Auto-dose duration"
       },
-      "auto_dose_system_setting_status": {
-        "name": "Auto-dose system setting status"
-      },
       "auto_grease_filter_indication": {
         "name": "Auto grease filter"
-      },
-      "auto_super_rinse_setting_status": {
-        "name": "Auto super rinse setting status"
       },
       "auto_tower_up": {
         "name": "Tower auto-raise"
@@ -3023,17 +3147,8 @@
       "coldwash": {
         "name": "Cold wash"
       },
-      "color_sensor_setting_status": {
-        "name": "Color sensor setting status"
-      },
       "commodity_inspection": {
         "name": "Commodity inspection"
-      },
-      "compartment1_type_setting_status": {
-        "name": "Compartment 1 type setting status"
-      },
-      "compartment2_type_setting_status": {
-        "name": "Compartment 2 type setting status"
       },
       "compartment_inuse": {
         "name": "Compartment in use"
@@ -3318,9 +3433,6 @@
       "descale_status": {
         "name": "Descale status"
       },
-      "detergent_amount_status": {
-        "name": "Detergent amount status"
-      },
       "detergent_buynotifyswitch": {
         "name": "Detergent buy notify switch"
       },
@@ -3483,9 +3595,6 @@
       "dose_assist_recommended_low_concenatration_detergent_quantity": {
         "name": "Dose assist recommended low concentration detergent quantity"
       },
-      "dose_assist_status": {
-        "name": "Dose assist status"
-      },
       "dose_detergent_amount": {
         "name": "Dose detergent amount"
       },
@@ -3503,9 +3612,6 @@
       },
       "downloadprogram": {
         "name": "Download program"
-      },
-      "drum_light_setting_status": {
-        "name": "Drum light setting status"
       },
       "drumcleancycle_runsnumber": {
         "name": "Drum clean cycle runs number"
@@ -4585,9 +4691,6 @@
       "lightscolor_temperature_setting": {
         "name": "Lights color temperature setting"
       },
-      "liquid_unit_setting_status": {
-        "name": "Liquid unit setting status"
-      },
       "load_operation_status2": {
         "name": "Load operation status 2"
       },
@@ -4645,9 +4748,6 @@
       },
       "market_mode_exist": {
         "name": "Market mode exist"
-      },
-      "max_rpm_allowed_stat": {
-        "name": "Max RPM allowed status"
       },
       "maxtimeevent": {
         "name": "Max time event"
@@ -4764,9 +4864,6 @@
       },
       "no_autodoseswitch": {
         "name": "No auto-dose switch"
-      },
-      "no_sound_status": {
-        "name": "No sound status"
       },
       "normal_sound_size": {
         "name": "Normal sound size"
@@ -4887,9 +4984,6 @@
       },
       "power_save": {
         "name": "Power save"
-      },
-      "power_save_status": {
-        "name": "Power save status"
       },
       "power_value": {
         "name": "Power value"
@@ -5423,27 +5517,7 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Selected program",
-        "state": {
-          "baby": "Baby",
-          "color": "Color",
-          "down_feathers": "Down feathers",
-          "draining": "Draining",
-          "drum_cleaning": "Drum Cleaning",
-          "eco_40_60": "Eco 40-60",
-          "extra_hygiene": "Extra Hygiene",
-          "fast_20": "Fast 20'",
-          "intensive_59_32": "Intensive 59'/32'",
-          "mix_synthetic": "Mix/Synthetic",
-          "no_program_selected": "No program selected",
-          "pet_hair_removal": "Pet hair removal",
-          "rinsing_softening": "Rinsing & Softening",
-          "shirts": "Shirts",
-          "spinning_draining": "Spinning & Draining",
-          "sport": "Sport",
-          "white_cotton": "White Cotton",
-          "wool_manual": "Wool & Manual"
-        }
+        "name": "Selected program"
       },
       "selected_program_intensive_mode": {
         "name": "Selected program intensive mode"
@@ -5456,9 +5530,6 @@
       },
       "selected_program_mode": {
         "name": "Selected program mode"
-      },
-      "selected_program_mode2_status": {
-        "name": "Selected program mode 2 status"
       },
       "selected_program_mode_status": {
         "name": "Program mode",
@@ -5474,20 +5545,6 @@
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Remaining time of selected program"
-      },
-      "selected_program_set_temperature_status": {
-        "name": "Temperature",
-        "state": {
-          "20_c": "20 \u00b0C",
-          "30_c": "30 \u00b0C",
-          "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C",
-          "cold": "Cold",
-          "not_available": "Not available"
-        }
-      },
-      "selected_program_small_load_status": {
-        "name": "Selected program small load status"
       },
       "selected_program_storage_function": {
         "name": "Selected program storage function"
@@ -6540,17 +6597,11 @@
       "slotdry_flag1": {
         "name": "Slotdry flag 1"
       },
-      "smart_sync_setting_status": {
-        "name": "Smart sync setting status"
-      },
       "soft_pairing_setting": {
         "name": "Soft pairing setting"
       },
       "soft_pairing_status": {
         "name": "Soft pairing status"
-      },
-      "softener_amount_status": {
-        "name": "Softener amount status"
       },
       "softener_buynotifyswitch": {
         "name": "Softener buy notify switch"
@@ -6605,9 +6656,6 @@
       },
       "sound_setting": {
         "name": "Sound setting"
-      },
-      "sound_setting_status": {
-        "name": "Sound setting status"
       },
       "sound_settings": {
         "name": "Sound settings"
@@ -7732,9 +7780,6 @@
       "temperature_room_judge": {
         "name": "Temperature room judge"
       },
-      "temperature_unit_setting_status": {
-        "name": "Temperature unit setting status"
-      },
       "temperature_unit_status": {
         "name": "Temperature unit status"
       },
@@ -7780,9 +7825,6 @@
       },
       "time_program_set_time_status": {
         "name": "Time program set time status"
-      },
-      "time_save_status": {
-        "name": "Time save status"
       },
       "time_zone_setting": {
         "name": "Time zone setting"
@@ -7862,17 +7904,11 @@
       "totalprogramscycles": {
         "name": "Total program cycles"
       },
-      "turbidity_sensor_setting_status": {
-        "name": "Turbidity sensor setting status"
-      },
       "unfreeze_run_status": {
         "name": "Unfreeze run status"
       },
       "unfreeze_switch_status": {
         "name": "Unfreeze switch status"
-      },
-      "units_setting_status": {
-        "name": "Units setting status"
       },
       "unpair_all_users": {
         "name": "Unpair all users"
@@ -7933,9 +7969,6 @@
       },
       "variation_sensor_real_temperature": {
         "name": "Variation sensor real temperature"
-      },
-      "view_size_setting_status": {
-        "name": "View size setting status"
       },
       "volume_setting": {
         "name": "Volume setting"
@@ -8144,9 +8177,6 @@
       "water_hardness_setting": {
         "name": "Water hardness setting"
       },
-      "water_hardness_setting_status": {
-        "name": "Water hardness"
-      },
       "water_heat_switch": {
         "name": "Water heat switch"
       },
@@ -8192,9 +8222,6 @@
       },
       "weight_unit_setting": {
         "name": "Weight unit setting"
-      },
-      "weight_unit_setting_status": {
-        "name": "Weight unit setting status"
       },
       "wet_and_dry_space": {
         "name": "Wet and dry space"
@@ -8279,11 +8306,17 @@
       "activemodestatus": {
         "name": "Active mode"
       },
+      "adapt_sense_setting_status": {
+        "name": "Adapt sense"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptive sense setting"
       },
       "addclothes": {
         "name": "Add clothes"
+      },
+      "air_shower_setting_status": {
+        "name": "Air shower"
       },
       "allergymodeenable": {
         "name": "Allergy mode"
@@ -8321,8 +8354,14 @@
       "auto_dose_setting_status": {
         "name": "Auto-dose"
       },
+      "auto_dose_system_setting_status": {
+        "name": "Auto-dose system"
+      },
       "auto_fast_preheat": {
         "name": "Auto fast preheat"
+      },
+      "auto_super_rinse_setting_status": {
+        "name": "Auto super rinse"
       },
       "autodose": {
         "name": "Auto-dose"
@@ -8336,6 +8375,9 @@
       "child_lock": {
         "name": "Child lock"
       },
+      "child_lock_setting_status": {
+        "name": "Child lock"
+      },
       "childlockenabled": {
         "name": "Child lock"
       },
@@ -8345,22 +8387,37 @@
       "coldwash": {
         "name": "Cold wash"
       },
+      "color_sensor_setting_status": {
+        "name": "Color sensor"
+      },
       "crisp_function_status": {
         "name": "Crisp function status"
       },
       "demo_mode": {
         "name": "Demo mode"
       },
+      "demo_mode_status": {
+        "name": "Demo mode"
+      },
       "display_standby": {
         "name": "Display standby"
       },
+      "dose_assist_status": {
+        "name": "Dose assist"
+      },
       "drum_light": {
+        "name": "Drum light"
+      },
+      "drum_light_setting_status": {
         "name": "Drum light"
       },
       "drumvleanprogramwarning": {
         "name": "Drum clean program warning"
       },
       "extra_rinse": {
+        "name": "Extra rinse"
+      },
+      "extra_rinse_status": {
         "name": "Extra rinse"
       },
       "extrarinse": {
@@ -8402,6 +8459,9 @@
       "lightstatus": {
         "name": "Light"
       },
+      "logo_setting_status": {
+        "name": "Logo"
+      },
       "mute": {
         "name": "Mute"
       },
@@ -8411,8 +8471,14 @@
       "night_mode_status": {
         "name": "Night mode status"
       },
+      "no_sound_status": {
+        "name": "Mute"
+      },
       "odor_control_setting": {
         "name": "Odor control"
+      },
+      "power_save_status": {
+        "name": "Power save"
       },
       "prewash": {
         "name": "Prewash"
@@ -8429,6 +8495,27 @@
       "save_mode": {
         "name": "Save mode"
       },
+      "selected_program_anticrease_status": {
+        "name": "Anti-crease"
+      },
+      "selected_program_entry_steam_status": {
+        "name": "Entry steam"
+      },
+      "selected_program_prewash_status": {
+        "name": "Prewash"
+      },
+      "selected_program_rinse_hold_status": {
+        "name": "Rinse hold"
+      },
+      "selected_program_small_load_status": {
+        "name": "Small load"
+      },
+      "selected_program_water_pluse_status": {
+        "name": "Water pulse"
+      },
+      "session_pairing_status": {
+        "name": "Session pairing"
+      },
       "sf_mode": {
         "name": "SF mode"
       },
@@ -8437,6 +8524,12 @@
       },
       "showmeasuredtemperature": {
         "name": "Show measured temperature"
+      },
+      "smart_sync_setting_status": {
+        "name": "Smart sync"
+      },
+      "soft_pairing_status": {
+        "name": "Soft pairing"
       },
       "sound": {
         "name": "Sound"
@@ -8515,6 +8608,12 @@
       },
       "time_save": {
         "name": "Time save"
+      },
+      "time_save_status": {
+        "name": "Time save"
+      },
+      "turbidity_sensor_setting_status": {
+        "name": "Turbidity sensor"
       },
       "welcome": {
         "name": "Welcome"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1210,7 +1210,7 @@
         "name": "Sabbath mode switch status"
       },
       "selected_program_anticrease_status": {
-        "name": "Selected program anti crease status"
+        "name": "Anti-crease"
       },
       "selected_program_auto_door_open_function": {
         "name": "Selected program auto door open"
@@ -2056,11 +2056,12 @@
         }
       },
       "compartment2_type_setting_status": {
-        "name": "Compartment 2 type setting status",
+        "name": "Compartment 2 type",
         "state": {
           "black_detergent": "Black detergent",
           "color_detergent": "Color detergent",
           "detergent": "Detergent",
+          "other_rinse_agent": "Other rinse agent",
           "sensitive_detergent": "Sensitive detergent",
           "softener": "Softener",
           "white_detergent": "White detergent"
@@ -5598,14 +5599,14 @@
         "name": "Selected program UV function"
       },
       "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Selected program washing spin speed rpm status",
+        "name": "Spin speed",
         "state": {
-          "0_rpm": "0 rpm",
-          "1000_rpm": "1000 rpm",
-          "1200_rpm": "1200 rpm",
-          "1400_rpm": "1400 rpm",
-          "400_rpm": "400 rpm",
-          "800_rpm": "800 rpm",
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "400_rpm": "400",
+          "800_rpm": "800",
           "no_spin": "No spin",
           "not_available": "Not available"
         }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2107,6 +2107,14 @@
           "none": "None"
         }
       },
+      "delaystart_delayend_mode_status": {
+        "name": "Delay start mode",
+        "state": {
+          "delay_end": "Delay end",
+          "delay_start": "Delay start",
+          "not_active": "Not active"
+        }
+      },
       "detergent": {
         "name": "Detergent",
         "state": {
@@ -2399,6 +2407,17 @@
           "speed_mode": "Speed"
         }
       },
+      "selected_program_mode_status": {
+        "name": "Program mode",
+        "state": {
+          "extra_fast": "Extra fast",
+          "fast": "Fast",
+          "intensive": "Intensive",
+          "normal": "Normal",
+          "time_care_1": "Time Care 1",
+          "time_care_2": "Time Care 2"
+        }
+      },
       "selected_program_set_temperature_status": {
         "name": "Temperature",
         "state": {
@@ -2407,6 +2426,21 @@
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
           "cold": "Cold"
+        }
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Spin speed",
+        "state": {
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "1600_rpm": "1600",
+          "400_rpm": "400",
+          "600_rpm": "600",
+          "700_rpm": "700",
+          "800_rpm": "800",
+          "no_spin": "No spin"
         }
       },
       "setmaxmotorspeed": {
@@ -3404,13 +3438,6 @@
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Delay start duration"
-      },
-      "delaystart_delayend_mode_status": {
-        "name": "Delay start status",
-        "state": {
-          "off": "Off",
-          "on": "On"
-        }
       },
       "delaystart_delayend_remaining_time_in_minutes": {
         "name": "Delay start/end remaining time"
@@ -5532,13 +5559,7 @@
         "name": "Selected program mode"
       },
       "selected_program_mode_status": {
-        "name": "Program mode",
-        "state": {
-          "extra_fast": "Extra fast",
-          "fast": "Fast",
-          "normal": "Normal",
-          "not_available": "Not available"
-        }
+        "name": "Program mode"
       },
       "selected_program_night_mode": {
         "name": "Selected program night mode"
@@ -5569,19 +5590,6 @@
       },
       "selected_program_uv_function": {
         "name": "Selected program UV function"
-      },
-      "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Spin speed",
-        "state": {
-          "0_rpm": "0",
-          "1000_rpm": "1000",
-          "1200_rpm": "1200",
-          "1400_rpm": "1400",
-          "400_rpm": "400",
-          "800_rpm": "800",
-          "no_spin": "No spin",
-          "not_available": "Not available"
-        }
       },
       "selected_program_water_add": {
         "name": "Selected program water add"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1210,7 +1210,7 @@
         "name": "Sabbath mode switch status"
       },
       "selected_program_anticrease_status": {
-        "name": "Anti-crease"
+        "name": "Selected program anti crease status"
       },
       "selected_program_auto_door_open_function": {
         "name": "Selected program auto door open"
@@ -2056,12 +2056,11 @@
         }
       },
       "compartment2_type_setting_status": {
-        "name": "Compartment 2 type",
+        "name": "Compartment 2 type setting status",
         "state": {
           "black_detergent": "Black detergent",
           "color_detergent": "Color detergent",
           "detergent": "Detergent",
-          "other_rinse_agent": "Other rinse agent",
           "sensitive_detergent": "Sensitive detergent",
           "softener": "Softener",
           "white_detergent": "White detergent"
@@ -2112,7 +2111,9 @@
         "state": {
           "delay_end": "Delay end",
           "delay_start": "Delay start",
-          "not_active": "Not active"
+          "not_active": "Not active",
+          "off": "Off",
+          "on": "On"
         }
       },
       "detergent": {
@@ -2363,30 +2364,30 @@
           "color": "Color",
           "down_feathers": "Down feathers",
           "draining": "Draining",
-          "drum_cleaning": "Drum cleaning",
+          "drum_cleaning": "Drum Cleaning",
           "eco": "Eco",
-          "eco_40_60": "Eco 40 60",
-          "extra_hygiene": "Extra hygiene",
-          "fast_20": "Fast 20",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Extra Hygiene",
+          "fast_20": "Fast 20'",
           "glass": "Glass",
           "hygiene": "Hygiene",
           "intensive": "Intensive",
-          "intensive_59_32": "Intensive 59 32",
-          "mix_synthetic": "Mix synthetic",
+          "intensive_59_32": "Intensive 59'/32'",
+          "mix_synthetic": "Mix/Synthetic",
           "night": "Night",
           "no_program_selected": "No program selected",
           "one_hour": "One hour",
           "pet_hair_removal": "Pet hair removal",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rinse and hold",
-          "rinsing_softening": "Rinsing softening",
+          "rinsing_softening": "Rinsing & Softening",
           "self_cleaning": "Self cleaning",
           "shirts": "Shirts",
-          "spinning_draining": "Spinning draining",
+          "spinning_draining": "Spinning & Draining",
           "sport": "Sport",
           "time_program": "Time program",
-          "white_cotton": "White cotton",
-          "wool_manual": "Wool manual"
+          "white_cotton": "White Cotton",
+          "wool_manual": "Wool & Manual"
         }
       },
       "selected_program_mode": {
@@ -2410,8 +2411,6 @@
       "selected_program_mode_status": {
         "name": "Program mode",
         "state": {
-          "extra_fast": "Extra fast",
-          "fast": "Fast",
           "intensive": "Intensive",
           "normal": "Normal",
           "time_care_1": "Time Care 1",
@@ -2425,6 +2424,8 @@
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
+          "90_c": "90 \u00b0C",
+          "95_c": "95 \u00b0C",
           "cold": "Cold"
         }
       },
@@ -2439,8 +2440,7 @@
           "400_rpm": "400",
           "600_rpm": "600",
           "700_rpm": "700",
-          "800_rpm": "800",
-          "no_spin": "No spin"
+          "800_rpm": "800"
         }
       },
       "setmaxmotorspeed": {
@@ -5559,7 +5559,13 @@
         "name": "Selected program mode"
       },
       "selected_program_mode_status": {
-        "name": "Program mode"
+        "name": "Program mode",
+        "state": {
+          "extra_fast": "Extra fast",
+          "fast": "Fast",
+          "normal": "Normal",
+          "not_available": "Not available"
+        }
       },
       "selected_program_night_mode": {
         "name": "Selected program night mode"
@@ -5590,6 +5596,19 @@
       },
       "selected_program_uv_function": {
         "name": "Selected program UV function"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Selected program washing spin speed rpm status",
+        "state": {
+          "0_rpm": "0 rpm",
+          "1000_rpm": "1000 rpm",
+          "1200_rpm": "1200 rpm",
+          "1400_rpm": "1400 rpm",
+          "400_rpm": "400 rpm",
+          "800_rpm": "800 rpm",
+          "no_spin": "No spin",
+          "not_available": "Not available"
+        }
       },
       "selected_program_water_add": {
         "name": "Selected program water add"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -671,6 +671,12 @@
       "auto_dose_quantity_setting_status": {
         "name": "Configuraci\u00f3n autom\u00e1tica de la cantidad de dosificador"
       },
+      "delaystart_delayend_mode_status": {
+        "state": {
+          "off": "Apagado",
+          "on": "Encendido"
+        }
+      },
       "dry_level": {
         "name": "Nivel Secado",
         "state": {}

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -660,6 +660,14 @@
       }
     },
     "select": {
+      "ads_dirtiness_setting_status": {
+        "name": "Suciedad",
+        "state": {
+          "high": "Alta",
+          "low": "Baja",
+          "medium": "Media"
+        }
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Configuraci\u00f3n autom\u00e1tica de la cantidad de dosificador"
       },
@@ -682,6 +690,9 @@
           "mid": "Medio",
           "mute": "Silenciar"
         }
+      },
+      "max_rpm_allowed_stat": {
+        "name": "Velocidad m\u00e1xima de centrifugado"
       },
       "notification_volumen_setting_status": {
         "state": {
@@ -749,6 +760,23 @@
           "night": "Noche",
           "normal": "Normal",
           "speed": "R\u00e1pido"
+        }
+      },
+      "selected_program_mode2_status": {
+        "name": "Modo eco",
+        "state": {
+          "green_mode": "Verde",
+          "night_mode": "Noche",
+          "speed_mode": "Velocidad"
+        }
+      },
+      "sound_setting_status": {
+        "name": "Volumen",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
         }
       },
       "spin_speed_rpm": {
@@ -1080,8 +1108,7 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Programa seleccionado",
-        "state": {}
+        "name": "Programa seleccionado"
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Tiempo restante programa seleccionado"
@@ -1569,6 +1596,9 @@
       },
       "mute": {
         "name": "Silenciar"
+      },
+      "no_sound_status": {
+        "name": "Silencio"
       },
       "prewash": {
         "name": "Prelavado"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1797,6 +1797,14 @@
           "none": "Geen"
         }
       },
+      "delaystart_delayend_mode_status": {
+        "name": "Uitgestelde start",
+        "state": {
+          "delay_end": "Uitgesteld einde",
+          "delay_start": "Uitgestelde start",
+          "not_active": "Niet actief"
+        }
+      },
       "detergent": {
         "name": "Wasmiddel",
         "state": {
@@ -2064,6 +2072,17 @@
           "speed_mode": "Snel"
         }
       },
+      "selected_program_mode_status": {
+        "name": "Programmamodus",
+        "state": {
+          "extra_fast": "Extra snel",
+          "fast": "Snel",
+          "intensive": "Intensief",
+          "normal": "Normaal",
+          "time_care_1": "Time Care 1",
+          "time_care_2": "Time Care 2"
+        }
+      },
       "selected_program_set_temperature_status": {
         "name": "Temperatuur",
         "state": {
@@ -2072,6 +2091,21 @@
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
           "cold": "Koud"
+        }
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Centrifugesnelheid",
+        "state": {
+          "0_rpm": "0 toeren",
+          "1000_rpm": "1000 toeren",
+          "1200_rpm": "1200 toeren",
+          "1400_rpm": "1400 toeren",
+          "1600_rpm": "1600 toeren",
+          "400_rpm": "400 toeren",
+          "600_rpm": "600 toeren",
+          "700_rpm": "700 toeren",
+          "800_rpm": "800 toeren",
+          "no_spin": "Niet centrifugeren"
         }
       },
       "softener": {
@@ -2989,13 +3023,6 @@
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Uitgestelde start duur"
-      },
-      "delaystart_delayend_mode_status": {
-        "name": "Uitgestelde start",
-        "state": {
-          "off": "Uit",
-          "on": "Aan"
-        }
       },
       "delaystart_delayend_remaining_time_in_minutes": {
         "name": "Resterende tijd uitgestelde start/einde"
@@ -4942,13 +4969,7 @@
         "name": "Selected program mode"
       },
       "selected_program_mode_status": {
-        "name": "Programmamodus",
-        "state": {
-          "extra_fast": "Extra snel",
-          "fast": "Snel",
-          "normal": "Normaal",
-          "not_available": "Niet beschikbaar"
-        }
+        "name": "Programmamodus"
       },
       "selected_program_night_mode": {
         "name": "Selected program night mode"
@@ -4979,19 +5000,6 @@
       },
       "selected_program_uv_function": {
         "name": "Selected program UV function"
-      },
-      "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Centrifugeersnelheid",
-        "state": {
-          "0_rpm": "0 toeren",
-          "1000_rpm": "1000 toeren",
-          "1200_rpm": "1200 toeren",
-          "1400_rpm": "1400 toeren",
-          "400_rpm": "400 toeren",
-          "800_rpm": "800 toeren",
-          "no_spin": "Niet centrifugeren",
-          "not_available": "Niet beschikbaar"
-        }
       },
       "selected_program_water_add": {
         "name": "Selected program water add"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -609,9 +609,6 @@
       "existing_sr_mode": {
         "name": "Bestaande SR-modus"
       },
-      "extra_rinse_status": {
-        "name": "Spoelen+"
-      },
       "f-filter": {
         "name": "Filter"
       },
@@ -951,23 +948,11 @@
       "selected_program_disinfection": {
         "name": "Desinfectie"
       },
-      "selected_program_entry_steam_status": {
-        "name": "Stoomtoevoer"
-      },
       "selected_program_extradry_status": {
         "name": "Extra droog"
       },
-      "selected_program_prewash_status": {
-        "name": "Voorwas"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Spoelstop"
-      },
       "selected_program_steamfinish": {
         "name": "Stoomafwerking"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Water pulse"
       },
       "session_pairing_active": {
         "name": "Sessiekoppeling actief"
@@ -1720,6 +1705,14 @@
           "stop_finish": "Stop afronden"
         }
       },
+      "ads_dirtiness_setting_status": {
+        "name": "Vuilheid",
+        "state": {
+          "high": "Hoog",
+          "low": "Laag",
+          "medium": "Gemiddeld"
+        }
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Auto doseer hoeveelheid"
       },
@@ -1746,6 +1739,29 @@
         "state": {
           "exhaust": "Afvoer",
           "recirculation": "Recirculatie"
+        }
+      },
+      "compartment1_type_setting_status": {
+        "name": "Compartiment 1 type",
+        "state": {
+          "black_detergent": "Zwartwasmiddel",
+          "color_detergent": "Kleurwasmiddel",
+          "detergent": "Wasmiddel",
+          "sensitive_detergent": "Wasmiddel voor gevoelige stoffen",
+          "softener": "Wasverzachter",
+          "white_detergent": "Witwasmiddel"
+        }
+      },
+      "compartment2_type_setting_status": {
+        "name": "Compartiment 2 type",
+        "state": {
+          "black_detergent": "Zwartwasmiddel",
+          "color_detergent": "Kleurwasmiddel",
+          "detergent": "Wasmiddel",
+          "other_rinse_agent": "Ander spoelmiddel",
+          "sensitive_detergent": "Wasmiddel voor gevoelige stoffen",
+          "softener": "Wasverzachter",
+          "white_detergent": "Witwasmiddel"
         }
       },
       "cooking_intensity": {
@@ -1789,6 +1805,16 @@
           "more": "Meer",
           "off": "Uit",
           "standard": "Standaard"
+        }
+      },
+      "detergent_amount_status": {
+        "name": "Wasmiddelhoeveelheid",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Uit"
         }
       },
       "dry_level": {
@@ -1847,6 +1873,33 @@
         "state": {
           "english": "Engels",
           "simplified_chinese": "Vereenvoudigd Chinees"
+        }
+      },
+      "liquid_unit_setting_status": {
+        "name": "Vloeistofeenheid",
+        "state": {
+          "ml": "ml",
+          "tbs": "el"
+        }
+      },
+      "max_rpm_allowed_stat": {
+        "name": "Max centrifugesnelheid",
+        "state": {
+          "0_rpm": "0 toeren",
+          "1000_rpm": "1000 toeren",
+          "1100_rpm": "1100 toeren",
+          "1200_rpm": "1200 toeren",
+          "1300_rpm": "1300 toeren",
+          "1400_rpm": "1400 toeren",
+          "1500_rpm": "1500 toeren",
+          "1600_rpm": "1600 toeren",
+          "1700_rpm": "1700 toeren",
+          "1800_rpm": "1800 toeren",
+          "400_rpm": "400 toeren",
+          "600_rpm": "600 toeren",
+          "700_rpm": "700 toeren",
+          "800_rpm": "800 toeren",
+          "900_rpm": "900 toeren"
         }
       },
       "notification_volumen_setting_status": {
@@ -1962,17 +2015,35 @@
         "name": "Geselecteerd programma",
         "state": {
           "auto": "Auto",
+          "baby": "Baby",
           "clean": "Schoon",
+          "color": "Kleur",
+          "down_feathers": "Donsveren",
+          "draining": "Afpompen",
+          "drum_cleaning": "Trommelreiniging",
           "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Extra hygi\u00ebne",
+          "fast_20": "Snel 20'",
           "glass": "Glas",
           "hygiene": "Hygi\u00ebne",
           "intensive": "Intensief",
+          "intensive_59_32": "Intensief 59'/32'",
+          "mix_synthetic": "Mix/Synthetisch",
           "night": "Nacht",
+          "no_program_selected": "Geen programma geselecteerd",
           "one_hour": "1 uur",
+          "pet_hair_removal": "Huisdierhaar verwijderen",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Spoelen en wachten",
+          "rinsing_softening": "Spoelen & verzachten",
           "self_cleaning": "Zelfreiniging",
-          "time_program": "Tijdprogramma"
+          "shirts": "Shirts",
+          "spinning_draining": "Centrifugeren & afpompen",
+          "sport": "Sport",
+          "time_program": "Tijdprogramma",
+          "white_cotton": "Wit katoen",
+          "wool_manual": "Wol & Handmatig"
         }
       },
       "selected_program_mode": {
@@ -1985,6 +2056,24 @@
           "speed": "Snel"
         }
       },
+      "selected_program_mode2_status": {
+        "name": "Eco-modus",
+        "state": {
+          "green_mode": "Groen",
+          "night_mode": "Nacht",
+          "speed_mode": "Snel"
+        }
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Temperatuur",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "cold": "Koud"
+        }
+      },
       "softener": {
         "name": "Wasverzachter",
         "state": {
@@ -1993,6 +2082,25 @@
           "more": "Meer",
           "off": "Uit",
           "standard": "Standaard"
+        }
+      },
+      "softener_amount_status": {
+        "name": "Wasverzachterhoeveelheid",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Uit"
+        }
+      },
+      "sound_setting_status": {
+        "name": "Volume",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
         }
       },
       "spin_speed_rpm": {
@@ -2203,6 +2311,13 @@
           "fahrenheit": "Fahrenheit"
         }
       },
+      "temperature_unit_setting_status": {
+        "name": "Temperatuureenheid",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
       "time_format": {
         "name": "Tijdsweergave",
         "state": {
@@ -2233,6 +2348,20 @@
           "stop": "Stop"
         }
       },
+      "units_setting_status": {
+        "name": "Eenheden",
+        "state": {
+          "imperial": "Imperiaal",
+          "metric": "Metriek"
+        }
+      },
+      "view_size_setting_status": {
+        "name": "Weergavegrootte",
+        "state": {
+          "big_text": "Grote tekst",
+          "normal_text": "Normale tekst"
+        }
+      },
       "volume": {
         "name": "Volume"
       },
@@ -2250,7 +2379,17 @@
       "water_hardness_setting_status": {
         "name": "Waterhardheid",
         "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
           "not_set": "Niet ingesteld"
+        }
+      },
+      "weight_unit_setting_status": {
+        "name": "Gewichtseenheid",
+        "state": {
+          "kg": "kg",
+          "lbs": "lbs"
         }
       }
     },
@@ -2266,9 +2405,6 @@
       },
       "activemodemotorlevel": {
         "name": "Motorniveau actieve modus"
-      },
-      "adapt_sense_setting_status": {
-        "name": "Adapt Sense-instelling"
       },
       "adapttech_setting": {
         "name": "Adapt Tech-instelling"
@@ -2288,9 +2424,6 @@
       "add_water_flag": {
         "name": "Water bijvullen"
       },
-      "ads_dirtiness_setting_status": {
-        "name": "Status ADS-vuilheidsinstelling"
-      },
       "ads_settings_current_program_detergent_setting_status": {
         "name": "Status ADS-instelling wasmiddel huidig programma"
       },
@@ -2308,9 +2441,6 @@
       },
       "air_freshness": {
         "name": "Luchtverversing"
-      },
-      "air_shower_setting_status": {
-        "name": "Status Air Shower-instelling"
       },
       "airdryflag": {
         "name": "Indicator luchtdrogen"
@@ -2469,14 +2599,8 @@
       "auto_dose_duration": {
         "name": "Auto doseer duur"
       },
-      "auto_dose_system_setting_status": {
-        "name": "Status auto-dose systeeminstelling"
-      },
       "auto_grease_filter_indication": {
         "name": "Automatisch vetfilter"
-      },
-      "auto_super_rinse_setting_status": {
-        "name": "Status instelling automatisch extra spoelen"
       },
       "auto_tower_up": {
         "name": "Toren automatisch omhoog"
@@ -2629,17 +2753,8 @@
       "coldwash": {
         "name": "Koude was"
       },
-      "color_sensor_setting_status": {
-        "name": "Status kleursensorinstelling"
-      },
       "commodity_inspection": {
         "name": "Productinspectie"
-      },
-      "compartment1_type_setting_status": {
-        "name": "Status type-instelling compartiment 1"
-      },
-      "compartment2_type_setting_status": {
-        "name": "Status type-instelling compartiment 2"
       },
       "compartment_inuse": {
         "name": "Compartiment in gebruik"
@@ -2897,9 +3012,6 @@
       "descale_status": {
         "name": "Ontkalken"
       },
-      "detergent_amount_status": {
-        "name": "Wasmiddelhoeveelheid"
-      },
       "detergent_buynotifyswitch": {
         "name": "Schakelaar melding wasmiddel kopen"
       },
@@ -3052,9 +3164,6 @@
       "dose_assist_recommended_low_concenatration_detergent_quantity": {
         "name": "Aanbevolen hoeveelheid laaggeconcentreerd wasmiddel dose assist"
       },
-      "dose_assist_status": {
-        "name": "Doseerhulp status"
-      },
       "dose_detergent_amount": {
         "name": "Hoeveelheid wasmiddel doseren"
       },
@@ -3072,9 +3181,6 @@
       },
       "downloadprogram": {
         "name": "Programma downloaden"
-      },
-      "drum_light_setting_status": {
-        "name": "Trommelverlichting instelling status"
       },
       "drumcleancycle_runsnumber": {
         "name": "Aantal trommelreinigingscycli"
@@ -4037,9 +4143,6 @@
       "lightscolor_temperature_setting": {
         "name": "Lights color temperature setting"
       },
-      "liquid_unit_setting_status": {
-        "name": "Liquid unit setting status"
-      },
       "load_operation_status2": {
         "name": "Load operation status 2"
       },
@@ -4094,9 +4197,6 @@
       },
       "market_mode_exist": {
         "name": "Market mode exist"
-      },
-      "max_rpm_allowed_stat": {
-        "name": "Maximale toegestane toeren status"
       },
       "mdo_on_demand": {
         "name": "MDO on demand"
@@ -4211,9 +4311,6 @@
       "no_autodoseswitch": {
         "name": "Geen automatische dosering"
       },
-      "no_sound_status": {
-        "name": "Geen geluid status"
-      },
       "normal_sound_size": {
         "name": "Normale geluids grootte"
       },
@@ -4321,9 +4418,6 @@
       },
       "power_save": {
         "name": "Energiebesparing"
-      },
-      "power_save_status": {
-        "name": "Energiebesparing status"
       },
       "power_value": {
         "name": "Vermogen"
@@ -4833,27 +4927,7 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Geselecteerd programma",
-        "state": {
-          "baby": "Baby",
-          "color": "Kleur",
-          "down_feathers": "Donsveren",
-          "draining": "Afpompen",
-          "drum_cleaning": "Trommelreiniging",
-          "eco_40_60": "Eco 40-60",
-          "extra_hygiene": "Extra hygi\u00ebne",
-          "fast_20": "Snel 20'",
-          "intensive_59_32": "Intensief 59'/32'",
-          "mix_synthetic": "Mix/Synthetisch",
-          "no_program_selected": "Geen programma geselecteerd",
-          "pet_hair_removal": "Huisdierhaar verwijderen",
-          "rinsing_softening": "Spoelen & verzachten",
-          "shirts": "Shirts",
-          "spinning_draining": "Centrifugeren & afpompen",
-          "sport": "Sport",
-          "white_cotton": "Wit katoen",
-          "wool_manual": "Wol & Handmatig"
-        }
+        "name": "Geselecteerd programma"
       },
       "selected_program_intensive_mode": {
         "name": "Selected program intensive mode"
@@ -4866,9 +4940,6 @@
       },
       "selected_program_mode": {
         "name": "Selected program mode"
-      },
-      "selected_program_mode2_status": {
-        "name": "Selected program mode 2 status"
       },
       "selected_program_mode_status": {
         "name": "Programmamodus",
@@ -4884,20 +4955,6 @@
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Resterende tijd van geselecteerd programma"
-      },
-      "selected_program_set_temperature_status": {
-        "name": "Temperatuur",
-        "state": {
-          "20_c": "20 \u00b0C",
-          "30_c": "30 \u00b0C",
-          "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C",
-          "cold": "Koud",
-          "not_available": "Niet beschikbaar"
-        }
-      },
-      "selected_program_small_load_status": {
-        "name": "Selected program small load status"
       },
       "selected_program_storage_function": {
         "name": "Selected program storage function"
@@ -5932,17 +5989,11 @@
       "slotdry_flag1": {
         "name": "Slotdry flag 1"
       },
-      "smart_sync_setting_status": {
-        "name": "Smart sync setting status"
-      },
       "soft_pairing_setting": {
         "name": "Soft pairing setting"
       },
       "soft_pairing_status": {
         "name": "Soft pairing status"
-      },
-      "softener_amount_status": {
-        "name": "Softener amount status"
       },
       "softener_buynotifyswitch": {
         "name": "Softener buy notify switch"
@@ -5994,9 +6045,6 @@
       },
       "sound_setting": {
         "name": "Geluid"
-      },
-      "sound_setting_status": {
-        "name": "Sound setting status"
       },
       "sound_settings": {
         "name": "Sound settings"
@@ -7115,9 +7163,6 @@
       "temperature_room_judge": {
         "name": "Temperatuur kamer beoordeling"
       },
-      "temperature_unit_setting_status": {
-        "name": "Temperature unit setting status"
-      },
       "temperature_unit_status": {
         "name": "Temperature unit status"
       },
@@ -7144,9 +7189,6 @@
       },
       "time_program_set_time_status": {
         "name": "Time program set time status"
-      },
-      "time_save_status": {
-        "name": "Time save status"
       },
       "time_zone_setting": {
         "name": "Time zone setting"
@@ -7217,17 +7259,11 @@
       "total_water_consumption": {
         "name": "Totale waterverbruik"
       },
-      "turbidity_sensor_setting_status": {
-        "name": "Turbidity sensor setting status"
-      },
       "unfreeze_run_status": {
         "name": "Unfreeze run status"
       },
       "unfreeze_switch_status": {
         "name": "Unfreeze switch status"
-      },
-      "units_setting_status": {
-        "name": "Units setting status"
       },
       "unpair_all_users": {
         "name": "Unpair all users"
@@ -7288,9 +7324,6 @@
       },
       "variation_sensor_real_temperature": {
         "name": "Werkelijke variatiesensortemperatuur"
-      },
-      "view_size_setting_status": {
-        "name": "View size setting status"
       },
       "volume_setting": {
         "name": "Volume setting"
@@ -7499,9 +7532,6 @@
       "water_hardness_setting": {
         "name": "Water hardness setting"
       },
-      "water_hardness_setting_status": {
-        "name": "Waterhardheid"
-      },
       "water_heat_switch": {
         "name": "Water heat switch"
       },
@@ -7547,9 +7577,6 @@
       },
       "weight_unit_setting": {
         "name": "Weight unit setting"
-      },
-      "weight_unit_setting_status": {
-        "name": "Weight unit setting status"
       },
       "wet_and_dry_space": {
         "name": "Wet and dry space"
@@ -7634,8 +7661,14 @@
       "activemodestatus": {
         "name": "Actieve modus"
       },
+      "adapt_sense_setting_status": {
+        "name": "Adapt Sense"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptive sense instelling"
+      },
+      "air_shower_setting_status": {
+        "name": "Air Shower"
       },
       "ambientlightstatus": {
         "name": "Sfeerverlichting"
@@ -7670,8 +7703,14 @@
       "auto_dose_setting_status": {
         "name": "Automatisch doseren"
       },
+      "auto_dose_system_setting_status": {
+        "name": "Auto-dose systeem"
+      },
       "auto_fast_preheat": {
         "name": "Auto fast voorverwarmen"
+      },
+      "auto_super_rinse_setting_status": {
+        "name": "Automatisch extra spoelen"
       },
       "autodose": {
         "name": "Automatisch doseren"
@@ -7685,8 +7724,14 @@
       "child_lock": {
         "name": "Kinderbeveiliging"
       },
+      "child_lock_setting_status": {
+        "name": "Kinderbeveiliging"
+      },
       "cleanairstatus": {
         "name": "Schone lucht"
+      },
+      "color_sensor_setting_status": {
+        "name": "Kleursensor"
       },
       "crisp_function_status": {
         "name": "Crisp-functie"
@@ -7694,13 +7739,25 @@
       "demo_mode": {
         "name": "Demo modus"
       },
+      "demo_mode_status": {
+        "name": "Demomodus"
+      },
       "display_standby": {
         "name": "Display standby"
+      },
+      "dose_assist_status": {
+        "name": "Doseerhulp"
       },
       "drum_light": {
         "name": "Trommelverlichting"
       },
+      "drum_light_setting_status": {
+        "name": "Trommelverlichting"
+      },
       "extra_rinse": {
+        "name": "Spoelen+"
+      },
+      "extra_rinse_status": {
         "name": "Spoelen+"
       },
       "fota_cmd": {
@@ -7733,6 +7790,9 @@
       "lightstatus": {
         "name": "Verlichting"
       },
+      "logo_setting_status": {
+        "name": "Logo"
+      },
       "mute": {
         "name": "Stil"
       },
@@ -7742,8 +7802,14 @@
       "night_mode_status": {
         "name": "Nachtmodus"
       },
+      "no_sound_status": {
+        "name": "Dempen"
+      },
       "odor_control_setting": {
         "name": "Geurcontrole"
+      },
+      "power_save_status": {
+        "name": "Energiebesparing"
       },
       "prewash": {
         "name": "Voorwas"
@@ -7757,11 +7823,38 @@
       "save_mode": {
         "name": "Spaarstand"
       },
+      "selected_program_anticrease_status": {
+        "name": "Anti-kreuk"
+      },
+      "selected_program_entry_steam_status": {
+        "name": "Stoomtoevoer"
+      },
+      "selected_program_prewash_status": {
+        "name": "Voorwas"
+      },
+      "selected_program_rinse_hold_status": {
+        "name": "Spoelstop"
+      },
+      "selected_program_small_load_status": {
+        "name": "Kleine lading"
+      },
+      "selected_program_water_pluse_status": {
+        "name": "Water pulse"
+      },
+      "session_pairing_status": {
+        "name": "Sessiepairing"
+      },
       "sf_mode": {
         "name": "SF-modus"
       },
       "sf_sr_mutex_mode": {
         "name": "SF SR mutex modus"
+      },
+      "smart_sync_setting_status": {
+        "name": "Smart sync"
+      },
+      "soft_pairing_status": {
+        "name": "Soft pairing"
       },
       "sr_mode": {
         "name": "SR-modus"
@@ -7834,6 +7927,12 @@
       },
       "time_save": {
         "name": "Tijd besparen"
+      },
+      "time_save_status": {
+        "name": "Tijdbesparing"
+      },
+      "turbidity_sensor_setting_status": {
+        "name": "Troebelheidssensor"
       },
       "welcome": {
         "name": "Welkom"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1758,6 +1758,7 @@
           "black_detergent": "Zwartwasmiddel",
           "color_detergent": "Kleurwasmiddel",
           "detergent": "Wasmiddel",
+          "other_rinse_agent": "Ander spoelmiddel",
           "sensitive_detergent": "Wasmiddel voor gevoelige stoffen",
           "softener": "Wasverzachter",
           "white_detergent": "Witwasmiddel"
@@ -4969,7 +4970,13 @@
         "name": "Selected program mode"
       },
       "selected_program_mode_status": {
-        "name": "Programmamodus"
+        "name": "Programmamodus",
+        "state": {
+          "extra_fast": "Extra snel",
+          "fast": "Snel",
+          "normal": "Normaal",
+          "not_available": "Niet beschikbaar"
+        }
       },
       "selected_program_night_mode": {
         "name": "Selected program night mode"
@@ -5000,6 +5007,19 @@
       },
       "selected_program_uv_function": {
         "name": "Selected program UV function"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Centrifugeersnelheid",
+        "state": {
+          "0_rpm": "0 toeren",
+          "1000_rpm": "1000 toeren",
+          "1200_rpm": "1200 toeren",
+          "1400_rpm": "1400 toeren",
+          "400_rpm": "400 toeren",
+          "800_rpm": "800 toeren",
+          "no_spin": "Niet centrifugeren",
+          "not_available": "Niet beschikbaar"
+        }
       },
       "selected_program_water_add": {
         "name": "Selected program water add"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1758,7 +1758,6 @@
           "black_detergent": "Zwartwasmiddel",
           "color_detergent": "Kleurwasmiddel",
           "detergent": "Wasmiddel",
-          "other_rinse_agent": "Ander spoelmiddel",
           "sensitive_detergent": "Wasmiddel voor gevoelige stoffen",
           "softener": "Wasverzachter",
           "white_detergent": "Witwasmiddel"
@@ -1802,7 +1801,9 @@
         "state": {
           "delay_end": "Uitgesteld einde",
           "delay_start": "Uitgestelde start",
-          "not_active": "Niet actief"
+          "not_active": "Niet actief",
+          "off": "Uit",
+          "on": "Aan"
         }
       },
       "detergent": {
@@ -2075,8 +2076,6 @@
       "selected_program_mode_status": {
         "name": "Programmamodus",
         "state": {
-          "extra_fast": "Extra snel",
-          "fast": "Snel",
           "intensive": "Intensief",
           "normal": "Normaal",
           "time_care_1": "Time Care 1",
@@ -2090,6 +2089,8 @@
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
+          "90_c": "90 \u00b0C",
+          "95_c": "95 \u00b0C",
           "cold": "Koud"
         }
       },
@@ -2104,8 +2105,7 @@
           "400_rpm": "400 toeren",
           "600_rpm": "600 toeren",
           "700_rpm": "700 toeren",
-          "800_rpm": "800 toeren",
-          "no_spin": "Niet centrifugeren"
+          "800_rpm": "800 toeren"
         }
       },
       "softener": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1758,7 +1758,6 @@
           "black_detergent": "Svartvaskemiddel",
           "color_detergent": "Fargevaskemiddel",
           "detergent": "Vaskemiddel",
-          "other_rinse_agent": "Annet skyllemiddel",
           "sensitive_detergent": "Vaskemiddel for sensitive plagg",
           "softener": "T\u00f8ymykner",
           "white_detergent": "Hvitvaskemiddel"
@@ -1802,7 +1801,9 @@
         "state": {
           "delay_end": "Utsatt slutt",
           "delay_start": "Utsatt start",
-          "not_active": "Ikke aktiv"
+          "not_active": "Ikke aktiv",
+          "off": "Av",
+          "on": "P\u00e5"
         }
       },
       "detergent": {
@@ -2075,8 +2076,6 @@
       "selected_program_mode_status": {
         "name": "Programmodus",
         "state": {
-          "extra_fast": "Ekstra hurtig",
-          "fast": "Hurtig",
           "intensive": "Intensiv",
           "normal": "Normal",
           "time_care_1": "Time Care 1",
@@ -2090,6 +2089,8 @@
           "30_c": "30 \u00b0C",
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
+          "90_c": "90 \u00b0C",
+          "95_c": "95 \u00b0C",
           "cold": "Kald"
         }
       },
@@ -2104,8 +2105,7 @@
           "400_rpm": "400",
           "600_rpm": "600",
           "700_rpm": "700",
-          "800_rpm": "800",
-          "no_spin": "Ingen sentrifugering"
+          "800_rpm": "800"
         }
       },
       "softener": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1758,6 +1758,7 @@
           "black_detergent": "Svartvaskemiddel",
           "color_detergent": "Fargevaskemiddel",
           "detergent": "Vaskemiddel",
+          "other_rinse_agent": "Annet skyllemiddel",
           "sensitive_detergent": "Vaskemiddel for sensitive plagg",
           "softener": "T\u00f8ymykner",
           "white_detergent": "Hvitvaskemiddel"
@@ -4969,7 +4970,13 @@
         "name": "Modus for valgt program"
       },
       "selected_program_mode_status": {
-        "name": "Programmodus"
+        "name": "Programmodus",
+        "state": {
+          "extra_fast": "Ekstra hurtig",
+          "fast": "Hurtig",
+          "normal": "Normal",
+          "not_available": "Ikke tilgjengelig"
+        }
       },
       "selected_program_night_mode": {
         "name": "Valgt program \u2013 nattmodus"
@@ -5000,6 +5007,19 @@
       },
       "selected_program_uv_function": {
         "name": "Valgt program \u2013 UV-funksjon"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Sentrifugehastighet",
+        "state": {
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "400_rpm": "400",
+          "800_rpm": "800",
+          "no_spin": "Ingen sentrifugering",
+          "not_available": "Ikke tilgjengelig"
+        }
       },
       "selected_program_water_add": {
         "name": "Valgt program \u2013 tilf\u00f8r vann"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -609,9 +609,6 @@
       "existing_sr_mode": {
         "name": "Eksisterende SR-modus"
       },
-      "extra_rinse_status": {
-        "name": "Ekstra skyll"
-      },
       "f-filter": {
         "name": "Filter"
       },
@@ -951,23 +948,11 @@
       "selected_program_disinfection": {
         "name": "Desinfeksjon"
       },
-      "selected_program_entry_steam_status": {
-        "name": "Inngangsdamp"
-      },
       "selected_program_extradry_status": {
         "name": "Ekstra t\u00f8rr"
       },
-      "selected_program_prewash_status": {
-        "name": "Forvask"
-      },
-      "selected_program_rinse_hold_status": {
-        "name": "Skyllehold"
-      },
       "selected_program_steamfinish": {
         "name": "Dampavslutning"
-      },
-      "selected_program_water_pluse_status": {
-        "name": "Vannpuls"
       },
       "session_pairing_active": {
         "name": "\u00d8ktparing aktiv"
@@ -1720,6 +1705,14 @@
           "stop_finish": "Stopp og avslutt"
         }
       },
+      "ads_dirtiness_setting_status": {
+        "name": "Smussgrad",
+        "state": {
+          "high": "H\u00f8y",
+          "low": "Lav",
+          "medium": "Middels"
+        }
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Autodoseringsmengde"
       },
@@ -1746,6 +1739,29 @@
         "state": {
           "exhaust": "Avtrekk",
           "recirculation": "Resirkulering"
+        }
+      },
+      "compartment1_type_setting_status": {
+        "name": "Kammer 1 type",
+        "state": {
+          "black_detergent": "Svartvaskemiddel",
+          "color_detergent": "Fargevaskemiddel",
+          "detergent": "Vaskemiddel",
+          "sensitive_detergent": "Vaskemiddel for sensitive plagg",
+          "softener": "T\u00f8ymykner",
+          "white_detergent": "Hvitvaskemiddel"
+        }
+      },
+      "compartment2_type_setting_status": {
+        "name": "Kammer 2 type",
+        "state": {
+          "black_detergent": "Svartvaskemiddel",
+          "color_detergent": "Fargevaskemiddel",
+          "detergent": "Vaskemiddel",
+          "other_rinse_agent": "Annet skyllemiddel",
+          "sensitive_detergent": "Vaskemiddel for sensitive plagg",
+          "softener": "T\u00f8ymykner",
+          "white_detergent": "Hvitvaskemiddel"
         }
       },
       "cooking_intensity": {
@@ -1789,6 +1805,16 @@
           "more": "Mer",
           "off": "Av",
           "standard": "Standard"
+        }
+      },
+      "detergent_amount_status": {
+        "name": "Vaskemiddelmengde",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Av"
         }
       },
       "dry_level": {
@@ -1847,6 +1873,33 @@
         "state": {
           "english": "Engelsk",
           "simplified_chinese": "Forenklet kinesisk"
+        }
+      },
+      "liquid_unit_setting_status": {
+        "name": "V\u00e6skeenhet",
+        "state": {
+          "ml": "ml",
+          "tbs": "ss"
+        }
+      },
+      "max_rpm_allowed_stat": {
+        "name": "Maks sentrifugehastighet",
+        "state": {
+          "0_rpm": "0 RPM",
+          "1000_rpm": "1000 RPM",
+          "1100_rpm": "1100 RPM",
+          "1200_rpm": "1200 RPM",
+          "1300_rpm": "1300 RPM",
+          "1400_rpm": "1400 RPM",
+          "1500_rpm": "1500 RPM",
+          "1600_rpm": "1600 RPM",
+          "1700_rpm": "1700 RPM",
+          "1800_rpm": "1800 RPM",
+          "400_rpm": "400 RPM",
+          "600_rpm": "600 RPM",
+          "700_rpm": "700 RPM",
+          "800_rpm": "800 RPM",
+          "900_rpm": "900 RPM"
         }
       },
       "notification_volumen_setting_status": {
@@ -1959,20 +2012,38 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Program",
+        "name": "Valgt program",
         "state": {
           "auto": "Auto",
+          "baby": "Baby",
           "clean": "Rens",
+          "color": "Farge",
+          "down_feathers": "Dun",
+          "draining": "T\u00f8mmer vann",
+          "drum_cleaning": "Trommelrens",
           "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Ekstra hygiene",
+          "fast_20": "Hurtig 20'",
           "glass": "Glass",
           "hygiene": "Hygiene",
           "intensive": "Intensiv",
+          "intensive_59_32": "Intensiv 59'/32'",
+          "mix_synthetic": "Mix/Syntet",
           "night": "Natt",
+          "no_program_selected": "Intet program valgt",
           "one_hour": "\u00c9n time",
+          "pet_hair_removal": "Fjerning av kj\u00e6ledyrh\u00e5r",
           "quick_pro": "Hurtig pro",
           "rinse_and_hold": "Skyll og hold",
+          "rinsing_softening": "Skylling og myking",
           "self_cleaning": "Selvrens",
-          "time_program": "Tidsprogram"
+          "shirts": "Skjorter",
+          "spinning_draining": "Sentrifugering og t\u00f8mming",
+          "sport": "Sport",
+          "time_program": "Tidsprogram",
+          "white_cotton": "Hvit bomull",
+          "wool_manual": "Ull og manuell"
         }
       },
       "selected_program_mode": {
@@ -1985,6 +2056,24 @@
           "speed": "Hastighet"
         }
       },
+      "selected_program_mode2_status": {
+        "name": "Eco-modus",
+        "state": {
+          "green_mode": "Gr\u00f8nn",
+          "night_mode": "Natt",
+          "speed_mode": "Hurtig"
+        }
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Temperatur",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "cold": "Kald"
+        }
+      },
       "softener": {
         "name": "T\u00f8ymykner",
         "state": {
@@ -1993,6 +2082,25 @@
           "more": "Mer",
           "off": "Av",
           "standard": "Standard"
+        }
+      },
+      "softener_amount_status": {
+        "name": "T\u00f8ymyknermengde",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Av"
+        }
+      },
+      "sound_setting_status": {
+        "name": "Volum",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3"
         }
       },
       "spin_speed_rpm": {
@@ -2203,6 +2311,13 @@
           "fahrenheit": "Fahrenheit"
         }
       },
+      "temperature_unit_setting_status": {
+        "name": "Temperaturenhet",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
       "time_format": {
         "name": "Tidsformat",
         "state": {
@@ -2233,6 +2348,20 @@
           "stop": "Stopp"
         }
       },
+      "units_setting_status": {
+        "name": "Enheter",
+        "state": {
+          "imperial": "Imperial",
+          "metric": "Metrisk"
+        }
+      },
+      "view_size_setting_status": {
+        "name": "Visningsst\u00f8rrelse",
+        "state": {
+          "big_text": "Stor tekst",
+          "normal_text": "Normal tekst"
+        }
+      },
       "volume": {
         "name": "Volum"
       },
@@ -2248,9 +2377,19 @@
         "name": "Vannhardhet"
       },
       "water_hardness_setting_status": {
-        "name": "Innstilling for vannhardhet",
+        "name": "Vannhardhet",
         "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
           "not_set": "Ikke satt"
+        }
+      },
+      "weight_unit_setting_status": {
+        "name": "Vektenhet",
+        "state": {
+          "kg": "kg",
+          "lbs": "lbs"
         }
       }
     },
@@ -2266,9 +2405,6 @@
       },
       "activemodemotorlevel": {
         "name": "Motorniv\u00e5 i aktiv modus"
-      },
-      "adapt_sense_setting_status": {
-        "name": "Status for tilpasset sansing"
       },
       "adapttech_setting": {
         "name": "Innstilling for tilpasset teknologi"
@@ -2288,9 +2424,6 @@
       "add_water_flag": {
         "name": "Flagg for \u00e5 fylle p\u00e5 vann"
       },
-      "ads_dirtiness_setting_status": {
-        "name": "ADS smussinnstilling"
-      },
       "ads_settings_current_program_detergent_setting_status": {
         "name": "ADS \u2013 vaskemiddelinnstilling for n\u00e5v\u00e6rende program"
       },
@@ -2308,9 +2441,6 @@
       },
       "air_freshness": {
         "name": "Luftfriskhet"
-      },
-      "air_shower_setting_status": {
-        "name": "Innstilling for luftdusj"
       },
       "airdryflag": {
         "name": "Luftt\u00f8rkflagg"
@@ -2469,14 +2599,8 @@
       "auto_dose_duration": {
         "name": "Autodoseringsvarighet"
       },
-      "auto_dose_system_setting_status": {
-        "name": "Innstilling for autodoseringssystem"
-      },
       "auto_grease_filter_indication": {
         "name": "Automatisk fettfilter"
-      },
-      "auto_super_rinse_setting_status": {
-        "name": "Innstilling for auto superskyll"
       },
       "auto_tower_up": {
         "name": "T\u00e5rn automatisk hevet"
@@ -2629,17 +2753,8 @@
       "coldwash": {
         "name": "Kaldvask"
       },
-      "color_sensor_setting_status": {
-        "name": "Innstilling for fargesensor"
-      },
       "commodity_inspection": {
         "name": "Vareinspeksjon"
-      },
-      "compartment1_type_setting_status": {
-        "name": "Innstilling for kammer 1 type"
-      },
-      "compartment2_type_setting_status": {
-        "name": "Innstilling for kammer 2 type"
       },
       "compartment_inuse": {
         "name": "Kammer i bruk"
@@ -2897,9 +3012,6 @@
       "descale_status": {
         "name": "Status for avkalking"
       },
-      "detergent_amount_status": {
-        "name": "Status for vaskemiddelmengde"
-      },
       "detergent_buynotifyswitch": {
         "name": "Bryter for kj\u00f8psvarsel for vaskemiddel"
       },
@@ -3052,9 +3164,6 @@
       "dose_assist_recommended_low_concenatration_detergent_quantity": {
         "name": "Anbefalt vaskemiddelmengde for lavkonsentrert"
       },
-      "dose_assist_status": {
-        "name": "Status for doseringshjelper"
-      },
       "dose_detergent_amount": {
         "name": "Dosert vaskemiddelmengde"
       },
@@ -3072,9 +3181,6 @@
       },
       "downloadprogram": {
         "name": "Last ned program"
-      },
-      "drum_light_setting_status": {
-        "name": "Innstillingsstatus for trommellys"
       },
       "drumcleancycle_runsnumber": {
         "name": "Antall trommelrenssykluser"
@@ -4037,9 +4143,6 @@
       "lightscolor_temperature_setting": {
         "name": "Innstilling for lysfargetemperatur"
       },
-      "liquid_unit_setting_status": {
-        "name": "Innstilling for v\u00e6skeenhet"
-      },
       "load_operation_status2": {
         "name": "Status for lastoperasjon 2"
       },
@@ -4094,9 +4197,6 @@
       },
       "market_mode_exist": {
         "name": "Butikkmodus finnes"
-      },
-      "max_rpm_allowed_stat": {
-        "name": "Status for maks tillatt RPM"
       },
       "mdo_on_demand": {
         "name": "MDO p\u00e5 foresp\u00f8rsel"
@@ -4211,9 +4311,6 @@
       "no_autodoseswitch": {
         "name": "Ingen autodoseringsbryter"
       },
-      "no_sound_status": {
-        "name": "Ingen lyd-status"
-      },
       "normal_sound_size": {
         "name": "Normal lydst\u00f8rrelse"
       },
@@ -4321,9 +4418,6 @@
       },
       "power_save": {
         "name": "Str\u00f8msparing"
-      },
-      "power_save_status": {
-        "name": "Status for str\u00f8msparing"
       },
       "power_value": {
         "name": "Effektverdi"
@@ -4833,27 +4927,7 @@
         }
       },
       "selected_program_id_status": {
-        "name": "Valgt program",
-        "state": {
-          "baby": "Baby",
-          "color": "Farge",
-          "down_feathers": "Dun",
-          "draining": "T\u00f8mmer vann",
-          "drum_cleaning": "Trommelrens",
-          "eco_40_60": "Eco 40-60",
-          "extra_hygiene": "Ekstra hygiene",
-          "fast_20": "Hurtig 20'",
-          "intensive_59_32": "Intensiv 59'/32'",
-          "mix_synthetic": "Mix/Syntet",
-          "no_program_selected": "Intet program valgt",
-          "pet_hair_removal": "Fjerning av kj\u00e6ledyrh\u00e5r",
-          "rinsing_softening": "Skylling og myking",
-          "shirts": "Skjorter",
-          "spinning_draining": "Sentrifugering og t\u00f8mming",
-          "sport": "Sport",
-          "white_cotton": "Hvit bomull",
-          "wool_manual": "Ull og manuell"
-        }
+        "name": "Valgt program"
       },
       "selected_program_intensive_mode": {
         "name": "Valgt program \u2013 intensivmodus"
@@ -4866,9 +4940,6 @@
       },
       "selected_program_mode": {
         "name": "Modus for valgt program"
-      },
-      "selected_program_mode2_status": {
-        "name": "Status for valgt program \u2013 modus 2"
       },
       "selected_program_mode_status": {
         "name": "Programmodus",
@@ -4884,20 +4955,6 @@
       },
       "selected_program_remaining_time_in_minutes": {
         "name": "Gjenst\u00e5ende tid for valgt program"
-      },
-      "selected_program_set_temperature_status": {
-        "name": "Temperatur",
-        "state": {
-          "20_c": "20 \u00b0C",
-          "30_c": "30 \u00b0C",
-          "40_c": "40 \u00b0C",
-          "60_c": "60 \u00b0C",
-          "cold": "Kald",
-          "not_available": "Ikke tilgjengelig"
-        }
-      },
-      "selected_program_small_load_status": {
-        "name": "Valgt program \u2013 liten last-status"
       },
       "selected_program_storage_function": {
         "name": "Valgt program \u2013 lagringsfunksjon"
@@ -5932,17 +5989,11 @@
       "slotdry_flag1": {
         "name": "Slotdry-flagg 1"
       },
-      "smart_sync_setting_status": {
-        "name": "Innstilling for smart synk"
-      },
       "soft_pairing_setting": {
         "name": "Innstilling for myk paring"
       },
       "soft_pairing_status": {
         "name": "Status for myk paring"
-      },
-      "softener_amount_status": {
-        "name": "Status for t\u00f8ymyknermengde"
       },
       "softener_buynotifyswitch": {
         "name": "Bryter for kj\u00f8psvarsel for t\u00f8ymykner"
@@ -5994,9 +6045,6 @@
       },
       "sound_setting": {
         "name": "Lydinnstilling"
-      },
-      "sound_setting_status": {
-        "name": "Status for lydinnstilling"
       },
       "sound_settings": {
         "name": "Lydinnstillinger"
@@ -7115,9 +7163,6 @@
       "temperature_room_judge": {
         "name": "Temperaturvurdering for rom"
       },
-      "temperature_unit_setting_status": {
-        "name": "Innstillingsstatus for temperaturenhet"
-      },
       "temperature_unit_status": {
         "name": "Status for temperaturenhet"
       },
@@ -7144,9 +7189,6 @@
       },
       "time_program_set_time_status": {
         "name": "Status for innstilt tid i tidsprogram"
-      },
-      "time_save_status": {
-        "name": "Status for tidsbesparelse"
       },
       "time_zone_setting": {
         "name": "Innstilling for tidssone"
@@ -7217,17 +7259,11 @@
       "total_water_consumption": {
         "name": "Totalt vannforbruk"
       },
-      "turbidity_sensor_setting_status": {
-        "name": "Innstilling for turbiditetssensor"
-      },
       "unfreeze_run_status": {
         "name": "Kj\u00f8restatus for opptining"
       },
       "unfreeze_switch_status": {
         "name": "Bryterstatus for opptining"
-      },
-      "units_setting_status": {
-        "name": "Innstilling for enheter"
       },
       "unpair_all_users": {
         "name": "Fjern paring for alle brukere"
@@ -7288,9 +7324,6 @@
       },
       "variation_sensor_real_temperature": {
         "name": "Faktisk temperatur fra variasjonssensor"
-      },
-      "view_size_setting_status": {
-        "name": "Innstilling for visningsst\u00f8rrelse"
       },
       "volume_setting": {
         "name": "Voluminnstilling"
@@ -7499,9 +7532,6 @@
       "water_hardness_setting": {
         "name": "Innstilling for vannhardhet"
       },
-      "water_hardness_setting_status": {
-        "name": "Vannhardhet"
-      },
       "water_heat_switch": {
         "name": "Bryter for vannvarming"
       },
@@ -7547,9 +7577,6 @@
       },
       "weight_unit_setting": {
         "name": "Innstilling for vektenhet"
-      },
-      "weight_unit_setting_status": {
-        "name": "Status for innstilling av vektenhet"
       },
       "wet_and_dry_space": {
         "name": "V\u00e5tt og t\u00f8rt rom"
@@ -7634,8 +7661,14 @@
       "activemodestatus": {
         "name": "Aktiv modus"
       },
+      "adapt_sense_setting_status": {
+        "name": "Tilpasset sansing"
+      },
       "adaptive_sense_setting": {
         "name": "Adaptiv sansingsinnstilling"
+      },
+      "air_shower_setting_status": {
+        "name": "Luftdusj"
       },
       "ambientlightstatus": {
         "name": "Omgivelseslys"
@@ -7670,8 +7703,14 @@
       "auto_dose_setting_status": {
         "name": "Autodosering"
       },
+      "auto_dose_system_setting_status": {
+        "name": "Autodoseringssystem"
+      },
       "auto_fast_preheat": {
         "name": "Automatisk hurtigforvarming"
+      },
+      "auto_super_rinse_setting_status": {
+        "name": "Auto superskyll"
       },
       "autodose": {
         "name": "Autodosering"
@@ -7685,8 +7724,14 @@
       "child_lock": {
         "name": "Barnesikring"
       },
+      "child_lock_setting_status": {
+        "name": "Barnesikring"
+      },
       "cleanairstatus": {
         "name": "Ren luft"
+      },
+      "color_sensor_setting_status": {
+        "name": "Fargesensor"
       },
       "crisp_function_status": {
         "name": "Status for spr\u00f8-funksjon"
@@ -7694,13 +7739,25 @@
       "demo_mode": {
         "name": "Demomodus"
       },
+      "demo_mode_status": {
+        "name": "Demomodus"
+      },
       "display_standby": {
         "name": "Skjermstandby"
+      },
+      "dose_assist_status": {
+        "name": "Doseringshjelper"
       },
       "drum_light": {
         "name": "Trommellys"
       },
+      "drum_light_setting_status": {
+        "name": "Trommellys"
+      },
       "extra_rinse": {
+        "name": "Ekstra skyll"
+      },
+      "extra_rinse_status": {
         "name": "Ekstra skyll"
       },
       "fota_cmd": {
@@ -7733,6 +7790,9 @@
       "lightstatus": {
         "name": "Lys"
       },
+      "logo_setting_status": {
+        "name": "Logo"
+      },
       "mute": {
         "name": "Lydl\u00f8s"
       },
@@ -7742,8 +7802,14 @@
       "night_mode_status": {
         "name": "Nattmodusstatus"
       },
+      "no_sound_status": {
+        "name": "Lydl\u00f8s"
+      },
       "odor_control_setting": {
         "name": "Luktkontroll"
+      },
+      "power_save_status": {
+        "name": "Str\u00f8msparing"
       },
       "prewash": {
         "name": "Forvask"
@@ -7757,11 +7823,38 @@
       "save_mode": {
         "name": "Sparemodus"
       },
+      "selected_program_anticrease_status": {
+        "name": "Anti-kr\u00f8ll"
+      },
+      "selected_program_entry_steam_status": {
+        "name": "Inngangsdamp"
+      },
+      "selected_program_prewash_status": {
+        "name": "Forvask"
+      },
+      "selected_program_rinse_hold_status": {
+        "name": "Skyllehold"
+      },
+      "selected_program_small_load_status": {
+        "name": "Liten last"
+      },
+      "selected_program_water_pluse_status": {
+        "name": "Vannpuls"
+      },
+      "session_pairing_status": {
+        "name": "\u00d8ktparing"
+      },
       "sf_mode": {
         "name": "SF-modus"
       },
       "sf_sr_mutex_mode": {
         "name": "SF/SR-mutex-modus"
+      },
+      "smart_sync_setting_status": {
+        "name": "Smart synk"
+      },
+      "soft_pairing_status": {
+        "name": "Myk paring"
       },
       "sr_mode": {
         "name": "SR-modus"
@@ -7834,6 +7927,12 @@
       },
       "time_save": {
         "name": "Tidsbesparelse"
+      },
+      "time_save_status": {
+        "name": "Tidsbesparelse"
+      },
+      "turbidity_sensor_setting_status": {
+        "name": "Turbiditetssensor"
       },
       "welcome": {
         "name": "Velkommen"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1797,6 +1797,14 @@
           "none": "Ingen"
         }
       },
+      "delaystart_delayend_mode_status": {
+        "name": "Utsatt start",
+        "state": {
+          "delay_end": "Utsatt slutt",
+          "delay_start": "Utsatt start",
+          "not_active": "Ikke aktiv"
+        }
+      },
       "detergent": {
         "name": "Vaskemiddel",
         "state": {
@@ -2064,6 +2072,17 @@
           "speed_mode": "Hurtig"
         }
       },
+      "selected_program_mode_status": {
+        "name": "Programmodus",
+        "state": {
+          "extra_fast": "Ekstra hurtig",
+          "fast": "Hurtig",
+          "intensive": "Intensiv",
+          "normal": "Normal",
+          "time_care_1": "Time Care 1",
+          "time_care_2": "Time Care 2"
+        }
+      },
       "selected_program_set_temperature_status": {
         "name": "Temperatur",
         "state": {
@@ -2072,6 +2091,21 @@
           "40_c": "40 \u00b0C",
           "60_c": "60 \u00b0C",
           "cold": "Kald"
+        }
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Sentrifugehastighet",
+        "state": {
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "1600_rpm": "1600",
+          "400_rpm": "400",
+          "600_rpm": "600",
+          "700_rpm": "700",
+          "800_rpm": "800",
+          "no_spin": "Ingen sentrifugering"
         }
       },
       "softener": {
@@ -2989,13 +3023,6 @@
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Varighet for utsatt start"
-      },
-      "delaystart_delayend_mode_status": {
-        "name": "Status for utsatt start",
-        "state": {
-          "off": "Av",
-          "on": "P\u00e5"
-        }
       },
       "delaystart_delayend_remaining_time_in_minutes": {
         "name": "Gjenst\u00e5ende tid for utsatt start/slutt"
@@ -4942,13 +4969,7 @@
         "name": "Modus for valgt program"
       },
       "selected_program_mode_status": {
-        "name": "Programmodus",
-        "state": {
-          "extra_fast": "Ekstra hurtig",
-          "fast": "Hurtig",
-          "normal": "Normal",
-          "not_available": "Ikke tilgjengelig"
-        }
+        "name": "Programmodus"
       },
       "selected_program_night_mode": {
         "name": "Valgt program \u2013 nattmodus"
@@ -4979,19 +5000,6 @@
       },
       "selected_program_uv_function": {
         "name": "Valgt program \u2013 UV-funksjon"
-      },
-      "selected_program_washing_spin_speed_rpm_status": {
-        "name": "Sentrifugehastighet",
-        "state": {
-          "0_rpm": "0",
-          "1000_rpm": "1000",
-          "1200_rpm": "1200",
-          "1400_rpm": "1400",
-          "400_rpm": "400",
-          "800_rpm": "800",
-          "no_spin": "Ingen sentrifugering",
-          "not_available": "Ikke tilgjengelig"
-        }
       },
       "selected_program_water_add": {
         "name": "Valgt program \u2013 tilf\u00f8r vann"


### PR DESCRIPTION
## Summary

Wire up writable counterparts in the 027 (washing machine) data dictionary.

### Read → writable conversions

Convert ~40 read-side `*_status` properties into switches/selects that write
to the matching `*_setting` via `command.name` with `adjust: 1` (status enums
have `Not available` at index 0 which the setting enum doesn't have). Pairing
properties (`Session_pairing_status`, `Soft_pairing_status`) use `off:0, on:1`
with no adjust because both sides share the same encoding.

Add `unavailable: 0` so entities are skipped on machines that don't expose the
feature.

### Entity categorization

- `config`: device-wide settings (sound/volume, units, child lock, water
  hardness, compartment types, feature toggles, max spin speed, etc.)
- `diagnostic`: pairing infrastructure
- uncategorized: per-wash options (program, temperature, dose amounts,
  dirtiness, mode2, `Time_save`, `selected_program_*`)

### Display names

Drop the "setting status" suffix on the converted controls. Rename a few
where the auto-generated label was awkward for a writable entity:
`No_sound` → "Mute", `Sound_setting` → "Volume", `mode2` → "Eco mode",
`ADS_Dirtiness` → "Dirtiness", `Max_RPM_allowed` → "Max spin speed".

### Unknown-value sentinels

- `Selected_program_id_status`: `unknown_value: 255` (no program selected)
- `Selected_program_set_temperature_status`: `unknown_value: 15` (temperature
  None)

### Base vs. variant overrides

The base `027.yaml` is updated for 027-000, including three enums whose
previous option keys didn't match the values 027-000 actually emits:
`Selected_program_mode_status`, `Selected_program_washing_spin_speed_rpm_status`,
`Delaystart_delayend_mode_status`.

The two pre-existing variants preserve their original (PR #218 / #268)
read-side mappings via override files:

- `027-washing-machine-wm22.yaml`: overrides `Delaystart_delayend_mode_status`
  to `{1: off, 3: on}` while inheriting the base's command + `adjust: 1`.
- `027-washing-machine-wm22-b2plus.yaml`: overrides
  `Selected_program_mode_status` and
  `Selected_program_washing_spin_speed_rpm_status` to read-only sensors with
  the variant's original labels (writes via the base's command would land on
  wrong values for this variant's encoding).

Adds a new `027-000.yaml` stub and a row in `DEVICES.md`.

### Known caveat

`Compartment2_type_setting_status` is exposed as a writable select with
`adjust: 1` (same pattern as Compartment1). There's reason to believe
Detergent/Softener may be swapped between read and write encodings for
Compartment 2 only, which `adjust` can't express. We assume that's not the
case here; if writes turn out to be backwards, the YAML comment flags what
to flip.

### Translations

English, Dutch, Norwegian, German, and (where applicable) Spanish translations
updated to reflect the new platform keys, curated display names, and
state labels. Variant-specific state labels (e.g. `fast`, `extra_fast`,
`no_spin`) preserved on the wm22-b2plus sensor entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)