### PR TITLE
Make coordinator entity register instance-scoped

### DIFF
--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -27,12 +27,15 @@ class ConnectLifeCoordinator(DataUpdateCoordinator[dict[str, ConnectLifeApplianc
 
     # We need initial data, so no retries for first request.
     error_count = MAX_RETRIES
-    # Register of current entities (used for cleanup).
-    entities: dict[str, Platform] = {}
 
     def __init__(self, hass, api: ConnectLifeApi):
         """Initialize coordinator."""
         self.api = api
+        # Register of entities created this setup, keyed by unique ID (used by
+        # cleanup_removed_entities). Instance-scoped so a reload — e.g. after
+        # toggling a per-device option — starts fresh and prunes entities that
+        # are no longer created, such as the offline-state binary sensor.
+        self.entities: dict[str, Platform] = {}
         super().__init__(
             hass,
             _LOGGER,


### PR DESCRIPTION
## Summary

The entity register used by `cleanup_removed_entities` was a class-level dict that was never reset and was shared across config entries. On a same-process reload (e.g. an options change), the stale unique IDs from the previous load survived, so cleanup treated removed entities as current and skipped pruning them until the next full restart.

This moves the register into `__init__` as an instance attribute, so each setup starts with a fresh register that is repopulated as entities are created. Entities that are no longer created (e.g. after a mapping change or a per-device option toggle) are then pruned on reload rather than lingering as unavailable until restart.

## Why

- **Reload-time cleanup now works:** previously, removing/renaming an entity only took effect on a full HA restart because the class-level register kept the old unique IDs in-process.
- **No cross-entry leakage:** the register is no longer shared between multiple config entries.

`cleanup_removed_entities` runs after `async_forward_entry_setups`, so the register is fully populated before pruning.

## Testing

- `uv run pyright` — 0 errors, 0 warnings
- `uv run pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)