### PR TITLE
Improve mappings for tumble dryer (032)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/032.yaml
+++ b/custom_components/connectlife/data_dictionaries/032.yaml
@@ -1,7 +1,24 @@
 # Tumble dryer
 properties:
+  - property: Actions
+    select:
+      options:
+        0: stop
+        1: start
+        2: pause
+        3: cancel
+        4: reset_programs_to_default
+        5: program_continue
+        6: production_test
   - property: AdaptTech_setting
     # Example value: 2
+  - property: Airing_program_Set_time
+    optional: true
+    number:
+      device_class: duration
+      unit: min
+      command:
+        name: Airing_program_Set_time_set
   - property: Alarm_1
     optional: true
     icon: mdi:tumble-dryer-alert
@@ -64,9 +81,17 @@ properties:
       device_class: problem
   - property: AntiCrease_setting
     # anti crease 1,2,3 hours
-    sensor:
-      device_class: duration
-      unit: h
+    unavailable: 0
+    select:
+      options:
+        1: "off"
+        2: 1_hour
+        3: 2_hours
+        4: 3_hours
+        5: 4_hours
+      command:
+        name: Selected_program_AntiCrease
+        adjust: 1
   - property: Appliance_status
     icon: mdi:tumble-dryer
     sensor:
@@ -75,6 +100,12 @@ properties:
         5: "off"
         6: idle
         7: running
+  - property: Brightness_setting
+    optional: true
+    entity_category: config
+    number:
+      command:
+        name: Brightness_setting_set
   - property: Bundling_Humidity
     sensor:
       device_class: humidity
@@ -89,8 +120,35 @@ properties:
       state_class: measurement
   - property: Bundling_sensor_setting_status
     # Example value: 0
+  - property: Buzzer_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Buzzer_setting_set
+        adjust: 1
   - property: Child_Lock_status
-    binary_sensor:
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Child_Lock
+        adjust: 1
+  - property: Cleaning_reminder_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Cleaning_reminder_setting_set
+        adjust: 1
   - property: Condensed_watermode
     optional: true
   - property: Current_programphase
@@ -117,6 +175,16 @@ properties:
     sensor:
       device_class: duration
       unit: min
+  - property: Demo_mode
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Demo_mode_set
+        adjust: 1
   - property: Door_status
     unavailable: 0
     hide: true
@@ -126,6 +194,16 @@ properties:
       options:
         1: off
         2: on
+  - property: Drum_illumination
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Drum_illumination_set
+        adjust: 1
   - property: Error_0
     optional: true
     icon: mdi:tumble-dryer-alert
@@ -212,18 +290,65 @@ properties:
     binary_sensor:
       device_class: problem
   - property: ExtraDry_setting
-    sensor:
+    unavailable: 0
+    select:
+      options:
+        1: "off"
+        2: 5_min
+        3: 10_min
+        4: 15_min
+      command:
+        name: Selected_program_ExtraDry
+        adjust: 1
   - property: Float_switch
     binary_sensor:
   - property: Fota
     optional: true
+  - property: Fota_cmd
+    optional: true
+    switch: {}
   - property: HardPairingStatus
     optional: true
+  - property: Heating_power_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Heating_power_setting_set
+        adjust: 1
   - property: Humidity_sensor
     binary_sensor:
     optional: true
+  - property: Language_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    select:
+      options:
+        1: us_english
+        2: gb_english
+        3: au_english
+        4: norwegian
+        5: swedish_asko
+        6: swedish_cylinda
+      command:
+        name: Language_setting_set
+        adjust: 1
   - property: Logo_setting_status
     optional: true
+  - property: Notification_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Notification_setting_set
+        adjust: 1
   - property: NTC_sensor_1
     optional: true
   - property: NTC_sensor_2
@@ -263,11 +388,44 @@ properties:
         13: extra_hygiene
         14: remote
         255: none
+  - property: Selected_program_Load
+    optional: true
+    unavailable: 0
+    select:
+      options:
+        1: light
+        2: medium
+        3: heavy
+      command:
+        name: Selected_program_Load_set
+  - property: Selected_program_mode2
+    optional: true
+    unavailable: 0
+    select:
+      options:
+        1: delicate
+        2: disinfection
+      command:
+        name: Selected_program_mode2_set
+        adjust: 1
   - property: Selected_program_SteamFinish
     binary_sensor:
-  - property: Selected_program_mode_status
+  - property: Selected_program_TimeDry_Set_Duration
     optional: true
+    number:
+      device_class: duration
+      unit: min
+  - property: Selected_program_mode_status
     # Example value: 1
+    unavailable: 0
+    select:
+      options:
+        1: normal
+        2: nature_dry
+        3: steam_tech
+      command:
+        name: Selected_program_mode
+        adjust: 1
   - property: Selected_programduration_inminutes
     sensor:
       device_class: duration
@@ -281,15 +439,55 @@ properties:
     optional: true
   - property: Session_pairing_setting
     optional: true
+  - property: Smart_sync_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Smart_sync_setting_set
+        adjust: 1
   - property: Soft_pairing_setting
     optional: true
   - property: Sound_settings
     optional: true
     # Example value: 3
+    unavailable: 0
+    entity_category: config
+    select:
+      options:
+        1: '0'
+        2: '1'
+        3: '2'
+        4: '3'
+        5: '4'
+        6: '5'
+      command:
+        name: Sound_setting
+        adjust: 1
   - property: UTC_DateTime_BDC_DelayStart_DelayEnd_timestamp
     optional: true
     sensor:
       device_class: timestamp
+  - property: View_size_setting
+    optional: true
+    unavailable: 0
+    entity_category: config
+    select:
+      options:
+        1: normal_text
+        2: big_text
+      command:
+        name: View_size_setting_set
+        adjust: 1
+  - property: Volume_setting
+    optional: true
+    entity_category: config
+    number:
+      command:
+        name: Volume_setting_set
   - property: Washer_to_Dryer_available_for_hours_v
     hide: true
     # Example value: 1
@@ -299,6 +497,14 @@ properties:
   - property: Washer_to_Dryersetting_status
     optional: true
     # Example value: 0
+    unavailable: 0
+    entity_category: config
+    switch:
+      "off": 1
+      "on": 2
+      command:
+        name: Washer_to_Dryersetting
+        adjust: 1
   - property: Washer_to_dryerwizard_trigger_status
     optional: true
     # Example value: 1

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -462,9 +462,6 @@
       "child_lock_open_door_sound_alarm": {
         "name": "Child lock open door sound alarm"
       },
-      "child_lock_status": {
-        "name": "Child lock"
-      },
       "child_lock_status_status": {
         "name": "Child lock"
       },
@@ -1909,6 +1906,9 @@
       }
     },
     "number": {
+      "airing_program_set_time": {
+        "name": "Airing time"
+      },
       "aus_zone1_opencontrol": {
         "name": "Zone 1 opening"
       },
@@ -1932,6 +1932,9 @@
       },
       "aus_zone8_opencontrol": {
         "name": "Zone 8 opening"
+      },
+      "brightness_setting": {
+        "name": "Brightness"
       },
       "delayendtime": {
         "name": "Delay end time"
@@ -1972,6 +1975,9 @@
       "refrigerator_temperature": {
         "name": "Refrigerator temperature"
       },
+      "selected_program_timedry_set_duration": {
+        "name": "Time dry duration"
+      },
       "t_fanspeedcv": {
         "name": "Variable fan speed"
       },
@@ -1983,6 +1989,9 @@
       },
       "variation_temperature": {
         "name": "Variation temperature"
+      },
+      "volume_setting": {
+        "name": "Volume"
       }
     },
     "select": {
@@ -1991,9 +2000,13 @@
         "state": {
           "add_duration": "Add duration",
           "add_gratin": "Add gratin",
+          "cancel": "Cancel",
           "direct_steam": "Direct steam",
           "none": "None",
           "pause": "Pause",
+          "production_test": "Production test",
+          "program_continue": "Program continue",
+          "reset_programs_to_default": "Reset programs to default",
           "start": "Start",
           "steam_shot": "Steam shot",
           "steamer_water_tank_door_open": "Open steamer water tank door",
@@ -2007,6 +2020,16 @@
           "high": "High",
           "low": "Low",
           "medium": "Medium"
+        }
+      },
+      "anticrease_setting": {
+        "name": "Anti-crease duration",
+        "state": {
+          "1_hour": "1 hour",
+          "2_hours": "2 hours",
+          "3_hours": "3 hours",
+          "4_hours": "4 hours",
+          "off": "Off"
         }
       },
       "auto_dose_quantity_setting_status": {
@@ -2183,6 +2206,15 @@
           "wardrobe": "Wardrobe"
         }
       },
+      "extradry_setting": {
+        "name": "Extra dry",
+        "state": {
+          "10_min": "10 min",
+          "15_min": "15 min",
+          "5_min": "5 min",
+          "off": "Off"
+        }
+      },
       "extrarinsenum": {
         "name": "Extra rinse",
         "state": {
@@ -2203,6 +2235,17 @@
         "state": {
           "not_active": "Not active",
           "reset": "Reset"
+        }
+      },
+      "language_setting": {
+        "name": "Language",
+        "state": {
+          "au_english": "English (AU)",
+          "gb_english": "English (GB)",
+          "norwegian": "Norwegian",
+          "swedish_asko": "Swedish (ASKO)",
+          "swedish_cylinda": "Swedish (Cylinda)",
+          "us_english": "English (US)"
         }
       },
       "language_status": {
@@ -2391,6 +2434,14 @@
           "wool_manual": "Wool & Manual"
         }
       },
+      "selected_program_load": {
+        "name": "Load",
+        "state": {
+          "heavy": "Heavy",
+          "light": "Light",
+          "medium": "Medium"
+        }
+      },
       "selected_program_mode": {
         "name": "Mode",
         "state": {
@@ -2399,6 +2450,13 @@
           "normal": "Normal",
           "not_available": "Not available",
           "speed": "Speed"
+        }
+      },
+      "selected_program_mode2": {
+        "name": "Special mode",
+        "state": {
+          "delicate": "Delicate",
+          "disinfection": "Disinfection"
         }
       },
       "selected_program_mode2_status": {
@@ -2413,7 +2471,9 @@
         "name": "Program mode",
         "state": {
           "intensive": "Intensive",
+          "nature_dry": "NatureDry",
           "normal": "Normal",
+          "steam_tech": "SteamTech",
           "time_care_1": "Time Care 1",
           "time_care_2": "Time Care 2"
         }
@@ -2494,6 +2554,17 @@
           "1": "1",
           "2": "2",
           "3": "3"
+        }
+      },
+      "sound_settings": {
+        "name": "Sound level",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4",
+          "5": "5"
         }
       },
       "spin_speed_rpm": {
@@ -2756,6 +2827,13 @@
           "metric": "Metric"
         }
       },
+      "view_size_setting": {
+        "name": "View size",
+        "state": {
+          "big_text": "Big text",
+          "normal_text": "Normal text"
+        }
+      },
       "view_size_setting_status": {
         "name": "View size",
         "state": {
@@ -2948,9 +3026,6 @@
       },
       "anticrease_flag": {
         "name": "Anti-crease flag"
-      },
-      "anticrease_setting": {
-        "name": "Anti-crease duration"
       },
       "appcontrol_flag": {
         "name": "App control flag"
@@ -4186,9 +4261,6 @@
       },
       "extra_soft_hideflag": {
         "name": "Extra soft hide flag"
-      },
-      "extradry_setting": {
-        "name": "ExtraDry setting"
       },
       "extrarinsenum": {
         "name": "Extra rinse number"
@@ -6685,9 +6757,6 @@
       "sound_setting": {
         "name": "Sound setting"
       },
-      "sound_settings": {
-        "name": "Sound settings"
-      },
       "special_space": {
         "name": "Special space"
       },
@@ -8013,9 +8082,6 @@
       "washer_to_dryer_program_id": {
         "name": "Washer to dryer program ID"
       },
-      "washer_to_dryersetting_status": {
-        "name": "Washer to dryer setting status"
-      },
       "washer_to_dryerwizard_trigger_status": {
         "name": "Washer to dryer wizard trigger status"
       },
@@ -8400,10 +8466,16 @@
       "autotubclean": {
         "name": "Auto tub clean"
       },
+      "buzzer_setting": {
+        "name": "Buzzer"
+      },
       "child_lock": {
         "name": "Child lock"
       },
       "child_lock_setting_status": {
+        "name": "Child lock"
+      },
+      "child_lock_status": {
         "name": "Child lock"
       },
       "childlockenabled": {
@@ -8411,6 +8483,9 @@
       },
       "cleanairstatus": {
         "name": "Clean air"
+      },
+      "cleaning_reminder_setting": {
+        "name": "Cleaning reminder"
       },
       "coldwash": {
         "name": "Cold wash"
@@ -8432,6 +8507,9 @@
       },
       "dose_assist_status": {
         "name": "Dose assist"
+      },
+      "drum_illumination": {
+        "name": "Drum light"
       },
       "drum_light": {
         "name": "Drum light"
@@ -8459,6 +8537,9 @@
       },
       "heater2enable": {
         "name": "Auxiliary heater"
+      },
+      "heating_power_setting": {
+        "name": "Heating power"
       },
       "heatingsteps": {
         "name": "Heating steps"
@@ -8501,6 +8582,9 @@
       },
       "no_sound_status": {
         "name": "Mute"
+      },
+      "notification_setting": {
+        "name": "Notifications"
       },
       "odor_control_setting": {
         "name": "Odor control"
@@ -8552,6 +8636,9 @@
       },
       "showmeasuredtemperature": {
         "name": "Show measured temperature"
+      },
+      "smart_sync_setting": {
+        "name": "Smart sync"
       },
       "smart_sync_setting_status": {
         "name": "Smart sync"
@@ -8642,6 +8729,9 @@
       },
       "turbidity_sensor_setting_status": {
         "name": "Turbidity sensor"
+      },
+      "washer_to_dryersetting_status": {
+        "name": "Washer-to-dryer sync"
       },
       "welcome": {
         "name": "Welcome"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -370,9 +370,6 @@
       "child_lock_open_door_sound_alarm": {
         "name": "T\u00fcrton-Alarm bei ge\u00f6ffneter Kindersicherung"
       },
-      "child_lock_status": {
-        "name": "Kindersicherung"
-      },
       "child_lock_status_status": {
         "name": "Kindersicherung"
       },
@@ -1196,6 +1193,12 @@
       }
     },
     "number": {
+      "airing_program_set_time": {
+        "name": "L\u00fcftungsdauer"
+      },
+      "brightness_setting": {
+        "name": "Helligkeit"
+      },
       "freeze_max_temperature": {
         "name": "Maximale Gefriertemperatur"
       },
@@ -1220,6 +1223,9 @@
       "refrigerator_temperature": {
         "name": "K\u00fchlschranktemperatur"
       },
+      "selected_program_timedry_set_duration": {
+        "name": "Zeitprogramm-Dauer"
+      },
       "variation_max_temperature": {
         "name": "Maximale Temperaturvariation"
       },
@@ -1228,6 +1234,9 @@
       },
       "variation_temperature": {
         "name": "Temperaturvariation"
+      },
+      "volume_setting": {
+        "name": "Lautst\u00e4rke"
       }
     },
     "select": {
@@ -1250,6 +1259,16 @@
           "high": "Hoch",
           "low": "Niedrig",
           "medium": "Mittel"
+        }
+      },
+      "anticrease_setting": {
+        "name": "Anti-Knitter-Dauer",
+        "state": {
+          "1_hour": "1 Stunde",
+          "2_hours": "2 Stunden",
+          "3_hours": "3 Stunden",
+          "4_hours": "4 Stunden",
+          "off": "Aus"
         }
       },
       "auto_dose_quantity_setting_status": {
@@ -1383,6 +1402,15 @@
           "wardrobe": "Schranktrocken"
         }
       },
+      "extradry_setting": {
+        "name": "ExtraTrocken",
+        "state": {
+          "10_min": "10 min",
+          "15_min": "15 min",
+          "5_min": "5 min",
+          "off": "Aus"
+        }
+      },
       "extrarinsenum": {
         "name": "Zus\u00e4tzliche Sp\u00fclg\u00e4nge",
         "state": {
@@ -1396,6 +1424,17 @@
           "low": "Niedrig",
           "mid": "Mittel",
           "mute": "Stumm"
+        }
+      },
+      "language_setting": {
+        "name": "Sprache",
+        "state": {
+          "au_english": "Englisch (AU)",
+          "gb_english": "Englisch (GB)",
+          "norwegian": "Norwegisch",
+          "swedish_asko": "Schwedisch (ASKO)",
+          "swedish_cylinda": "Schwedisch (Cylinda)",
+          "us_english": "Englisch (US)"
         }
       },
       "language_status": {
@@ -1538,6 +1577,14 @@
           "wool_manual": "Wolle & Manuell"
         }
       },
+      "selected_program_load": {
+        "name": "Beladung",
+        "state": {
+          "heavy": "Schwer",
+          "light": "Leicht",
+          "medium": "Mittel"
+        }
+      },
       "selected_program_mode": {
         "name": "Programm Modus",
         "state": {
@@ -1545,6 +1592,13 @@
           "night": "Nacht",
           "normal": "Normal",
           "speed": "Schnell"
+        }
+      },
+      "selected_program_mode2": {
+        "name": "Spezialmodus",
+        "state": {
+          "delicate": "Schonend",
+          "disinfection": "Desinfektion"
         }
       },
       "selected_program_mode2_status": {
@@ -1559,7 +1613,9 @@
         "name": "Programm Modus",
         "state": {
           "intensive": "Intensiv",
+          "nature_dry": "NatureDry",
           "normal": "Normal",
+          "steam_tech": "SteamTech",
           "time_care_1": "Time Care 1",
           "time_care_2": "Time Care 2"
         }
@@ -1616,6 +1672,17 @@
           "1": "1",
           "2": "2",
           "3": "3"
+        }
+      },
+      "sound_settings": {
+        "name": "Tonstufe",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4",
+          "5": "5"
         }
       },
       "spin_speed_rpm": {
@@ -1827,6 +1894,9 @@
           "metric": "Metrisch"
         }
       },
+      "view_size_setting": {
+        "name": "Anzeigegr\u00f6\u00dfe"
+      },
       "view_size_setting_status": {
         "name": "Anzeigegr\u00f6\u00dfe",
         "state": {
@@ -1868,9 +1938,6 @@
     "sensor": {
       "almost_finished_notification_settingtimer_in_minutes": {
         "name": "Bald-fertig-Benachrichtigung Timer"
-      },
-      "anticrease_setting": {
-        "name": "Anti-Knitter-Dauer"
       },
       "appliance_status": {
         "state": {
@@ -2096,9 +2163,6 @@
       },
       "error_read_out_3_cycle": {
         "name": "Fehlerzyklus 3 auslesen"
-      },
-      "extradry_setting": {
-        "name": "ExtraTrocken-Einstellung"
       },
       "f_cool_qvalue": {
         "name": "K\u00fchlung"
@@ -3608,8 +3672,17 @@
       "autotubclean": {
         "name": "Automatische Trommelreinigung"
       },
+      "buzzer_setting": {
+        "name": "Summer"
+      },
       "child_lock": {
         "name": "Kindersicherung"
+      },
+      "child_lock_status": {
+        "name": "Kindersicherung"
+      },
+      "cleaning_reminder_setting": {
+        "name": "Reinigungserinnerung"
       },
       "crisp_function_status": {
         "name": "Knusperfunktion Status"
@@ -3619,6 +3692,9 @@
       },
       "display_standby": {
         "name": "Display Standby"
+      },
+      "drum_illumination": {
+        "name": "Trommellicht"
       },
       "drum_light": {
         "name": "Trommelbeleuchtung"
@@ -3631,6 +3707,9 @@
       },
       "fota_cmd": {
         "name": "Firmwareaktualisierung"
+      },
+      "heating_power_setting": {
+        "name": "Heizleistung"
       },
       "hide_setting": {
         "name": "Einstellung ausblenden"
@@ -3665,6 +3744,9 @@
       "no_sound_status": {
         "name": "Stumm"
       },
+      "notification_setting": {
+        "name": "Benachrichtigungen"
+      },
       "odor_control_setting": {
         "name": "Geruchskontrolle"
       },
@@ -3691,6 +3773,9 @@
       },
       "sf_sr_mutex_mode": {
         "name": "SF-SR-Mutex-Modus"
+      },
+      "smart_sync_setting": {
+        "name": "Smart Sync"
       },
       "sr_mode": {
         "name": "SR-Modus"
@@ -3739,6 +3824,9 @@
       },
       "time_save": {
         "name": "Zeitsparen"
+      },
+      "washer_to_dryersetting_status": {
+        "name": "W\u00e4scher-zu-Trockner-Sync"
       },
       "welcome": {
         "name": "Willkommen"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -462,9 +462,6 @@
       "child_lock_open_door_sound_alarm": {
         "name": "Child lock open door sound alarm"
       },
-      "child_lock_status": {
-        "name": "Child lock"
-      },
       "child_lock_status_status": {
         "name": "Child lock"
       },
@@ -1909,6 +1906,9 @@
       }
     },
     "number": {
+      "airing_program_set_time": {
+        "name": "Airing time"
+      },
       "aus_zone1_opencontrol": {
         "name": "Zone 1 opening"
       },
@@ -1932,6 +1932,9 @@
       },
       "aus_zone8_opencontrol": {
         "name": "Zone 8 opening"
+      },
+      "brightness_setting": {
+        "name": "Brightness"
       },
       "delayendtime": {
         "name": "Delay end time"
@@ -1972,6 +1975,9 @@
       "refrigerator_temperature": {
         "name": "Refrigerator temperature"
       },
+      "selected_program_timedry_set_duration": {
+        "name": "Time dry duration"
+      },
       "t_fanspeedcv": {
         "name": "Variable fan speed"
       },
@@ -1983,6 +1989,9 @@
       },
       "variation_temperature": {
         "name": "Variation temperature"
+      },
+      "volume_setting": {
+        "name": "Volume"
       }
     },
     "select": {
@@ -1991,9 +2000,13 @@
         "state": {
           "add_duration": "Add duration",
           "add_gratin": "Add gratin",
+          "cancel": "Cancel",
           "direct_steam": "Direct steam",
           "none": "None",
           "pause": "Pause",
+          "production_test": "Production test",
+          "program_continue": "Program continue",
+          "reset_programs_to_default": "Reset programs to default",
           "start": "Start",
           "steam_shot": "Steam shot",
           "steamer_water_tank_door_open": "Open steamer water tank door",
@@ -2007,6 +2020,16 @@
           "high": "High",
           "low": "Low",
           "medium": "Medium"
+        }
+      },
+      "anticrease_setting": {
+        "name": "Anti-crease duration",
+        "state": {
+          "1_hour": "1 hour",
+          "2_hours": "2 hours",
+          "3_hours": "3 hours",
+          "4_hours": "4 hours",
+          "off": "Off"
         }
       },
       "auto_dose_quantity_setting_status": {
@@ -2183,6 +2206,15 @@
           "wardrobe": "Wardrobe"
         }
       },
+      "extradry_setting": {
+        "name": "Extra dry",
+        "state": {
+          "10_min": "10 min",
+          "15_min": "15 min",
+          "5_min": "5 min",
+          "off": "Off"
+        }
+      },
       "extrarinsenum": {
         "name": "Extra rinse",
         "state": {
@@ -2203,6 +2235,17 @@
         "state": {
           "not_active": "Not active",
           "reset": "Reset"
+        }
+      },
+      "language_setting": {
+        "name": "Language",
+        "state": {
+          "au_english": "English (AU)",
+          "gb_english": "English (GB)",
+          "norwegian": "Norwegian",
+          "swedish_asko": "Swedish (ASKO)",
+          "swedish_cylinda": "Swedish (Cylinda)",
+          "us_english": "English (US)"
         }
       },
       "language_status": {
@@ -2391,6 +2434,14 @@
           "wool_manual": "Wool & Manual"
         }
       },
+      "selected_program_load": {
+        "name": "Load",
+        "state": {
+          "heavy": "Heavy",
+          "light": "Light",
+          "medium": "Medium"
+        }
+      },
       "selected_program_mode": {
         "name": "Mode",
         "state": {
@@ -2399,6 +2450,13 @@
           "normal": "Normal",
           "not_available": "Not available",
           "speed": "Speed"
+        }
+      },
+      "selected_program_mode2": {
+        "name": "Special mode",
+        "state": {
+          "delicate": "Delicate",
+          "disinfection": "Disinfection"
         }
       },
       "selected_program_mode2_status": {
@@ -2413,7 +2471,9 @@
         "name": "Program mode",
         "state": {
           "intensive": "Intensive",
+          "nature_dry": "NatureDry",
           "normal": "Normal",
+          "steam_tech": "SteamTech",
           "time_care_1": "Time Care 1",
           "time_care_2": "Time Care 2"
         }
@@ -2494,6 +2554,17 @@
           "1": "1",
           "2": "2",
           "3": "3"
+        }
+      },
+      "sound_settings": {
+        "name": "Sound level",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4",
+          "5": "5"
         }
       },
       "spin_speed_rpm": {
@@ -2756,6 +2827,13 @@
           "metric": "Metric"
         }
       },
+      "view_size_setting": {
+        "name": "View size",
+        "state": {
+          "big_text": "Big text",
+          "normal_text": "Normal text"
+        }
+      },
       "view_size_setting_status": {
         "name": "View size",
         "state": {
@@ -2948,9 +3026,6 @@
       },
       "anticrease_flag": {
         "name": "Anti-crease flag"
-      },
-      "anticrease_setting": {
-        "name": "Anti-crease duration"
       },
       "appcontrol_flag": {
         "name": "App control flag"
@@ -4186,9 +4261,6 @@
       },
       "extra_soft_hideflag": {
         "name": "Extra soft hide flag"
-      },
-      "extradry_setting": {
-        "name": "ExtraDry setting"
       },
       "extrarinsenum": {
         "name": "Extra rinse number"
@@ -6685,9 +6757,6 @@
       "sound_setting": {
         "name": "Sound setting"
       },
-      "sound_settings": {
-        "name": "Sound settings"
-      },
       "special_space": {
         "name": "Special space"
       },
@@ -8013,9 +8082,6 @@
       "washer_to_dryer_program_id": {
         "name": "Washer to dryer program ID"
       },
-      "washer_to_dryersetting_status": {
-        "name": "Washer to dryer setting status"
-      },
       "washer_to_dryerwizard_trigger_status": {
         "name": "Washer to dryer wizard trigger status"
       },
@@ -8400,10 +8466,16 @@
       "autotubclean": {
         "name": "Auto tub clean"
       },
+      "buzzer_setting": {
+        "name": "Buzzer"
+      },
       "child_lock": {
         "name": "Child lock"
       },
       "child_lock_setting_status": {
+        "name": "Child lock"
+      },
+      "child_lock_status": {
         "name": "Child lock"
       },
       "childlockenabled": {
@@ -8411,6 +8483,9 @@
       },
       "cleanairstatus": {
         "name": "Clean air"
+      },
+      "cleaning_reminder_setting": {
+        "name": "Cleaning reminder"
       },
       "coldwash": {
         "name": "Cold wash"
@@ -8432,6 +8507,9 @@
       },
       "dose_assist_status": {
         "name": "Dose assist"
+      },
+      "drum_illumination": {
+        "name": "Drum light"
       },
       "drum_light": {
         "name": "Drum light"
@@ -8459,6 +8537,9 @@
       },
       "heater2enable": {
         "name": "Auxiliary heater"
+      },
+      "heating_power_setting": {
+        "name": "Heating power"
       },
       "heatingsteps": {
         "name": "Heating steps"
@@ -8501,6 +8582,9 @@
       },
       "no_sound_status": {
         "name": "Mute"
+      },
+      "notification_setting": {
+        "name": "Notifications"
       },
       "odor_control_setting": {
         "name": "Odor control"
@@ -8552,6 +8636,9 @@
       },
       "showmeasuredtemperature": {
         "name": "Show measured temperature"
+      },
+      "smart_sync_setting": {
+        "name": "Smart sync"
       },
       "smart_sync_setting_status": {
         "name": "Smart sync"
@@ -8642,6 +8729,9 @@
       },
       "turbidity_sensor_setting_status": {
         "name": "Turbidity sensor"
+      },
+      "washer_to_dryersetting_status": {
+        "name": "Washer-to-dryer sync"
       },
       "welcome": {
         "name": "Welcome"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -181,9 +181,6 @@
       "child_lock": {
         "name": "Bloqueo ni\u00f1os"
       },
-      "child_lock_status": {
-        "name": "Bloqueo ni\u00f1os"
-      },
       "clean_filter": {
         "name": "Limpiar filtro"
       },
@@ -668,6 +665,9 @@
           "medium": "Media"
         }
       },
+      "anticrease_setting": {
+        "name": "Duraci\u00f3n anti arrugas"
+      },
       "auto_dose_quantity_setting_status": {
         "name": "Configuraci\u00f3n autom\u00e1tica de la cantidad de dosificador"
       },
@@ -688,6 +688,9 @@
           "pre-ironing": "Plancha",
           "wardrobe": "Armario"
         }
+      },
+      "extradry_setting": {
+        "name": "Configuraci\u00f3n extra-seco"
       },
       "feedback_volumen_setting_status": {
         "state": {
@@ -844,9 +847,6 @@
       }
     },
     "sensor": {
-      "anticrease_setting": {
-        "name": "Duraci\u00f3n anti arrugas"
-      },
       "appliance_status": {
         "state": {
           "idle": "Inactivo",
@@ -977,9 +977,6 @@
           "none": "Ninguno",
           "unbalance_alarm": "Alarma de desequilibrio"
         }
-      },
-      "extradry_setting": {
-        "name": "Configuraci\u00f3n extra-seco"
       },
       "f_cool_qvalue": {
         "name": "Enfriando"
@@ -1593,6 +1590,9 @@
       },
       "child_lock": {
         "name": "Bloqueo para ni\u00f1os"
+      },
+      "child_lock_status": {
+        "name": "Bloqueo ni\u00f1os"
       },
       "drum_light": {
         "name": "Luz tambor"

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -25,9 +25,6 @@
       "alarm_door_opened": {
         "name": "Porta aperta"
       },
-      "child_lock_status": {
-        "name": "Blocco bambini"
-      },
       "delaystart_delayend_mode": {
         "name": "Partenza ritardata"
       },
@@ -235,6 +232,9 @@
       }
     },
     "select": {
+      "anticrease_setting": {
+        "name": "Durata antipiega"
+      },
       "t_fan_speed": {
         "name": "Fan speed",
         "state": {
@@ -276,9 +276,6 @@
       }
     },
     "sensor": {
-      "anticrease_setting": {
-        "name": "Durata antipiega"
-      },
       "appliance_status": {
         "state": {
           "idle": "Idle",
@@ -604,6 +601,9 @@
       }
     },
     "switch": {
+      "child_lock_status": {
+        "name": "Blocco bambini"
+      },
       "t_air": {
         "name": "Air"
       },

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -414,9 +414,6 @@
       "child_lock_open_door_sound_alarm": {
         "name": "Kinderbeveiliging open deur geluid alarm"
       },
-      "child_lock_status": {
-        "name": "Kinderbeveiliging"
-      },
       "child_lock_status_status": {
         "name": "Kinderbeveiliging"
       },
@@ -1621,6 +1618,9 @@
       }
     },
     "number": {
+      "airing_program_set_time": {
+        "name": "Beluchtingstijd"
+      },
       "aus_zone1_opencontrol": {
         "name": "Zone 1 opening"
       },
@@ -1644,6 +1644,9 @@
       },
       "aus_zone8_opencontrol": {
         "name": "Zone 8 opening"
+      },
+      "brightness_setting": {
+        "name": "Helderheid"
       },
       "delayendtime": {
         "name": "Delay end time"
@@ -1678,6 +1681,9 @@
       "refrigerator_temperature": {
         "name": "Koelkast temperatuur"
       },
+      "selected_program_timedry_set_duration": {
+        "name": "Tijdprogramma-duur"
+      },
       "t_fanspeedcv": {
         "name": "Variable fan speed"
       },
@@ -1689,6 +1695,9 @@
       },
       "variation_temperature": {
         "name": "Variatie temperatuur"
+      },
+      "volume_setting": {
+        "name": "Volume"
       }
     },
     "select": {
@@ -1711,6 +1720,16 @@
           "high": "Hoog",
           "low": "Laag",
           "medium": "Gemiddeld"
+        }
+      },
+      "anticrease_setting": {
+        "name": "Anti-kreukduur",
+        "state": {
+          "1_hour": "1 uur",
+          "2_hours": "2 uur",
+          "3_hours": "3 uur",
+          "4_hours": "4 uur",
+          "off": "Uit"
         }
       },
       "auto_dose_quantity_setting_status": {
@@ -1856,6 +1875,15 @@
           "wardrobe": "Kastdroog"
         }
       },
+      "extradry_setting": {
+        "name": "Extra droog",
+        "state": {
+          "10_min": "10 min",
+          "15_min": "15 min",
+          "5_min": "5 min",
+          "off": "Uit"
+        }
+      },
       "extrarinsenum": {
         "name": "Extra spoelen",
         "state": {
@@ -1876,6 +1904,17 @@
         "state": {
           "not_active": "Niet actief",
           "reset": "Resetten"
+        }
+      },
+      "language_setting": {
+        "name": "Taal",
+        "state": {
+          "au_english": "Engels (AU)",
+          "gb_english": "Engels (GB)",
+          "norwegian": "Noors",
+          "swedish_asko": "Zweeds (ASKO)",
+          "swedish_cylinda": "Zweeds (Cylinda)",
+          "us_english": "Engels (US)"
         }
       },
       "language_status": {
@@ -2056,6 +2095,14 @@
           "wool_manual": "Wol & Handmatig"
         }
       },
+      "selected_program_load": {
+        "name": "Belading",
+        "state": {
+          "heavy": "Zwaar",
+          "light": "Licht",
+          "medium": "Gemiddeld"
+        }
+      },
       "selected_program_mode": {
         "name": "Geselecteerde programmamodus",
         "state": {
@@ -2064,6 +2111,13 @@
           "normal": "Normaal",
           "not_available": "Niet beschikbaar",
           "speed": "Snel"
+        }
+      },
+      "selected_program_mode2": {
+        "name": "Speciale modus",
+        "state": {
+          "delicate": "Fijne was",
+          "disinfection": "Desinfectie"
         }
       },
       "selected_program_mode2_status": {
@@ -2078,7 +2132,9 @@
         "name": "Programmamodus",
         "state": {
           "intensive": "Intensief",
+          "nature_dry": "NatureDry",
           "normal": "Normaal",
+          "steam_tech": "SteamTech",
           "time_care_1": "Time Care 1",
           "time_care_2": "Time Care 2"
         }
@@ -2136,6 +2192,17 @@
           "1": "1",
           "2": "2",
           "3": "3"
+        }
+      },
+      "sound_settings": {
+        "name": "Geluidsniveau",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4",
+          "5": "5"
         }
       },
       "spin_speed_rpm": {
@@ -2390,6 +2457,9 @@
           "metric": "Metriek"
         }
       },
+      "view_size_setting": {
+        "name": "Weergavegrootte"
+      },
       "view_size_setting_status": {
         "name": "Weergavegrootte",
         "state": {
@@ -2575,9 +2645,6 @@
       },
       "anticrease_flag": {
         "name": "Anti-kreuk flag"
-      },
-      "anticrease_setting": {
-        "name": "Anti-kreuk duur"
       },
       "appcontrol_flag": {
         "name": "App-bediening"
@@ -3752,9 +3819,6 @@
       },
       "extra_soft_hideflag": {
         "name": "Extra soft verborgen"
-      },
-      "extradry_setting": {
-        "name": "Extra droog instelling"
       },
       "extrarinsenum": {
         "name": "Extra spoelen nummer"
@@ -6074,9 +6138,6 @@
       "sound_setting": {
         "name": "Geluid"
       },
-      "sound_settings": {
-        "name": "Sound settings"
-      },
       "special_space": {
         "name": "Special space"
       },
@@ -7368,9 +7429,6 @@
       "washer_to_dryer_program_id": {
         "name": "Washer to dryer program ID"
       },
-      "washer_to_dryersetting_status": {
-        "name": "Washer to dryer setting status"
-      },
       "washer_to_dryerwizard_trigger_status": {
         "name": "Washer to dryer wizard trigger status"
       },
@@ -7749,14 +7807,23 @@
       "autotubclean": {
         "name": "Automatisch trommel reinigen"
       },
+      "buzzer_setting": {
+        "name": "Zoemer"
+      },
       "child_lock": {
         "name": "Kinderbeveiliging"
       },
       "child_lock_setting_status": {
         "name": "Kinderbeveiliging"
       },
+      "child_lock_status": {
+        "name": "Kinderbeveiliging"
+      },
       "cleanairstatus": {
         "name": "Schone lucht"
+      },
+      "cleaning_reminder_setting": {
+        "name": "Reinigingsherinnering"
       },
       "color_sensor_setting_status": {
         "name": "Kleursensor"
@@ -7765,7 +7832,7 @@
         "name": "Crisp-functie"
       },
       "demo_mode": {
-        "name": "Demo modus"
+        "name": "Demomodus"
       },
       "demo_mode_status": {
         "name": "Demomodus"
@@ -7775,6 +7842,9 @@
       },
       "dose_assist_status": {
         "name": "Doseerhulp"
+      },
+      "drum_illumination": {
+        "name": "Trommelverlichting"
       },
       "drum_light": {
         "name": "Trommelverlichting"
@@ -7793,6 +7863,9 @@
       },
       "greasefilterstatus": {
         "name": "Vetfiltertimer"
+      },
+      "heating_power_setting": {
+        "name": "Verwarmingsvermogen"
       },
       "hide_setting": {
         "name": "Instelling verbergen"
@@ -7832,6 +7905,9 @@
       },
       "no_sound_status": {
         "name": "Dempen"
+      },
+      "notification_setting": {
+        "name": "Meldingen"
       },
       "odor_control_setting": {
         "name": "Geurcontrole"
@@ -7877,6 +7953,9 @@
       },
       "sf_sr_mutex_mode": {
         "name": "SF SR mutex modus"
+      },
+      "smart_sync_setting": {
+        "name": "Smart sync"
       },
       "smart_sync_setting_status": {
         "name": "Smart sync"
@@ -7961,6 +8040,9 @@
       },
       "turbidity_sensor_setting_status": {
         "name": "Troebelheidssensor"
+      },
+      "washer_to_dryersetting_status": {
+        "name": "Wasser-naar-droger sync"
       },
       "welcome": {
         "name": "Welkom"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -414,9 +414,6 @@
       "child_lock_open_door_sound_alarm": {
         "name": "Lydalarm for \u00e5pen barnesikringsd\u00f8r"
       },
-      "child_lock_status": {
-        "name": "Barnesikring"
-      },
       "child_lock_status_status": {
         "name": "Barnesikring"
       },
@@ -1621,6 +1618,9 @@
       }
     },
     "number": {
+      "airing_program_set_time": {
+        "name": "Luftingstid"
+      },
       "aus_zone1_opencontrol": {
         "name": "Sone 1 \u00e5pning"
       },
@@ -1644,6 +1644,9 @@
       },
       "aus_zone8_opencontrol": {
         "name": "Sone 8 \u00e5pning"
+      },
+      "brightness_setting": {
+        "name": "Lysstyrke"
       },
       "delayendtime": {
         "name": "Utsatt sluttid"
@@ -1678,6 +1681,9 @@
       "refrigerator_temperature": {
         "name": "Kj\u00f8leskapstemperatur"
       },
+      "selected_program_timedry_set_duration": {
+        "name": "Tidsprogramvarighet"
+      },
       "t_fanspeedcv": {
         "name": "Variabel viftehastighet"
       },
@@ -1689,6 +1695,9 @@
       },
       "variation_temperature": {
         "name": "Variasjonstemperatur"
+      },
+      "volume_setting": {
+        "name": "Volum"
       }
     },
     "select": {
@@ -1711,6 +1720,16 @@
           "high": "H\u00f8y",
           "low": "Lav",
           "medium": "Middels"
+        }
+      },
+      "anticrease_setting": {
+        "name": "Anti-kr\u00f8ll-varighet",
+        "state": {
+          "1_hour": "1 time",
+          "2_hours": "2 timer",
+          "3_hours": "3 timer",
+          "4_hours": "4 timer",
+          "off": "Av"
         }
       },
       "auto_dose_quantity_setting_status": {
@@ -1856,6 +1875,15 @@
           "wardrobe": "Garderobe"
         }
       },
+      "extradry_setting": {
+        "name": "Ekstrat\u00f8rr",
+        "state": {
+          "10_min": "10 min",
+          "15_min": "15 min",
+          "5_min": "5 min",
+          "off": "Av"
+        }
+      },
       "extrarinsenum": {
         "name": "Ekstra skyll",
         "state": {
@@ -1876,6 +1904,17 @@
         "state": {
           "not_active": "Ikke aktiv",
           "reset": "Tilbakestill"
+        }
+      },
+      "language_setting": {
+        "name": "Spr\u00e5k",
+        "state": {
+          "au_english": "Engelsk (AU)",
+          "gb_english": "Engelsk (GB)",
+          "norwegian": "Norsk",
+          "swedish_asko": "Svensk (ASKO)",
+          "swedish_cylinda": "Svensk (Cylinda)",
+          "us_english": "Engelsk (US)"
         }
       },
       "language_status": {
@@ -2056,6 +2095,14 @@
           "wool_manual": "Ull og manuell"
         }
       },
+      "selected_program_load": {
+        "name": "Mengde",
+        "state": {
+          "heavy": "Tung",
+          "light": "Lett",
+          "medium": "Middels"
+        }
+      },
       "selected_program_mode": {
         "name": "Modus",
         "state": {
@@ -2064,6 +2111,13 @@
           "normal": "Normal",
           "not_available": "Ikke tilgjengelig",
           "speed": "Hastighet"
+        }
+      },
+      "selected_program_mode2": {
+        "name": "Spesialmodus",
+        "state": {
+          "delicate": "Sk\u00e5nsom",
+          "disinfection": "Desinfeksjon"
         }
       },
       "selected_program_mode2_status": {
@@ -2078,7 +2132,9 @@
         "name": "Programmodus",
         "state": {
           "intensive": "Intensiv",
+          "nature_dry": "NatureDry",
           "normal": "Normal",
+          "steam_tech": "SteamTech",
           "time_care_1": "Time Care 1",
           "time_care_2": "Time Care 2"
         }
@@ -2136,6 +2192,17 @@
           "1": "1",
           "2": "2",
           "3": "3"
+        }
+      },
+      "sound_settings": {
+        "name": "Lydniv\u00e5",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4",
+          "5": "5"
         }
       },
       "spin_speed_rpm": {
@@ -2390,6 +2457,9 @@
           "metric": "Metrisk"
         }
       },
+      "view_size_setting": {
+        "name": "Visningsst\u00f8rrelse"
+      },
       "view_size_setting_status": {
         "name": "Visningsst\u00f8rrelse",
         "state": {
@@ -2575,9 +2645,6 @@
       },
       "anticrease_flag": {
         "name": "Anti-kr\u00f8ll-flagg"
-      },
-      "anticrease_setting": {
-        "name": "Anti-kr\u00f8ll-varighet"
       },
       "appcontrol_flag": {
         "name": "App-styringsflagg"
@@ -3752,9 +3819,6 @@
       },
       "extra_soft_hideflag": {
         "name": "Skjul-flagg for ekstra mykt"
-      },
-      "extradry_setting": {
-        "name": "Innstilling for ekstrat\u00f8rr"
       },
       "extrarinsenum": {
         "name": "Antall ekstra skyll"
@@ -6074,9 +6138,6 @@
       "sound_setting": {
         "name": "Lydinnstilling"
       },
-      "sound_settings": {
-        "name": "Lydinnstillinger"
-      },
       "special_space": {
         "name": "Spesialrom"
       },
@@ -7368,9 +7429,6 @@
       "washer_to_dryer_program_id": {
         "name": "Vasker \u2192 t\u00f8rker program-ID"
       },
-      "washer_to_dryersetting_status": {
-        "name": "Innstilling for vasker \u2192 t\u00f8rker"
-      },
       "washer_to_dryerwizard_trigger_status": {
         "name": "Veivisertriggerstatus for vasker \u2192 t\u00f8rker"
       },
@@ -7749,14 +7807,23 @@
       "autotubclean": {
         "name": "Automatisk trommelrens"
       },
+      "buzzer_setting": {
+        "name": "Summer"
+      },
       "child_lock": {
         "name": "Barnesikring"
       },
       "child_lock_setting_status": {
         "name": "Barnesikring"
       },
+      "child_lock_status": {
+        "name": "Barnesikring"
+      },
       "cleanairstatus": {
         "name": "Ren luft"
+      },
+      "cleaning_reminder_setting": {
+        "name": "Rengj\u00f8ringsp\u00e5minnelse"
       },
       "color_sensor_setting_status": {
         "name": "Fargesensor"
@@ -7776,6 +7843,9 @@
       "dose_assist_status": {
         "name": "Doseringshjelper"
       },
+      "drum_illumination": {
+        "name": "Trommellys"
+      },
       "drum_light": {
         "name": "Trommellys"
       },
@@ -7793,6 +7863,9 @@
       },
       "greasefilterstatus": {
         "name": "Fettfiltertimer"
+      },
+      "heating_power_setting": {
+        "name": "Varmeeffekt"
       },
       "hide_setting": {
         "name": "Skjul innstilling"
@@ -7832,6 +7905,9 @@
       },
       "no_sound_status": {
         "name": "Lydl\u00f8s"
+      },
+      "notification_setting": {
+        "name": "Varslinger"
       },
       "odor_control_setting": {
         "name": "Luktkontroll"
@@ -7877,6 +7953,9 @@
       },
       "sf_sr_mutex_mode": {
         "name": "SF/SR-mutex-modus"
+      },
+      "smart_sync_setting": {
+        "name": "Smart synk"
       },
       "smart_sync_setting_status": {
         "name": "Smart synk"
@@ -7961,6 +8040,9 @@
       },
       "turbidity_sensor_setting_status": {
         "name": "Turbiditetssensor"
+      },
+      "washer_to_dryersetting_status": {
+        "name": "Vasker-til-t\u00f8rker-sync"
       },
       "welcome": {
         "name": "Velkommen"


### PR DESCRIPTION
## Summary

Wire up writable counterparts in the 032 (tumble dryer) data dictionary.

### Read → writable conversions

The 032 spec uses three different naming conventions for read↔write pairs (plus a few one-offs), so each pair is wired explicitly via `command.name`:

- `*_setting` → `*_setting_set` (newer config-style: Buzzer, Cleaning_reminder, Heating_power, Notification, Smart_sync)
- `*_status` → `*` (legacy: Child_Lock, Washer_to_Dryersetting, Selected_program_mode)
- `*` → `*_set` (middle-ground: Demo_mode, Drum_illumination, Selected_program_Load, Selected_program_mode2, Airing_program_Set_time)
- One-offs: `Sound_settings` (plural read) → `Sound_setting` (singular write); `AntiCrease_setting` → `Selected_program_AntiCrease`; `ExtraDry_setting` → `Selected_program_ExtraDry`

Use `adjust: 1` where the read enum has `Not available` at index 0; default (no adjust) where both sides share an encoding. Add `unavailable: 0` to skip entities on devices that don't expose the feature.

### Existing-entry conversions

- `Child_Lock_status`: binary_sensor → switch
- `AntiCrease_setting`: previously typed as `duration: h` (wrong — the values are an enum, not hours) → select with `off/1-4 hours`
- `ExtraDry_setting`: empty sensor → select with `off/5/10/15 min`
- `Selected_program_mode_status`, `Sound_settings`, `Washer_to_Dryersetting_status`: placeholders → typed selects/switches
- Dropped `optional: true` from `Selected_program_mode_status` so the per-wash program mode picker is visible by default.

### Categorization

Following 003/027 convention: device-wide settings get `config`, per-wash options stay uncategorized, pairing infrastructure stays `diagnostic`.

### Button-coming placeholders

`Actions`, `Fota_cmd`, and `Selected_program_TimeDry_Set_Duration` are staged here. They write to themselves (no separate command target) so they need button-platform support to instantiate.

### Translations

Curated English display names. Added German, Dutch, and Norwegian translations on the new platform keys. Restored Spanish and Italian names for converted entries (`child_lock_status`, `anticrease_setting`, `extradry_setting`).

A few targeted renames to avoid confusion:
- `Sound_settings` → "Sound level" (avoid collision with `Volume_setting`)
- `Selected_program_mode2` → "Special mode" (its `Program mode 2` auto-name is uninformative)
- `Washer_to_Dryersetting_status` → "Washer-to-dryer sync" (clarify what it toggles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)