### PR TITLE
Add per-device option to expose offline state

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Some devices will beep on every configuration change. To disable this, go to the
 [ConnectLife integration](https://my.home-assistant.io/redirect/integration/?domain=connectlife)
 and click "Configure" → "Configure a device" and select the device you want to disable beeping for. 
 
+## Expose offline state
+
+By default, when a device goes offline all of its entities become unavailable in Home Assistant. If you would
+rather keep the entities showing their last known values, go to the
+[ConnectLife integration](https://my.home-assistant.io/redirect/integration/?domain=connectlife)
+and click "Configure" → "Configure a device", select the device, and enable "Expose offline state".
+
+This adds a `connectivity` binary sensor (a diagnostic entity) reporting whether the device is online, and stops
+the device's other entities from going unavailable while it is offline — they keep their last reported values
+until the device comes back online.
+
 ## Service to set property values on sensors
 
 Entity service `connectlife.set_value` can be used to set values. Use with caution, as there is **no** validation

--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -3,15 +3,21 @@
 import logging
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import (
+    CONF_DEVICES,
+    CONF_EXPOSE_OFFLINE_STATE,
+    DOMAIN,
+    OFFLINE_STATE,
+)
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
@@ -28,6 +34,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up ConnectLife sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    devices = config_entry.options.get(CONF_DEVICES, {})
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
@@ -37,6 +44,10 @@ async def async_setup_entry(
             for s in appliance.status_list
             if has_platform(Platform.BINARY_SENSOR, dictionary.properties[s])
         )
+        if devices.get(appliance.device_id, {}).get(CONF_EXPOSE_OFFLINE_STATE, False):
+            async_add_entities(
+                [ConnectLifeOfflineStateBinarySensor(coordinator, appliance)]
+            )
 
 
 class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
@@ -76,3 +87,33 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
             else:
                 self._attr_is_on = None
                 _LOGGER.warning("Unknown value %d for %s", value, self.status)
+
+
+class ConnectLifeOfflineStateBinarySensor(ConnectLifeEntity, BinarySensorEntity):
+    """Connectivity sensor exposing the device's offline_state.
+
+    Created per-device when CONF_EXPOSE_OFFLINE_STATE is enabled.
+    """
+
+    def __init__(
+        self,
+        coordinator: ConnectLifeCoordinator,
+        appliance: ConnectLifeAppliance,
+    ):
+        """Initialize the entity."""
+        super().__init__(
+            coordinator, appliance, OFFLINE_STATE, Platform.BINARY_SENSOR
+        )
+        self.entity_description = BinarySensorEntityDescription(
+            key=self._attr_unique_id,
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            name="Connectivity",
+            translation_key=OFFLINE_STATE,
+        )
+        self._refresh_state()
+
+    @callback
+    def update_state(self):
+        appliance = self.coordinator.data.get(self.device_id)
+        self._attr_is_on = appliance is not None and appliance.offline_state == 1

--- a/custom_components/connectlife/button.py
+++ b/custom_components/connectlife/button.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
-            ConnectLifeButton(coordinator, appliance, button, config_entry)
+            ConnectLifeButton(coordinator, appliance, button)
             for button in dictionary.buttons
         )
 
@@ -37,11 +37,10 @@ class ConnectLifeButton(ConnectLifeEntity, ButtonEntity):
         coordinator: ConnectLifeCoordinator,
         appliance: ConnectLifeAppliance,
         button: Button,
-        config_entry: ConfigEntry,
     ):
         """Initialize the entity."""
         super().__init__(
-            coordinator, appliance, f"button-{button.key}", Platform.BUTTON, config_entry
+            coordinator, appliance, f"button-{button.key}", Platform.BUTTON
         )
         self.button = button
         self.entity_description = ButtonEntityDescription(

--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -81,8 +81,7 @@ async def async_setup_entry(
             entities.append(ConnectLifeClimate(
                 coordinator,
                 appliance,
-                dictionary,
-                config_entry
+                dictionary
             ))
     async_add_entities(entities)
 
@@ -120,11 +119,10 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
             self,
             coordinator: ConnectLifeCoordinator,
             appliance: ConnectLifeAppliance,
-            data_dictionary: Dictionary,
-            config_entry: ConfigEntry
+            data_dictionary: Dictionary
     ):
         """Initialize the entity."""
-        super().__init__(coordinator, appliance, "climate", Platform.CLIMATE, config_entry)
+        super().__init__(coordinator, appliance, "climate", Platform.CLIMATE)
 
         self.entity_description = ClimateEntityDescription(
             key=self._attr_unique_id,

--- a/custom_components/connectlife/config_flow.py
+++ b/custom_components/connectlife/config_flow.py
@@ -19,7 +19,14 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 
-from .const import CONF_DEVICES, CONF_DEVELOPMENT_MODE, CONF_DISABLE_BEEP, CONF_TEST_SERVER_URL, DOMAIN
+from .const import (
+    CONF_DEVICES,
+    CONF_DEVELOPMENT_MODE,
+    CONF_DISABLE_BEEP,
+    CONF_EXPOSE_OFFLINE_STATE,
+    CONF_TEST_SERVER_URL,
+    DOMAIN,
+)
 from connectlife.api import ConnectLifeApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -162,20 +169,32 @@ class OptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             data = self.config_entry.options.copy()
             data[CONF_DEVICES] = data[CONF_DEVICES].copy() if CONF_DEVICES in data else {}
-            data[CONF_DEVICES][self._device_id] = {CONF_DISABLE_BEEP: user_input[CONF_DISABLE_BEEP]}
+            data[CONF_DEVICES][self._device_id] = {
+                CONF_DISABLE_BEEP: user_input[CONF_DISABLE_BEEP],
+                CONF_EXPOSE_OFFLINE_STATE: user_input[CONF_EXPOSE_OFFLINE_STATE],
+            }
             if not user_input[CONF_DISABLE_BEEP]:
                 ir.async_delete_issue(self.hass, DOMAIN, f"unsupported_beep.{self._device_id}")
             return self.async_create_entry(title="", data=data)
 
         devices = self.config_entry.options.get(CONF_DEVICES, {})
         device = devices[self._device_id] if self._device_id in devices else {}
-        disable_beep = device[CONF_DISABLE_BEEP] if CONF_DISABLE_BEEP in device else False
+        disable_beep = device.get(CONF_DISABLE_BEEP, False)
+        expose_offline_state = device.get(CONF_EXPOSE_OFFLINE_STATE, False)
         schema = vol.Schema(
             {
                 vol.Optional(CONF_DISABLE_BEEP, default=disable_beep): bool,
+                vol.Optional(CONF_EXPOSE_OFFLINE_STATE, default=expose_offline_state): bool,
             }
         )
-        return self.async_show_form(step_id="configure_device", data_schema=schema)
+        coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
+        appliance = coordinator.data.get(self._device_id)
+        device_name = (appliance.device_nickname if appliance else self._device_id) or ""
+        return self.async_show_form(
+            step_id="configure_device",
+            data_schema=schema,
+            description_placeholders={"device_name": device_name},
+        )
 
     async def async_step_development(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the options."""

--- a/custom_components/connectlife/const.py
+++ b/custom_components/connectlife/const.py
@@ -9,7 +9,10 @@ ATTR_KEY = "key"
 CONF_DEVICES = "devices"
 CONF_DEVELOPMENT_MODE = "development_mode"
 CONF_DISABLE_BEEP = "disable_beep"
+CONF_EXPOSE_OFFLINE_STATE = "expose_offline_state"
 CONF_TEST_SERVER_URL = "test_server_url"
+
+OFFLINE_STATE = "offline_state"
 
 # Set by the orphaned-statistics repair flow once the user clicks Clear or
 # Ignore. While unset, every setup runs orphan detection so the repair

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -5,7 +5,6 @@ import re
 from abc import abstractmethod
 
 from connectlife.api import LifeConnectError
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.exceptions import ServiceValidationError
@@ -18,6 +17,7 @@ from connectlife.appliance import ConnectLifeAppliance
 from .const import (
     CONF_DEVICES,
     CONF_DISABLE_BEEP,
+    CONF_EXPOSE_OFFLINE_STATE,
     DOMAIN,
     SW_VERSION_PROPERTY,
 )
@@ -34,6 +34,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
     _attr_unique_id: str
     _disable_beep = False
     _disable_beep_failure_count = 0
+    _expose_offline_state = False
     _unavailable_status: str | None = None
     _unavailable_value: int | None = None
 
@@ -42,8 +43,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
             coordinator: ConnectLifeCoordinator,
             appliance: ConnectLifeAppliance,
             entity_name: str,
-            platform: Platform,
-            config_entry: ConfigEntry | None = None):
+            platform: Platform):
         """Initialize the entity."""
         super().__init__(coordinator)
         self.device_id = appliance.device_id
@@ -59,31 +59,37 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
             sw_version=sw_version if isinstance(sw_version, str) else None,
         )
         coordinator.add_entity(self._attr_unique_id, platform)
-        if config_entry and CONF_DEVICES in config_entry.options:
-            devices = config_entry.options[CONF_DEVICES]
-            if self.device_id in devices:
-                device = devices[self.device_id]
-                if CONF_DISABLE_BEEP in device:
-                    self._disable_beep = device[CONF_DISABLE_BEEP]
-                    if self._disable_beep:
-                        ir.async_delete_issue(
-                            self.coordinator.hass,
-                            DOMAIN,
-                            f"unsupported_beep.{self.device_id}",
-                        )
+        device = coordinator.config_entry.options.get(CONF_DEVICES, {}).get(self.device_id, {})
+        self._expose_offline_state = device.get(CONF_EXPOSE_OFFLINE_STATE, False)
+        self._disable_beep = device.get(CONF_DISABLE_BEEP, False)
+        if self._disable_beep:
+            ir.async_delete_issue(
+                self.coordinator.hass,
+                DOMAIN,
+                f"unsupported_beep.{self.device_id}",
+            )
 
     @property
     def available(self) -> bool:
-        # CoordinatorEntity.available only checks last_update_success, so
-        # _attr_available is ignored. Combine both with the device's
-        # offline_state (1 == online) so unplugged devices show as
-        # unavailable in HA. Also factor in the per-property `unavailable`
-        # sentinel: when the current value matches, the entity is shown as
-        # unavailable rather than being skipped at creation time.
+        # CoordinatorEntity.available only checks last_update_success and
+        # ignores _attr_available, so an entity is available only when all of
+        # the following hold:
+        #  - the coordinator's last update succeeded;
+        #  - the device is still present in the coordinator data;
+        #  - the device is online (offline_state == 1) — unless it is
+        #    configured to expose offline_state as a binary sensor, in which
+        #    case entities keep their last known value while offline instead
+        #    of going unavailable;
+        #  - the current value does not match the per-property `unavailable`
+        #    sentinel (which marks the entity unavailable at runtime rather
+        #    than skipping it at creation time).
         return (
             super().available
             and self.device_id in self.coordinator.data
-            and self.coordinator.data[self.device_id].offline_state == 1
+            and (
+                self._expose_offline_state
+                or self.coordinator.data[self.device_id].offline_state == 1
+            )
             and not self._is_value_unavailable()
         )
 

--- a/custom_components/connectlife/humidifier.py
+++ b/custom_components/connectlife/humidifier.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         if is_humidifier(dictionary):
-            entities.append(ConnectLifeHumidifier(coordinator, appliance, dictionary, config_entry))
+            entities.append(ConnectLifeHumidifier(coordinator, appliance, dictionary))
     async_add_entities(entities)
 
 
@@ -63,10 +63,9 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
             coordinator: ConnectLifeCoordinator,
             appliance: ConnectLifeAppliance,
             data_dictionary: Dictionary,
-            config_entry: ConfigEntry,
     ):
         """Initialize the entity."""
-        super().__init__(coordinator, appliance, "humidifier", Platform.HUMIDIFIER, config_entry)
+        super().__init__(coordinator, appliance, "humidifier", Platform.HUMIDIFIER)
 
         self.target_map = {}
         self.mode_map = {}

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -32,7 +32,6 @@ async def async_setup_entry(
                 appliance,
                 s,
                 dictionary.properties[s],
-                config_entry,
                 dictionary,
             )
             for s in appliance.status_list
@@ -51,11 +50,10 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
         appliance: ConnectLifeAppliance,
         status: str,
         dd_entry: Property,
-        config_entry: ConfigEntry,
         dictionary: Dictionary,
     ):
         """Initialize the entity."""
-        super().__init__(coordinator, appliance, status, Platform.NUMBER, config_entry)
+        super().__init__(coordinator, appliance, status, Platform.NUMBER)
         self.status = status
         self._unavailable_status = status
         self._unavailable_value = dd_entry.unavailable

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
             ConnectLifeSelect(
-                coordinator, appliance, s, dictionary.properties[s], config_entry
+                coordinator, appliance, s, dictionary.properties[s]
             )
             for s in appliance.status_list
             if has_platform(Platform.SELECT, dictionary.properties[s])
@@ -47,10 +47,9 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
         appliance: ConnectLifeAppliance,
         status: str,
         dd_entry: Property,
-        config_entry: ConfigEntry,
     ):
         """Initialize the entity."""
-        super().__init__(coordinator, appliance, status, Platform.SELECT, config_entry)
+        super().__init__(coordinator, appliance, status, Platform.SELECT)
         self.status = status
         self._unavailable_status = status
         self._unavailable_value = dd_entry.unavailable

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -18,7 +18,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SW_VERSION_PROPERTY
+from .const import (
+    CONF_DEVICES,
+    CONF_EXPOSE_OFFLINE_STATE,
+    DOMAIN,
+    SW_VERSION_PROPERTY,
+)
 from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
@@ -208,16 +213,19 @@ class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], S
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, appliance.device_id)},
         )
+        device = appliance_coordinator.config_entry.options.get(CONF_DEVICES, {}).get(self._device_id, {})
+        self._expose_offline_state = device.get(CONF_EXPOSE_OFFLINE_STATE, False)
         appliance_coordinator.add_entity(self._attr_unique_id, Platform.SENSOR)
         self._update_native_value()
 
     @property
     def available(self) -> bool:
         appliance = self._appliance_coordinator.data.get(self._device_id)
+        if appliance is None:
+            return False
         return (
             super().available
-            and appliance is not None
-            and appliance.offline_state == 1
+            and (self._expose_offline_state or appliance.offline_state == 1)
             and self.coordinator.data is not None
             and self.coordinator.data.get(self._device_id) is not None
         )

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1098,6 +1098,9 @@
       "motorspeednospinavailable": {
         "name": "Motor speed no spin available"
       },
+      "offline_state": {
+        "name": "Connectivity"
+      },
       "open_freeze_door_alarm": {
         "name": "Open freeze door alarm"
       },
@@ -8827,9 +8830,14 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Disable beep"
+          "disable_beep": "Disable beep",
+          "expose_offline_state": "Expose offline state"
         },
-        "description": "Configure a device."
+        "data_description": {
+          "disable_beep": "Suppress the appliance beep on commands sent from Home Assistant.",
+          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable."
+        },
+        "description": "Configure {device_name}."
       },
       "development": {
         "data": {

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
             ConnectLifeSwitch(
-                coordinator, appliance, s, dictionary.properties[s], config_entry
+                coordinator, appliance, s, dictionary.properties[s]
             )
             for s in appliance.status_list
             if has_platform(Platform.SWITCH, dictionary.properties[s])
@@ -46,10 +46,9 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
         appliance: ConnectLifeAppliance,
         status: str,
         dd_entry: Property,
-        config_entry: ConfigEntry,
     ):
         """Initialize the entity."""
-        super().__init__(coordinator, appliance, status, Platform.SWITCH, config_entry)
+        super().__init__(coordinator, appliance, status, Platform.SWITCH)
         self.status = status
         self._unavailable_status = status
         self._unavailable_value = dd_entry.unavailable

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1098,6 +1098,9 @@
       "motorspeednospinavailable": {
         "name": "Motor speed no spin available"
       },
+      "offline_state": {
+        "name": "Connectivity"
+      },
       "open_freeze_door_alarm": {
         "name": "Open freeze door alarm"
       },
@@ -8827,9 +8830,14 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Disable beep"
+          "disable_beep": "Disable beep",
+          "expose_offline_state": "Expose offline state"
         },
-        "description": "Configure a device."
+        "data_description": {
+          "disable_beep": "Suppress the appliance beep on commands sent from Home Assistant.",
+          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable."
+        },
+        "description": "Configure {device_name}."
       },
       "development": {
         "data": {

--- a/custom_components/connectlife/water_heater.py
+++ b/custom_components/connectlife/water_heater.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         if is_water_heater(dictionary):
-            entities.append(ConnectLifeWaterHeater(coordinator, appliance, dictionary, config_entry))
+            entities.append(ConnectLifeWaterHeater(coordinator, appliance, dictionary))
     async_add_entities(entities)
 
 
@@ -87,10 +87,9 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
             coordinator: ConnectLifeCoordinator,
             appliance: ConnectLifeAppliance,
             data_dictionary: Dictionary,
-            config_entry: ConfigEntry,
     ):
         """Initialize the entity."""
-        super().__init__(coordinator, appliance, "waterheater", Platform.WATER_HEATER, config_entry)
+        super().__init__(coordinator, appliance, "waterheater", Platform.WATER_HEATER)
 
         self.entity_description = WaterHeaterEntityDescription(  # type: ignore[assignment]
             key=self._attr_unique_id,

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -53,7 +53,11 @@ def main(basedir):
     ha_strings = load_ha_strings()
     with open(f'{basedir}/strings.json', 'r') as f:
         strings = json.load(f)
-    valid_properties = {"sensor": {"daily_energy_kwh"}}
+    # Entities not created based on status_list properties
+    valid_properties = {
+        "sensor": {"daily_energy_kwh"},
+        "binary_sensor": {"offline_state"},
+    }
     valid_options = {}
 
     device_dir = f'{basedir}/data_dictionaries'


### PR DESCRIPTION
## Summary

By default, when a device goes offline all of its entities become unavailable in Home Assistant. This adds a per-device **Expose offline state** option (configured in the options flow alongside *Disable beep*). When enabled for a device:

- a `connectivity` binary sensor is created reporting whether the device is online, and
- the device's other entities keep their **last known values** while it is offline instead of going unavailable.

Fixes #523.

## Details

- **New option** `expose_offline_state`, stored per device under `options[CONF_DEVICES][device_id]` and toggled in the "Configure a device" step. Toggling it reloads the entry, which creates/removes the connectivity sensor and prunes it from the registry when disabled.
- **Connectivity sensor** (`BinarySensorDeviceClass.CONNECTIVITY`, diagnostic): `on` = online (`offline_state == 1`). It stays available while the device is offline so it can report the state itself.
- **Availability** now skips the offline gate for a device when the option is enabled, so its entities (including the energy sensor) remain available with their last known values.
- **Options dialog polish**: the configure step now shows the device name and per-field help text (`data_description`).
- **Per-device options refactor**: options are read from the coordinator's config entry rather than threading `config_entry` through every platform's entity constructor. As a result, beep suppression now also applies uniformly, including to the `set_value` service on sensors (previously skipped — see note below).

## Behavior note

Reading per-device options uniformly means `disable_beep` now also covers the `connectlife.set_value` service on sensors, which previously did not inject `t_beep`. This is consistent with buttons (which already suppressed beep) and is protected by the existing retry-without-`t_beep` fallback.

## Testing

- `uv run pyright` — 0 errors, 0 warnings
- `uv run pytest` — all tests pass
- `uv run python -m scripts.validate_mappings` and `uv run python -m scripts.gen_strings` — clean
- Verified against the local test server

🤖 Generated with [Claude Code](https://claude.com/claude-code)