### PR TITLE
Centralize write error handling in ConnectLifeEntity.async_update_device

### DIFF
--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -8,6 +8,7 @@ from connectlife.api import LifeConnectError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -106,39 +107,42 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
     async def async_update_device(self, command: dict[str, int], properties: dict[str, int] | None = None):
         if properties is None:
             properties = command.copy()
-        if self._disable_beep:
-            command["t_beep"] = 0
-            try:
-                await self.coordinator.async_update_device(self.device_id, command, properties)
-            except LifeConnectError as err:
-                _LOGGER.debug(
-                    "Command failed with t_beep for %s (%s), retrying without",
-                    self.nickname,
-                    err,
-                )
-                del command["t_beep"]
+        try:
+            if self._disable_beep:
+                command["t_beep"] = 0
                 try:
                     await self.coordinator.async_update_device(self.device_id, command, properties)
-                except LifeConnectError:
-                    raise err from None
-                self._disable_beep = False
-                ir.async_create_issue(
-                    self.coordinator.hass,
-                    DOMAIN,
-                    f"unsupported_beep.{self.device_id}",
-                    is_fixable=True,
-                    severity=ir.IssueSeverity.WARNING,
-                    translation_key="unsupported_beep",
-                    translation_placeholders={
-                        "device_name": self.nickname or "",
-                    },
-                    data={
-                        "entry_id": self.coordinator.config_entry.entry_id,
-                        "device_id": self.device_id,
-                    },
-                )
-        else:
-            await self.coordinator.async_update_device(self.device_id, command, properties)
+                except LifeConnectError as err:
+                    _LOGGER.debug(
+                        "Command failed with t_beep for %s (%s), retrying without",
+                        self.nickname,
+                        err,
+                    )
+                    del command["t_beep"]
+                    try:
+                        await self.coordinator.async_update_device(self.device_id, command, properties)
+                    except LifeConnectError:
+                        raise err from None
+                    self._disable_beep = False
+                    ir.async_create_issue(
+                        self.coordinator.hass,
+                        DOMAIN,
+                        f"unsupported_beep.{self.device_id}",
+                        is_fixable=True,
+                        severity=ir.IssueSeverity.WARNING,
+                        translation_key="unsupported_beep",
+                        translation_placeholders={
+                            "device_name": self.nickname or "",
+                        },
+                        data={
+                            "entry_id": self.coordinator.config_entry.entry_id,
+                            "device_id": self.device_id,
+                        },
+                    )
+            else:
+                await self.coordinator.async_update_device(self.device_id, command, properties)
+        except LifeConnectError as api_error:
+            raise ServiceValidationError(str(api_error)) from api_error
 
     def to_translation_key(self, property_name: str) -> str:
         return re.sub(r'_+', '_', property_name.strip().lower().replace(" ", "_"))

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -5,14 +5,12 @@ from homeassistant.components.number import NumberEntity, NumberEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
-from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance
 from .utils import has_platform, to_unit
 
@@ -92,10 +90,7 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
         """Update the current value."""
         value = int(value)
         _LOGGER.debug("Setting %s to %d on %s", self.status, value, self.nickname)
-        try:
-            await self.async_update_device(
-                {self.command_name: value},
-                {self.status: value},
-            )
-        except LifeConnectError as api_error:
-            raise ServiceValidationError(str(api_error)) from api_error
+        await self.async_update_device(
+            {self.command_name: value},
+            {self.status: value},
+        )

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -6,14 +6,12 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
-from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance
 from .utils import has_platform
 
@@ -102,10 +100,7 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        try:
-            await self.async_update_device(
-                {self.command_name: self.reverse_options_map[option] - self.command_adjust},
-                {self.status: self.reverse_options_map[option]},
-            )
-        except LifeConnectError as api_error:
-            raise ServiceValidationError(str(api_error)) from api_error
+        await self.async_update_device(
+            {self.command_name: self.reverse_options_map[option] - self.command_adjust},
+            {self.status: self.reverse_options_map[option]},
+        )

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -22,7 +22,6 @@ from .const import DOMAIN, SW_VERSION_PROPERTY
 from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
-from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance, MAX_DATETIME
 from .utils import has_platform, to_unit
 
@@ -183,10 +182,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
             raise ServiceValidationError(
                 f"{self.entity_description.name} is read-only on {self.nickname}"
             )
-        try:
-            await self.async_update_device({self.status: value})
-        except LifeConnectError as api_error:
-            raise ServiceValidationError(str(api_error)) from api_error
+        await self.async_update_device({self.status: value})
 
 
 class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], SensorEntity):

--- a/custom_components/connectlife/services.py
+++ b/custom_components/connectlife/services.py
@@ -10,9 +10,11 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
+
+from connectlife.api import LifeConnectError
 
 from .coordinator import ConnectLifeCoordinator
 from .const import DOMAIN
@@ -68,7 +70,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             _LOGGER.debug(f"Updating {device_id} with data: {data}")
             # TODO: Consider trigging a data update to avoid waiting for next poll to update state.
             #       Make sure to only do this once per coordinater.
-            await coordinator.async_update_device(device_id, data, {})
+            try:
+                await coordinator.async_update_device(device_id, data, {})
+            except LifeConnectError as api_error:
+                raise ServiceValidationError(str(api_error)) from api_error
 
     async def async_set_action(call: ServiceCall) -> None:
         """Set action on device."""

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -6,10 +6,8 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from connectlife.api import LifeConnectError
 from connectlife.appliance import ConnectLifeAppliance
 
 from .const import DOMAIN
@@ -88,19 +86,13 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn off."""
-        try:
-            await self.async_update_device(
-                {self.command_name: self.command_off},
-                {self.status: self.off},
-            )
-        except LifeConnectError as api_error:
-            raise ServiceValidationError(str(api_error)) from api_error
+        await self.async_update_device(
+            {self.command_name: self.command_off},
+            {self.status: self.off},
+        )
 
     async def async_turn_on(self, **kwargs):
         """Turn on."""
-        try:
-            await self.async_update_device(
-                {self.command_name: self.command_on}, {self.status: self.on}
-            )
-        except LifeConnectError as api_error:
-            raise ServiceValidationError(str(api_error)) from api_error
+        await self.async_update_device(
+            {self.command_name: self.command_on}, {self.status: self.on}
+        )


### PR DESCRIPTION
## Summary

Wrap the body of `ConnectLifeEntity.async_update_device` in `try/except LifeConnectError → ServiceValidationError` so every entity-level write path benefits uniformly — including the button platform, which until now still surfaces cloud rejections as raw tracebacks when a press hits an unrecognized property.

Removes the now-redundant `try/except` wrappers from `sensor.py`, `number.py`, `select.py`, and `switch.py` (introduced in #531 / earlier), together with their unused imports.

For `services.py` — which calls `coordinator.async_update_device` directly, bypassing `ConnectLifeEntity` — wrap the shared `_async_update` helper so both registered services (`connectlife.set_action`, `connectlife.update`) also get clean error notifications.

Refs #529.

## Test plan

- [x] `uv run pyright` clean, `uv run python -m pytest tests/` passes.
- [x] Button press against an unrecognized property (test server, 015-000 with a temporary button) → clean `ServiceValidationError` notification, no traceback.
- [x] `connectlife.set_action` / `connectlife.update` service calls bypassing entities → clean `ServiceValidationError` notification, no traceback.
- [x] Existing select / switch / sensor / number write paths still report clean errors (regression check — wraps moved, not deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)