### PR TITLE
Validate hvac_mode/hvac_action option values

### DIFF
--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -275,7 +275,18 @@ type `climate`, a climate entity is created for the appliance.
 
 `is_on` is used when setting HVAC mode to on.
 
-`hvac_mode` can only be mapped to [pre-defined modes](https://developers.home-assistant.io/docs/core/entity/climate#hvac-modes).
+`hvac_mode` can only be mapped to [pre-defined modes](https://developers.home-assistant.io/docs/core/entity/climate#hvac-modes),
+with one exception: `eco` is accepted as an **alias** for `cool`. A device that reports `eco` as its
+`hvac_mode` value then displays as Cool instead of `unknown`. The alias is *display-only* — `eco` is
+not added to the selectable mode list, and selecting Cool always writes the canonical raw value (not
+the raw Eco value). To let the user switch the device into Eco, expose it as a [preset](#presets),
+e.g.:
+```yaml
+climate:
+  presets:
+    - preset: eco
+      t_work_mode: 5
+```
 
 `hvac_action` can only be mapped to [pre-defined actions](https://developers.home-assistant.io/docs/core/entity/climate#hvac-action).
 If a value does not have a sensible mapping, leave it out to set `hvac_action` to `None` for that value, or consider

--- a/scripts/validate_mappings.py
+++ b/scripts/validate_mappings.py
@@ -6,10 +6,15 @@ from os.path import isfile, join
 from jschon import create_catalog, JSON, JSONSchema
 import yaml
 
+from homeassistant.components.climate import HVACAction
+
+from custom_components.connectlife.climate import HVAC_MODE_ALIASES, HVAC_MODE_VALUES
 from custom_components.connectlife.dictionaries import _merge_property
 
 PLATFORMS = ('binary_sensor', 'climate', 'humidifier', 'number', 'select',
              'sensor', 'switch', 'water_heater')
+
+HVAC_ACTION_VALUES = {action.value for action in HVACAction}
 
 
 def my_construct_mapping(self, node, deep=False):
@@ -41,6 +46,45 @@ def _check_entity_category_config_on_sensor(filename, merged_entry):
         f"writable entities (number/select/switch); use diagnostic or "
         f"omit the category for sensors."
     )
+
+
+def _check_hvac_option_values(filename, merged_entry):
+    """``hvac_mode`` and ``hvac_action`` options must map to values Home
+    Assistant understands. An unknown ``hvac_mode`` value is silently dropped
+    at runtime — the entity shows ``unknown`` for that device state with no
+    warning — so catch it at validation time instead. ``hvac_action`` is logged
+    but otherwise ignored at runtime; validate it for the same reason.
+
+    A value is legal if it is a member of the corresponding HA enum, or — for
+    ``hvac_mode`` — a key in ``climate.HVAC_MODE_ALIASES`` (e.g. ``eco`` →
+    ``cool``). Aliased values are display-only; see climate.py."""
+    climate = merged_entry.get('climate')
+    if not climate:
+        return None
+    options = climate.get('options')
+    if not options:
+        return None
+    target = climate.get('target')
+    if target == 'hvac_mode':
+        legal = HVAC_MODE_VALUES | set(HVAC_MODE_ALIASES)
+    elif target == 'hvac_action':
+        legal = HVAC_ACTION_VALUES
+    else:
+        return None
+    illegal = sorted({v for v in options.values() if v not in legal})
+    if not illegal:
+        return None
+    alias_note = " or an alias in HVAC_MODE_ALIASES" if target == 'hvac_mode' else ""
+    return (
+        f"{filename}: property '{merged_entry['property']}' maps {target} to "
+        f"unknown value(s) {illegal}. Allowed: HA {target} states{alias_note}."
+    )
+
+
+CHECKS = (
+    _check_entity_category_config_on_sensor,
+    _check_hvac_option_values,
+)
 
 
 def main(basedir):
@@ -88,10 +132,11 @@ def main(basedir):
         for prop in (mappings_yaml.get('properties') or []):
             name = prop['property']
             merged = _merge_property(base_props.get(name), prop) if is_subtype else prop
-            err = _check_entity_category_config_on_sensor(filename, merged)
-            if err:
-                print(err)
-                errors.append(filename)
+            for check in CHECKS:
+                err = check(filename, merged)
+                if err:
+                    print(err)
+                    errors.append(filename)
 
     if errors:
         sys.exit(1)


### PR DESCRIPTION
## Summary

Follow-up to #536. An `hvac_mode` option value that isn't a pre-defined HA `HVACMode` is silently skipped at runtime, leaving the climate entity in `unknown` state with no warning — exactly how the `008` `t_work_mode: 5 -> eco` mapping went unnoticed until it shipped (fixed there by aliasing `eco -> cool`). This adds a lint-time check so the same class of bug fails the PR instead.

## Changes

- **`validate_mappings`**: new `_check_hvac_option_values` check (wired in via a `CHECKS` tuple). Every `hvac_mode` / `hvac_action` option value must be a member of the corresponding HA enum, or — for `hvac_mode` — a key in `HVAC_MODE_ALIASES`. The check imports `HVAC_MODE_VALUES` and `HVAC_MODE_ALIASES` from `climate.py`, so the validator and runtime share one source of truth (no drift if the alias table changes).
- **README**: document that `eco` is an accepted alias for `cool`, that it's display-only (reach it via a preset), with a preset example.

## Testing

- `uv run python -m scripts.validate_mappings` — passes on all current mappings (the 008 family's `5: eco` stays valid).
- Negative-tested directly: illegal `hvac_mode`/`hvac_action` values are caught, and `eco` is correctly rejected as an *action* (the alias is mode-scoped).
- `uv run pytest` — 25 passed. `uv run pyright` — clean (CI scope is `custom_components/connectlife`; `scripts/` is not type-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)