### PR TITLE
Fix unknown HVAC mode for AC units in Eco; add eco preset for 008-399

### DIFF
--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -36,6 +36,10 @@ from connectlife.appliance import ConnectLifeAppliance
 
 _LOGGER = logging.getLogger(__name__)
 
+HVAC_MODE_ALIASES = {
+    "eco": HVACMode.COOL,
+}
+
 
 async def async_setup_entry(
         hass: HomeAssistant,
@@ -150,11 +154,13 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
             elif target == HVAC_MODE:
                 modes = [mode.value for mode in HVACMode]
                 for (k, v) in data_dictionary.properties[status].climate.options.items():
-                    if v in modes:
-                        mode = HVACMode(v)
+                    if v in modes or v in HVAC_MODE_ALIASES:
+                        mode = HVACMode(v) if v in modes else HVAC_MODE_ALIASES[v]
                         self.hvac_mode_map[k] = mode
-                        hvac_modes.append(mode)
-                        self.hvac_mode_reverse_map[mode] = k
+                        if mode not in hvac_modes:
+                            hvac_modes.append(mode)
+                        if mode not in self.hvac_mode_reverse_map:
+                            self.hvac_mode_reverse_map[mode] = k
             elif target == FAN_MODE:
                 self.fan_mode_map = data_dictionary.properties[status].climate.options
                 self.fan_mode_reverse_map = {v: k for k, v in self.fan_mode_map.items()}

--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -39,6 +39,32 @@ _LOGGER = logging.getLogger(__name__)
 HVAC_MODE_ALIASES = {
     "eco": HVACMode.COOL,
 }
+HVAC_MODE_VALUES = {mode.value for mode in HVACMode}
+
+
+def _add_hvac_mode_mapping(
+        raw_mode: int,
+        mode_value: str,
+        hvac_modes: list[HVACMode],
+        hvac_mode_map: dict[int, HVACMode],
+        hvac_mode_reverse_map: dict[HVACMode, int],
+) -> None:
+    """Add a raw HVAC mode mapping if Home Assistant can represent it."""
+    if mode_value in HVAC_MODE_VALUES:
+        mode = HVACMode(mode_value)
+        add_selectable_mapping = True
+    elif mode_value in HVAC_MODE_ALIASES:
+        mode = HVAC_MODE_ALIASES[mode_value]
+        add_selectable_mapping = False
+    else:
+        return
+
+    hvac_mode_map[raw_mode] = mode
+    if add_selectable_mapping:
+        if mode not in hvac_modes:
+            hvac_modes.append(mode)
+        if mode not in hvac_mode_reverse_map:
+            hvac_mode_reverse_map[mode] = raw_mode
 
 
 async def async_setup_entry(
@@ -152,15 +178,14 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
                     if isinstance(unit, UnitOfTemperature):
                         self.temperature_unit_map[k] = unit
             elif target == HVAC_MODE:
-                modes = [mode.value for mode in HVACMode]
                 for (k, v) in data_dictionary.properties[status].climate.options.items():
-                    if v in modes or v in HVAC_MODE_ALIASES:
-                        mode = HVACMode(v) if v in modes else HVAC_MODE_ALIASES[v]
-                        self.hvac_mode_map[k] = mode
-                        if mode not in hvac_modes:
-                            hvac_modes.append(mode)
-                        if mode not in self.hvac_mode_reverse_map:
-                            self.hvac_mode_reverse_map[mode] = k
+                    _add_hvac_mode_mapping(
+                        k,
+                        v,
+                        hvac_modes,
+                        self.hvac_mode_map,
+                        self.hvac_mode_reverse_map,
+                    )
             elif target == FAN_MODE:
                 self.fan_mode_map = data_dictionary.properties[status].climate.options
                 self.fan_mode_reverse_map = {v: k for k, v in self.fan_mode_map.items()}

--- a/custom_components/connectlife/data_dictionaries/008-399.yaml
+++ b/custom_components/connectlife/data_dictionaries/008-399.yaml
@@ -1,4 +1,10 @@
 # Ultraslim AC
+climate:
+  presets:
+    - preset: eco
+      t_power: 1
+      t_work_mode: 5
+
 properties:
   - property: t_fan_speed
     climate:

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1862,6 +1862,7 @@
             "state": {
               "ai": "AI",
               "bedtime": "Bedtime",
+              "eco": "Eco",
               "eco_mute": "Eco mute",
               "eco_sleep_1": "Eco sleep 1",
               "eco_sleep_2": "Eco sleep 2",

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1862,7 +1862,6 @@
             "state": {
               "ai": "AI",
               "bedtime": "Bedtime",
-              "eco": "Eco",
               "eco_mute": "Eco mute",
               "eco_sleep_1": "Eco sleep 1",
               "eco_sleep_2": "Eco sleep 2",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,71 @@
+"""Tests for ConnectLife climate mode mapping."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from homeassistant.components.climate import ClimateEntityFeature, HVACMode
+
+from custom_components.connectlife.climate import (
+    ConnectLifeClimate,
+    _add_hvac_mode_mapping,
+)
+from custom_components.connectlife.const import HVAC_MODE, IS_ON
+from custom_components.connectlife.dictionaries import Dictionaries
+
+
+def test_hvac_mode_alias_does_not_override_canonical_reverse_mapping() -> None:
+    hvac_modes: list[HVACMode] = []
+    hvac_mode_map: dict[int, HVACMode] = {}
+    hvac_mode_reverse_map: dict[HVACMode, int] = {}
+
+    _add_hvac_mode_mapping(5, "eco", hvac_modes, hvac_mode_map, hvac_mode_reverse_map)
+
+    assert hvac_mode_map[5] == HVACMode.COOL
+    assert hvac_modes == []
+    assert hvac_mode_reverse_map == {}
+
+    _add_hvac_mode_mapping(2, "cool", hvac_modes, hvac_mode_map, hvac_mode_reverse_map)
+
+    assert hvac_mode_map[5] == HVACMode.COOL
+    assert hvac_mode_map[2] == HVACMode.COOL
+    assert hvac_modes == [HVACMode.COOL]
+    assert hvac_mode_reverse_map == {HVACMode.COOL: 2}
+
+
+async def test_set_hvac_mode_writes_canonical_cool_value() -> None:
+    climate = ConnectLifeClimate.__new__(ConnectLifeClimate)
+    climate.target_map = {
+        HVAC_MODE: "t_work_mode",
+        IS_ON: "t_power",
+    }
+    climate.hvac_mode_reverse_map = {HVACMode.COOL: 2}
+    climate._attr_supported_features = ClimateEntityFeature.TURN_ON
+    requests: list[dict[str, int]] = []
+
+    async def async_update_device(request: dict[str, int]) -> None:
+        requests.append(request)
+
+    climate.async_update_device = async_update_device
+    climate.add_target_temperature = lambda request: request
+
+    await climate.async_set_hvac_mode(HVACMode.COOL)
+
+    assert requests == [{"t_power": 1, "t_work_mode": 2}]
+
+
+def test_008_399_eco_preset_writes_raw_eco_mode() -> None:
+    Dictionaries.dictionaries.pop("008-399", None)
+    appliance = SimpleNamespace(
+        device_type_code="008",
+        device_feature_code="399",
+        device_nickname="Ultraslim AC",
+    )
+
+    dictionary = Dictionaries.get_dictionary(appliance)
+
+    assert {
+        "preset": "eco",
+        "t_power": 1,
+        "t_work_mode": 5,
+    } in dictionary.climate["presets"]


### PR DESCRIPTION
  ## Summary

  Fixes Hisense UltraSlim AC model `008-399` reporting `unknown` in Home Assistant when the unit is in Eco mode.

  Hisense exposes Eco as `t_work_mode: 5`, but Home Assistant climate entities do not support a custom HVAC mode named `eco`. This PR keeps the HA HVAC mode valid by aliasing raw Eco mode to `cool`, while
  exposing Eco as a climate preset so users can see and select it.

  ## Changes

  - Add `eco` preset for model `008-399`
    - writes `t_power: 1`
    - writes `t_work_mode: 5`
  - Map unsupported HVAC mode value `eco` to `HVACMode.COOL`
  - Avoid duplicate `cool` entries when multiple raw modes map to HA `cool`
  - Preserve normal Cool behavior so selecting `cool` still writes raw `t_work_mode: 2`

  ## Testing

  - `python3 -m py_compile custom_components/connectlife/climate.py`
  - Parsed `008-399.yaml`
  - Parsed `translations/en.json`
  - Verified mapping behavior:
    - raw `5` maps to HA `cool`
    - reverse `cool` remains raw `2`
    - preset `eco` writes `t_power: 1`, `t_work_mode: 5`