### PR TITLE
Wrap select/switch writes in ServiceValidationError

### DIFF
--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -6,12 +6,14 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
+from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance
 from .utils import is_entity
 
@@ -100,7 +102,10 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self.async_update_device(
-            {self.command_name: self.reverse_options_map[option] - self.command_adjust},
-            {self.status: self.reverse_options_map[option]},
-        )
+        try:
+            await self.async_update_device(
+                {self.command_name: self.reverse_options_map[option] - self.command_adjust},
+                {self.status: self.reverse_options_map[option]},
+            )
+        except LifeConnectError as api_error:
+            raise ServiceValidationError(str(api_error)) from api_error

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -6,8 +6,10 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance
 
 from .const import DOMAIN
@@ -86,13 +88,19 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn off."""
-        await self.async_update_device(
-            {self.command_name: self.command_off},
-            {self.status: self.off},
-        )
+        try:
+            await self.async_update_device(
+                {self.command_name: self.command_off},
+                {self.status: self.off},
+            )
+        except LifeConnectError as api_error:
+            raise ServiceValidationError(str(api_error)) from api_error
 
     async def async_turn_on(self, **kwargs):
         """Turn on."""
-        await self.async_update_device(
-            {self.command_name: self.command_on}, {self.status: self.on}
-        )
+        try:
+            await self.async_update_device(
+                {self.command_name: self.command_on}, {self.status: self.on}
+            )
+        except LifeConnectError as api_error:
+            raise ServiceValidationError(str(api_error)) from api_error


### PR DESCRIPTION
## Summary

`select.async_select_option` and `switch.async_turn_off`/`async_turn_on` let `LifeConnectError` propagate as-is, so a cloud-side rejection (e.g. `code=160001 description='Command status mutex'` when pausing a washing machine) surfaces in the HA log as a full traceback through `entity_service_call` (see #529).

Catch `LifeConnectError` and re-raise as `ServiceValidationError(str(err))` to match what `sensor.async_set_value` and `number.async_set_native_value` already do — HA renders this as a clean user notification.

Refs #529.

## Test plan

Verified locally against the `connectlife.test_server` (no test-server changes required — the existing "Unknown properties" 400 path is enough, because most writable entities use a `command.name` different from the status property name).

- [x] Run `uv run python -m connectlife.test_server` from `connectlife/dumps/`.
- [x] Configure the integration with `Test server URL: http://localhost:8080` and load device `027-000`.
- [x] Change the **Volume** select to any value → integration sends `{Sound_setting: n}`, test server replies `code=400 description='Unknown properties ['Sound_setting']'`.
- [x] Observe: clean `ServiceValidationError` notification in the HA UI; log shows a single `ERROR` line from `websocket_api`, no traceback through `entity_service_call`.
- [x] `uv run pyright` clean, `uv run python -m pytest tests/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)