### PR TITLE
Add button platform for write-only commands

### DIFF
--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -23,6 +23,7 @@ from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.HUMIDIFIER,
     Platform.NUMBER,

--- a/custom_components/connectlife/button.py
+++ b/custom_components/connectlife/button.py
@@ -1,0 +1,75 @@
+"""Provides a button for ConnectLife write-only actions."""
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from connectlife.appliance import ConnectLifeAppliance
+
+from .const import DOMAIN
+from .coordinator import ConnectLifeCoordinator
+from .dictionaries import Button, Dictionaries
+from .entity import ConnectLifeEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ConnectLife buttons."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    for appliance in coordinator.data.values():
+        dictionary = Dictionaries.get_dictionary(appliance)
+        async_add_entities(
+            ConnectLifeButton(coordinator, appliance, button, config_entry)
+            for button in dictionary.buttons
+        )
+
+
+class ConnectLifeButton(ConnectLifeEntity, ButtonEntity):
+    """Button class for ConnectLife write-only actions."""
+
+    def __init__(
+        self,
+        coordinator: ConnectLifeCoordinator,
+        appliance: ConnectLifeAppliance,
+        button: Button,
+        config_entry: ConfigEntry,
+    ):
+        """Initialize the entity."""
+        super().__init__(
+            coordinator, appliance, f"button-{button.key}", Platform.BUTTON, config_entry
+        )
+        self.button = button
+        self.entity_description = ButtonEntityDescription(
+            key=self._attr_unique_id,
+            icon=button.icon,
+            name=button.key.replace("_", " "),
+            translation_key=self.to_translation_key(button.key),
+        )
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        status_list = self.coordinator.data[self.device_id].status_list
+        for name, expected in self.button.available_when.items():
+            if status_list.get(name) != expected:
+                return False
+        return True
+
+    @callback
+    def update_state(self):
+        """Buttons have no state to track."""
+
+    async def async_press(self) -> None:
+        """Send the button's write map to the device."""
+        status_list = self.coordinator.data[self.device_id].status_list
+        # Only reflect read-back properties optimistically; write-only keys
+        # like Actions never appear in status_list and would linger as
+        # phantom values until the next poll.
+        properties = {k: v for k, v in self.button.write.items() if k in status_list}
+        await self.async_update_device(dict(self.button.write), properties)

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -83,13 +83,14 @@ Example: a feature variant returns a property as a direct value where the base c
 
 ## Create your own mapping file
 
-To map you device, create a file with the name `<deviceTypeCode>-<deviceFeatureCode>.yaml` in this directory. When done,
+To map your device, create a file with the name `<deviceTypeCode>-<deviceFeatureCode>.yaml` in this directory. When done,
 or if you need help with the mapping, please open a PR on GitHub with the file!
 
-The file contains two top level items:
+The file contains these top level items:
 
 - `climate`: top level [`Climate`](#presets) configuration.
 - `properties`: list of [`Property`](#property)
+- `buttons`: list of [`Button`](#buttons) entities for write-only commands
 
 To make a property visible by default, just add the property to the list. Note that properties you do not map are still
 mapped to [sensor](#type-sensor) entities, but registered as disabled by default.
@@ -410,6 +411,58 @@ reports `1 = off` and `2 = on` on the status property but expects `0 = off` and 
 ```
 
 The same mechanism works for [Select](#type-select): the value written is the integer key from `options` minus `adjust`.
+
+## Buttons
+
+The top-level `buttons` section declares device-level button entities for write-only commands —
+properties that don't appear in `status_list`, such as `Actions` on a dishwasher. Each list entry
+becomes one HA button entity. A press sends the `write` map to the device in a single request.
+
+| Item             | Type                            | Description                                                                                                                                                                                                                                  |
+|------------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `key`            | string                          | Unique key for this button within the device. Used as the translation key, as part of the entity unique id, and as the merge identity when a feature override changes an inherited button.                                                  |
+| `icon`           | `mdi:play`, etc.                | Icon for the button.                                                                                                                                                                                                                         |
+| `available_when` | dictionary of string to integer | Optional. Map of property name to required value. The button is only available when every listed property currently has the listed value. Use to gate buttons behind a remote-control-allowed status property.                              |
+| `write`          | dictionary of string to integer | Required for non-disabled buttons. Map of property name to value to send when pressed. Multiple entries are sent in a single request — useful for combos like "set delay + start".                                                          |
+| `disable`        | `true`, `false`                 | If `true`, suppress this button. Use in a feature override to remove a button inherited from the base when a device variant doesn't support that action code. Defaults to `false`.                                                          |
+
+Feature overrides merge with the base by `key`: matching entries shallow-merge field by field
+(`available_when` and `write` replace as a whole), and entries with a new `key` are appended.
+A feature override carrying only the differences keeps the override file small.
+
+Remember to add [translation strings](#translation-strings) for button names under `entity.button.<key>.name`.
+
+Example base file declaring start/stop/pause:
+
+```yaml
+# 015.yaml (base)
+buttons:
+  - key: start
+    icon: mdi:play
+    available_when:
+      Remote_control_monitoring_set_commands_actions: 2
+    write:
+      Actions: 2
+  - key: stop
+    icon: mdi:stop
+    write:
+      Actions: 1
+  - key: pause
+    icon: mdi:pause
+    available_when:
+      Remote_control_monitoring_set_commands_actions: 2
+    write:
+      Actions: 3
+```
+
+Example feature override disabling pause on a variant that doesn't support `Actions: 3`:
+
+```yaml
+# 015-{feature}.yaml (override — drops the pause button, keeps start/stop)
+buttons:
+  - key: pause
+    disable: true
+```
 
 ## Type `WaterHeater`
 

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -14,6 +14,13 @@
           "items": {
             "$ref": "#/$defs/Property"
           }
+        },
+        "buttons": {
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/Button"
+          },
+          "description": "Device-level buttons for write-only commands. A feature override replaces the base list as a whole."
         }
       },
       "title": "ConnectLife Data Dictionary"
@@ -126,6 +133,43 @@
       ],
       "title": "Property",
       "description": "Defines a property for an appliance."
+    },
+    "Button": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Unique key for this button within the device. Used as the translation key, as part of the entity unique id, and as the merge identity when a feature override changes an inherited button.",
+          "examples": ["start", "stop", "pause"]
+        },
+        "icon": {
+          "type": ["string", "null"],
+          "description": "Icon for the button.",
+          "examples": ["mdi:play", "mdi:stop", "mdi:pause"]
+        },
+        "available_when": {
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Map of property name to required value. The button is only available when every listed property currently has the listed value. Use to gate buttons behind a remote-control-allowed status property. Replaces the inherited value as a whole."
+        },
+        "write": {
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Map of property name to value to send when the button is pressed. Multiple entries are sent in a single request. Required for non-disabled buttons; replaces the inherited value as a whole."
+        },
+        "disable": {
+          "type": "boolean",
+          "description": "If true, suppress this button. Used in a feature override to remove a button inherited from the base — e.g. when a device variant doesn't support a particular action code.",
+          "default": false
+        }
+      },
+      "required": ["key"],
+      "title": "Button"
     },
     "BinarySensor": {
       "type": ["object", "null"],

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -28,12 +28,15 @@ from .const import (
 )
 
 ADJUST = "adjust"
+AVAILABLE_WHEN = "available_when"
+BUTTONS = "buttons"
 COMMAND = "command"
 DEVICE = "device"
 DEVICE_CLASS = "device_class"
 DISABLE = "disable"
 HIDE = "hide"
 ICON = "icon"
+KEY = "key"
 NAME = "name"
 OFF = "off"
 ON = "on"
@@ -54,6 +57,7 @@ UNAVAILABLE = "unavailable"
 ENTITY_CATEGORY = "entity_category"
 UNKNOWN_VALUE = "unknown_value"
 UNIT = "unit"
+WRITE = "write"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -368,6 +372,53 @@ class Property:
             self.sensor = Sensor(self.name, {})
 
 
+class Button:
+    """A button entity declared at the top level of a data dictionary.
+
+    Buttons are for write-only commands: a press writes ``write`` to the
+    device. ``available_when`` gates the button on read-back property values
+    (all keys must match for the button to be available).
+    """
+
+    key: str
+    icon: str | None
+    available_when: dict[str, int]
+    write: dict[str, int]
+
+    def __init__(self, entry: dict):
+        self.key = entry[KEY]
+        self.icon = _val(entry, ICON) or None
+        self.available_when = _val(entry, AVAILABLE_WHEN, {})
+        write = _val(entry, WRITE)
+        if not write:
+            _LOGGER.warning("Button %s has no write map", self.key)
+            self.write = {}
+        else:
+            self.write = write
+
+
+def _merge_buttons(base: list[dict], override: list[dict]) -> list[dict]:
+    """Merge button lists by ``key``.
+
+    Entries in ``override`` matching a key in ``base`` shallow-merge field by
+    field (override wins; ``available_when`` and ``write`` replace as a whole
+    since they're collections). Entries with keys not in ``base`` are
+    appended. ``disable: true`` removes the merged entry from the result —
+    use it to suppress an inherited button on a variant that doesn't support
+    the action.
+    """
+    by_key: dict[str, dict] = {b[KEY]: dict(b) for b in base}
+    order: list[str] = [b[KEY] for b in base]
+    for entry in override:
+        key = entry[KEY]
+        if key in by_key:
+            by_key[key] = {**by_key[key], **entry}
+        else:
+            by_key[key] = dict(entry)
+            order.append(key)
+    return [by_key[k] for k in order if not by_key[k].get(DISABLE)]
+
+
 @dataclass
 class Dictionary:
     """Data dictionary for a ConnectLife appliance"""
@@ -375,6 +426,7 @@ class Dictionary:
     # Todo: Refactor Climate dataclass
     climate: dict | None
     properties: dict[str, Property]
+    buttons: list[Button]
 
 
 PLATFORM_KEYS = (
@@ -470,14 +522,18 @@ class Dictionaries:
 
         climate: dict | None = None
         raw_entries: dict[str, dict] = {}
+        raw_buttons: list[dict] = []
 
         # TODO: Support default climate section
         _, base_data = _load_yaml(
             f"data_dictionaries/{appliance.device_type_code}.yaml"
         )
-        if base_data is not None and PROPERTIES in base_data and base_data[PROPERTIES] is not None:
-            for prop in base_data[PROPERTIES]:
-                raw_entries[prop[PROPERTY]] = prop
+        if base_data is not None:
+            if PROPERTIES in base_data and base_data[PROPERTIES] is not None:
+                for prop in base_data[PROPERTIES]:
+                    raw_entries[prop[PROPERTY]] = prop
+            if BUTTONS in base_data and base_data[BUTTONS] is not None:
+                raw_buttons = list(base_data[BUTTONS])
 
         sub_found, sub_data = _load_yaml(f"data_dictionaries/{key}.yaml")
         if not sub_found:
@@ -493,6 +549,8 @@ class Dictionaries:
                 for prop in sub_data[PROPERTIES]:
                     name = prop[PROPERTY]
                     raw_entries[name] = _merge_property(raw_entries.get(name), prop)
+            if BUTTONS in sub_data and sub_data[BUTTONS] is not None:
+                raw_buttons = _merge_buttons(raw_buttons, sub_data[BUTTONS])
 
         properties: dict[str, Property] = defaultdict(
             lambda: Property({PROPERTY: "default", OPTIONAL: True})
@@ -505,6 +563,8 @@ class Dictionaries:
                 for source in prop.combine:
                     properties[source[PROPERTY]].disable = True
 
-        dictionary = Dictionary(climate=climate, properties=properties)
+        buttons = [Button(b) for b in raw_buttons]
+
+        dictionary = Dictionary(climate=climate, properties=properties, buttons=buttons)
         cls.dictionaries[key] = dictionary
         return dictionary

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -164,7 +164,18 @@ def main(basedir):
                             if include_option(preset, filename):
                                 strings["entity"]["climate"]["connectlife"]["state_attributes"]["preset_mode"]["state"][preset] = pretty(preset)
 
-    for entity_type in ["binary_sensor", "switch", "number", "sensor", "select"]:
+            if "buttons" in appliance and appliance["buttons"] is not None:
+                if "button" not in strings["entity"]:
+                    strings["entity"]["button"] = {}
+                for button in appliance["buttons"]:
+                    key = to_key(button["key"])
+                    if key not in strings["entity"]["button"]:
+                        strings["entity"]["button"][key] = {"name": pretty(button["key"])}
+                    elif "name" not in strings["entity"]["button"][key]:
+                        strings["entity"]["button"][key]["name"] = pretty(button["key"])
+                    valid_properties.setdefault("button", set()).add(key)
+
+    for entity_type in ["binary_sensor", "button", "switch", "number", "sensor", "select"]:
         if entity_type not in strings["entity"]:
             continue
         valid = valid_properties.get(entity_type, set())


### PR DESCRIPTION
New top-level `buttons:` block declares button entities that send writes without a read-back status property. Used for `Actions` on dishwashers and ovens that aren't in `status_list`. Feature overrides merge by `key` with a `disable` field to suppress inherited buttons on variants that don't support the action.