### PR TITLE
Make `unavailable` dynamic instead of gating entity creation

### DIFF
--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -16,7 +16,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import is_entity
+from .utils import has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,11 +35,7 @@ async def async_setup_entry(
                 coordinator, appliance, s, dictionary.properties[s]
             )
             for s in appliance.status_list
-            if is_entity(
-                Platform.BINARY_SENSOR,
-                dictionary.properties[s],
-                appliance.status_list[s],
-            )
+            if has_platform(Platform.BINARY_SENSOR, dictionary.properties[s])
         )
 
 
@@ -56,6 +52,8 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.BINARY_SENSOR)
         self.status = status
+        self._unavailable_status = status
+        self._unavailable_value = dd_entry.unavailable
         self.options = dd_entry.binary_sensor.options
         self.entity_description = BinarySensorEntityDescription(
             key=self._attr_unique_id,
@@ -67,7 +65,7 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
             device_class=dd_entry.binary_sensor.device_class,
             entity_category=dd_entry.entity_category,
         )
-        self.update_state()
+        self._refresh_state()
 
     @callback
     def update_state(self):

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -31,6 +31,8 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
     _attr_has_entity_name = True
     _attr_unique_id: str
     _disable_beep = False
+    _unavailable_status: str | None = None
+    _unavailable_value: int | None = None
 
     def __init__(
             self,
@@ -66,12 +68,23 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
         # CoordinatorEntity.available only checks last_update_success, so
         # _attr_available is ignored. Combine both with the device's
         # offline_state (1 == online) so unplugged devices show as
-        # unavailable in HA.
+        # unavailable in HA. Also factor in the per-property `unavailable`
+        # sentinel: when the current value matches, the entity is shown as
+        # unavailable rather than being skipped at creation time.
         return (
             super().available
             and self.device_id in self.coordinator.data
             and self.coordinator.data[self.device_id].offline_state == 1
+            and not self._is_value_unavailable()
         )
+
+    def _is_value_unavailable(self) -> bool:
+        if self._unavailable_status is None or self._unavailable_value is None:
+            return False
+        if self.device_id not in self.coordinator.data:
+            return False
+        status_list = self.coordinator.data[self.device_id].status_list
+        return status_list.get(self._unavailable_status) == self._unavailable_value
 
     @callback
     @abstractmethod
@@ -79,9 +92,15 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
         """Subclasses implement this to update their state."""
 
     @callback
+    def _refresh_state(self) -> None:
+        """Run subclass update_state() unless the value matches the unavailable sentinel."""
+        if not self._is_value_unavailable():
+            self.update_state()
+
+    @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self.update_state()
+        self._refresh_state()
         self.async_write_ha_state()
 
     async def async_update_device(self, command: dict[str, int], properties: dict[str, int] | None = None):

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -14,7 +14,7 @@ from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import is_entity, to_unit
+from .utils import has_platform, to_unit
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,9 +38,7 @@ async def async_setup_entry(
                 dictionary,
             )
             for s in appliance.status_list
-            if is_entity(
-                Platform.NUMBER, dictionary.properties[s], appliance.status_list[s]
-            )
+            if has_platform(Platform.NUMBER, dictionary.properties[s])
         )
 
 
@@ -61,6 +59,8 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.NUMBER, config_entry)
         self.status = status
+        self._unavailable_status = status
+        self._unavailable_value = dd_entry.unavailable
         self.command_name = (
             dd_entry.number.command_name if dd_entry.number.command_name else status
         )
@@ -80,7 +80,7 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
             translation_key=self.to_translation_key(status),
             entity_category=dd_entry.entity_category,
         )
-        self.update_state()
+        self._refresh_state()
 
     @callback
     def update_state(self):

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -13,7 +13,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import is_entity
+from .utils import has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,9 +32,7 @@ async def async_setup_entry(
                 coordinator, appliance, s, dictionary.properties[s], config_entry
             )
             for s in appliance.status_list
-            if is_entity(
-                Platform.SELECT, dictionary.properties[s], appliance.status_list[s]
-            )
+            if has_platform(Platform.SELECT, dictionary.properties[s])
         )
 
 
@@ -54,6 +52,8 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.SELECT, config_entry)
         self.status = status
+        self._unavailable_status = status
+        self._unavailable_value = dd_entry.unavailable
         # Copy: unmapped values are added per-entity, avoid leaking to other appliances.
         self.options_map = dict(dd_entry.select.options)
         self.reverse_options_map = {v: k for k, v in self.options_map.items()}
@@ -72,7 +72,7 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
             translation_key=self.to_translation_key(status),
             entity_category=dd_entry.entity_category,
         )
-        self.update_state()
+        self._refresh_state()
 
     @callback
     def update_state(self):

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -24,7 +24,7 @@ from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance, MAX_DATETIME
-from .utils import is_entity, to_unit
+from .utils import has_platform, to_unit
 
 SERVICE_SET_VALUE = "set_value"
 
@@ -47,11 +47,7 @@ async def async_setup_entry(
             )
             for s in appliance.status_list
             if s != SW_VERSION_PROPERTY
-            and is_entity(
-                Platform.SENSOR,
-                dictionary.properties[s],
-                appliance.status_list[s],
-            )
+            and has_platform(Platform.SENSOR, dictionary.properties[s])
         )
         async_add_entities(
             ConnectLifeStatusSensor(
@@ -93,6 +89,8 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.SENSOR)
         self.status = status
+        self._unavailable_status = status
+        self._unavailable_value = dd_entry.unavailable
         self.combine = dd_entry.combine
         self.read_only = True if self.combine else dd_entry.sensor.read_only
         self.multiplier = dd_entry.sensor.multiplier
@@ -124,7 +122,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
             translation_key=self.to_translation_key(status),
             entity_category=dd_entry.entity_category,
         )
-        self.update_state()
+        self._refresh_state()
 
     @callback
     def update_state(self):

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
-from .utils import is_entity
+from .utils import has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,9 +33,7 @@ async def async_setup_entry(
                 coordinator, appliance, s, dictionary.properties[s], config_entry
             )
             for s in appliance.status_list
-            if is_entity(
-                Platform.SWITCH, dictionary.properties[s], appliance.status_list[s]
-            )
+            if has_platform(Platform.SWITCH, dictionary.properties[s])
         )
 
 
@@ -53,6 +51,8 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
         """Initialize the entity."""
         super().__init__(coordinator, appliance, status, Platform.SWITCH, config_entry)
         self.status = status
+        self._unavailable_status = status
+        self._unavailable_value = dd_entry.unavailable
         self.command_name = (
             dd_entry.switch.command_name if dd_entry.switch.command_name else status
         )
@@ -70,7 +70,7 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
             device_class=dd_entry.switch.device_class,
             entity_category=dd_entry.entity_category,
         )
-        self.update_state()
+        self._refresh_state()
 
     @callback
     def update_state(self):

--- a/custom_components/connectlife/utils.py
+++ b/custom_components/connectlife/utils.py
@@ -8,10 +8,13 @@ from .const import TEMPERATURE_UNIT
 from .dictionaries import Property, Dictionary
 
 
+def has_platform(platform: Platform, property: Property):
+    return hasattr(property, platform) and not property.disable
+
+
 def is_entity(platform: Platform, property: Property, value: float | int | str | dt.datetime | None):
     return (
-            hasattr(property, platform)
-            and not property.disable
+            has_platform(platform, property)
             and (
                     property.unavailable is None
                     or value != property.unavailable

--- a/custom_components/connectlife/utils.py
+++ b/custom_components/connectlife/utils.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import Platform, UnitOfTemperature
 
@@ -12,16 +10,6 @@ def has_platform(platform: Platform, property: Property):
     return hasattr(property, platform) and not property.disable
 
 
-def is_entity(platform: Platform, property: Property, value: float | int | str | dt.datetime | None):
-    return (
-            has_platform(platform, property)
-            and (
-                    property.unavailable is None
-                    or value != property.unavailable
-            )
-    )
-
-
 def to_unit(unit: str | None, appliance: ConnectLifeAppliance, dictionary: Dictionary):
     if unit is None:
         return None
@@ -30,15 +18,15 @@ def to_unit(unit: str | None, appliance: ConnectLifeAppliance, dictionary: Dicti
         if unit_property_name in dictionary.properties:
             unit_value = appliance.status_list[unit_property_name]
             unit_property = dictionary.properties[unit_property_name]
-            if is_entity(Platform.CLIMATE, unit_property, unit_value):
+            if has_platform(Platform.CLIMATE, unit_property):
                 unit_climate = unit_property.climate
                 if unit_climate.target == TEMPERATURE_UNIT and unit_value in unit_climate.options:
                     unit = unit_climate.options[unit_value]
-            elif is_entity(Platform.SENSOR, unit_property, unit_value):
+            elif has_platform(Platform.SENSOR, unit_property):
                 unit_sensor = unit_property.sensor
                 if unit_sensor.device_class == SensorDeviceClass.ENUM and unit_sensor.options is not None and unit_value in unit_sensor.options:
                     unit = unit_sensor.options[unit_value]  # type: ignore[index]
-            elif is_entity(Platform.SELECT, unit_property, unit_value):
+            elif has_platform(Platform.SELECT, unit_property):
                 unit_select = unit_property.select
                 if unit_value in unit_select.options:
                     unit = unit_select.options[unit_value]


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v0.36.0 (#519): the blanket addition of `unavailable: 0` to many 027 mappings caused entities whose property happened to sit at `0` at integration startup to stop being created at all. Users who had those entities before lost them and any automations referencing them broke — and program-gated controls (RPM, set temperature, prewash, …) could only "appear" by selecting a program in the vendor app *and* reloading the integration. See #528 for the user-facing complaint that surfaced this.

Move the `unavailable` check from creation time to HA's runtime `available`:

- `utils.has_platform()` — new helper: platform match + not disabled, no value check. Used by the per-property platform setups (binary_sensor, sensor, switch, select, number) so entities are always created when the property is present in `status_list`. The previous `is_entity()` is removed; its only other caller, `to_unit()`, switches to `has_platform()` (the value-validity gate was redundant — the inner branches already guard with `unit_value in <options>`).
- `ConnectLifeEntity` — base class stores `_unavailable_status` / `_unavailable_value` and reports `available = False` when the current value matches the sentinel. A new `_refresh_state()` wrapper skips `update_state()` while unavailable, so the existing "Unknown value 0" warnings in sensor/switch/select don't fire on every coordinator poll while the property is in its sentinel state.
- Per-property platforms — set the sentinel pair in `__init__` from `dd_entry.unavailable`, and call `_refresh_state()` instead of `update_state()` to seed initial state.

Devices without a feature don't expose it in `status_list` at all, so this doesn't create dead entities for absent features — only those whose state genuinely varies with the device's runtime mode.

Net effect: program-gated entities now exist on startup as `unavailable` and flip to available automatically once the underlying value changes — no integration reload needed.

Refs #528.

## Test plan

- [x] Existing tests pass (`uv run python -m pytest tests/`), pyright clean (`uv run pyright`).
- [x] On a device with program-gated controls (e.g. 027 washing machine): with no program selected, the program-gated entities exist but render as `unavailable`.
- [x] Properties without an `unavailable` sentinel are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)