### PR TITLE
Add device 025-1wj090729v0w (WFSE9014-LVW002 washing machine)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -80,6 +80,7 @@
 | WD3S8043BW3              | Washing machine          | 025              | 1wj080837v0w                |
 |                          | Washing machine          | 025              | 1wj090660v0w                |
 | WF5S9045BW               | Washing machine          | 025              | 1wj090728v0w                |
+| WFSE9014-LVW002          | Washing machine          | 025              | 1wj090729v0w                |
 | WD3S9043BB3              | Washing machine          | 025              | 1wj090913v0f                |
 | WF3S1014-SVW002          | Washing machine          | 025              | 1wj100404v0w                |
 | WFQR1014                 | Washing machine          | 025              | 1wj100649v0t                |

--- a/custom_components/connectlife/data_dictionaries/025-1wj090729v0w.yaml
+++ b/custom_components/connectlife/data_dictionaries/025-1wj090729v0w.yaml
@@ -1,0 +1,33 @@
+# Washing Machine WFSE9014-LVW002
+# Program IDs seeded from the WF5S9045BW (1wj090728v0w) sibling, which shares the
+# index-based spin/temperature encoding of the base 025.yaml. Unconfirmed: the
+# reporter needs to enumerate programs to verify the Selected_program_ID labels.
+properties:
+- property: Current_program_phase
+  sensor:
+    device_class: enum
+    options:
+      0: not_available
+      1: weigh
+      2: prewash
+      3: wash
+      4: rinse
+      7: spin-dry
+      8: drying
+      10: finished
+- property: Selected_program_ID
+  select:
+    options:
+      6: "drum_cleaning"
+      7: "cotton"
+      8: "synthetic"
+      9: "eco_40_60"
+      10: "wool"
+      11: "fast15"
+      14: "spin-dry"
+      15: "allergy_care"
+      16: "baby"
+      18: "sportswear"
+      24: "shirts"
+      41: "power49"
+      42: "auto"


### PR DESCRIPTION
Resolves #551.

The device (type `025`, feature `1wj090729v0w`) is already fully covered by the base `025.yaml` default mapping — all status properties map. This adds:

- **`025-1wj090729v0w.yaml`** — feature file labeling `Current_program_phase` and `Selected_program_ID`.
- **`DEVICES.md`** — row for `WFSE9014-LVW002`.

The device uses the index-based spin/temperature encoding the base already maps (matching the `WF5S9045BW` / `1wj090728v0w` family rather than the rpm×100 WFSE1114 variant), so `Selected_program_ID` and `Current_program_phase` are seeded from that sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)