### PR TITLE
Add devices 025-1wj105051v0w (washing machine) and 030-1wk090106v0w (dryer)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/025-1wj105051v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj105051v0w.yaml
@@ -1,0 +1,61 @@
+#Washing Machine HISENSE WF5S1045BW
+properties:
+- property: Current_program_phase
+  icon: mdi:washing-machine
+  sensor:
+    read_only: true
+    device_class: enum
+    options:
+      0: not_available
+      1: weigh
+      2: prewash
+      3: wash
+      4: rinse
+      7: spin-dry
+      8: drying
+      10: finished
+- property: Selected_program_ID
+  icon: mdi:tshirt-crew
+  select:
+    options:
+      1: "cotton_dry"
+      2: "synthetic_dry"
+      4: "refresh"
+      5: "anti_allergy"
+      6: "drum_cleaning"
+      7: "cotton"
+      8: "synthetic"
+      9: "eco_40_60"
+      10: "wool"
+      11: "fast15"
+      12: "mix"
+      14: "spin-dry"
+      16: "baby"
+      20: "rinse_spin"
+      21: "delicates"
+      22: "clean_dry_60"
+      24: "shirts"
+      41: "power49"
+      42: "auto"
+      44: "bed_linen"
+      45: "jeans"
+- property: Spin_speed_rpm
+  icon: mdi:rotate-3d-variant
+  select:
+    options:
+      14: "1400"
+      12: "1200"
+      10: "1000"
+      8: "800"
+      6: "600"
+      0: "none"
+- property: temperature
+  icon: mdi:thermometer-lines
+  select:
+    options:
+      0: "cold"
+      2: "20"
+      3: "30"
+      4: "40"
+      6: "60"
+      9: "90"

--- a/custom_components/connectlife/data_dictionaries/030-1wk090106v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/030-1wk090106v0w.yaml
@@ -1,0 +1,2 @@
+#Heat Pump Tumble Dryer HISENSE DH3S902BW3
+#Uses default mappings


### PR DESCRIPTION
Added the 2 devices i own as there own dictionaries.

The Washing Machine seems to use the same mappings as another one provided so thats basically a copy paste.
The Dryer works well with the default mappings.

if i finde missing stuff i will update in the future