### PR TITLE
Make hood light and motor controls writable at base level

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -65,6 +65,7 @@
 | HI21472SV                | Induction hob            | 010              | hob-pind                    |
 |                          | Hood                     | 012              | 000                         |
 |                          | Hood                     | 012              | hood-aa-lightfeedback       |
+|                          | Hood                     | 012              | hood-aa-tactile             |
 |                          | Oven                     | 013              | 000                         |
 | Bio21                    | Oven                     | 013              | oven-bio21-iconledplus      |
 | W-DW50/60-22             | Dishwasher               | 015              | 000                         |

--- a/custom_components/connectlife/data_dictionaries/012-hood-aa-lightfeedback.yaml
+++ b/custom_components/connectlife/data_dictionaries/012-hood-aa-lightfeedback.yaml
@@ -1,17 +1,2 @@
-# ATAG/ASKO hood (accepts direct writes to brightness, color temperature and motor level)
-properties:
-  - property: LightBrightness
-    number:
-      unit: "%"
-  - property: LightColorTemperature
-    number:
-      unit: "%"
-  - property: MotorLevel
-    select:
-      options:
-        0: "0"
-        1: "1"
-        2: "2"
-        3: "3"
-        4: "4"
-        5: "5"
+# ATAG/ASKO hood with light feedback
+# Uses default mappings

--- a/custom_components/connectlife/data_dictionaries/012-hood-aa-tactile.yaml
+++ b/custom_components/connectlife/data_dictionaries/012-hood-aa-tactile.yaml
@@ -1,0 +1,2 @@
+# ATAG/ASKO hood with tactile controls
+# Uses default mappings

--- a/custom_components/connectlife/data_dictionaries/012.yaml
+++ b/custom_components/connectlife/data_dictionaries/012.yaml
@@ -15,8 +15,14 @@ properties:
         5: reserved
   - property: MotorLevel
     icon: mdi:fan
-    sensor:
-      read_only: true
+    select:
+      options:
+        0: "0"
+        1: "1"
+        2: "2"
+        3: "3"
+        4: "4"
+        5: "5"
   - property: LightStatus
     icon: mdi:lightbulb
     unavailable: 0
@@ -28,13 +34,11 @@ properties:
         adjust: 1
   - property: LightBrightness
     icon: mdi:lightbulb-on
-    sensor:
-      read_only: true
+    number:
       unit: "%"
   - property: LightColorTemperature
     icon: mdi:thermometer
-    sensor:
-      read_only: true
+    number:
       unit: "%"
   - property: CirculationModeStatus
     icon: mdi:weather-windy

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -4788,12 +4788,6 @@
       "lidopenflag": {
         "name": "Lid open flag"
       },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
       "lights_duration_setting": {
         "name": "Lights duration setting"
       },
@@ -4921,9 +4915,6 @@
         "name": "Motor"
       },
       "motor_level": {
-        "name": "Motor level"
-      },
-      "motorlevel": {
         "name": "Motor level"
       },
       "navigation_sound_setting": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -4788,12 +4788,6 @@
       "lidopenflag": {
         "name": "Lid open flag"
       },
-      "lightbrightness": {
-        "name": "Light brightness"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
       "lights_duration_setting": {
         "name": "Lights duration setting"
       },
@@ -4921,9 +4915,6 @@
         "name": "Motor"
       },
       "motor_level": {
-        "name": "Motor level"
-      },
-      "motorlevel": {
         "name": "Motor level"
       },
       "navigation_sound_setting": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1672,6 +1672,12 @@
       "greasefiltersetlifetimeinhours": {
         "name": "Vetfilter levensduur"
       },
+      "lightbrightness": {
+        "name": "Helderheid verlichting"
+      },
+      "lightcolortemperature": {
+        "name": "Light color temperature"
+      },
       "refrigerator_max_temperature": {
         "name": "Koelkast max temperatuur"
       },
@@ -1950,6 +1956,9 @@
           "800_rpm": "800 toeren",
           "900_rpm": "900 toeren"
         }
+      },
+      "motorlevel": {
+        "name": "Motor level"
       },
       "notification_volumen_setting_status": {
         "name": "Meldingsvolume",
@@ -4220,12 +4229,6 @@
       "lidopenflag": {
         "name": "Indicator deksel open"
       },
-      "lightbrightness": {
-        "name": "Helderheid verlichting"
-      },
-      "lightcolortemperature": {
-        "name": "Light color temperature"
-      },
       "lights_duration_setting": {
         "name": "Lights duration setting"
       },
@@ -4347,9 +4350,6 @@
         "name": "Motor"
       },
       "motor_level": {
-        "name": "Motor level"
-      },
-      "motorlevel": {
         "name": "Motor level"
       },
       "navigation_sound_setting": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1672,6 +1672,12 @@
       "greasefiltersetlifetimeinhours": {
         "name": "Fettfilterlevetid"
       },
+      "lightbrightness": {
+        "name": "Lysstyrke"
+      },
+      "lightcolortemperature": {
+        "name": "Fargetemperatur for lys"
+      },
       "refrigerator_max_temperature": {
         "name": "Maks kj\u00f8leskapstemperatur"
       },
@@ -1950,6 +1956,9 @@
           "800_rpm": "800 RPM",
           "900_rpm": "900 RPM"
         }
+      },
+      "motorlevel": {
+        "name": "Motorniv\u00e5"
       },
       "notification_volumen_setting_status": {
         "name": "Varselvolum",
@@ -4220,12 +4229,6 @@
       "lidopenflag": {
         "name": "Flagg for \u00e5pent lokk"
       },
-      "lightbrightness": {
-        "name": "Lysstyrke"
-      },
-      "lightcolortemperature": {
-        "name": "Fargetemperatur for lys"
-      },
       "lights_duration_setting": {
         "name": "Innstilling for lysvarighet"
       },
@@ -4347,9 +4350,6 @@
         "name": "Motor"
       },
       "motor_level": {
-        "name": "Motorniv\u00e5"
-      },
-      "motorlevel": {
         "name": "Motorniv\u00e5"
       },
       "navigation_sound_setting": {


### PR DESCRIPTION
Promote `MotorLevel`, `LightBrightness` and `LightColorTemperature` from read-only sensors to writable `select`/`number` entities in the base `012.yaml`, so every hood variant gets working fan-speed and lamp controls by default.

PRs #499 and #516 demoted these three properties to read-only sensors at the base level, and #537 restored them as writable only for the `hood-aa-lightfeedback` subtype. As reported in #537, that left other hoods (e.g. `hood-aa-tactile`) unable to control fan speed and lamp brightness. Exposing the writable superset at the base fixes this for all hood variants; any variant that genuinely rejects these writes can still be narrowed back to read-only with its own subtype file.

## Changes
- `012.yaml`: `MotorLevel` → `select` (0–5), `LightBrightness` / `LightColorTemperature` → `number` (%).
- `012-hood-aa-lightfeedback.yaml`: reduced to a marker file — its overrides are now identical to the base.
- `012-hood-aa-tactile.yaml`: new marker file for the variant reported in #537, listed in `DEVICES.md`.
- Regenerated `strings.json` / `en.json`; relocated the existing `nl`/`no` translations from the removed sensor entries to the new `number`/`select` entities.

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)