### PR TITLE
Add TRIR (Russia/CIS) backend option

### DIFF
--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -10,11 +10,13 @@ from homeassistant.const import Platform, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
-from connectlife.api import ConnectLifeApi, LifeConnectAuthError, LifeConnectError
+from connectlife.api import LifeConnectAuthError, LifeConnectError
 
+from .client import create_api
 from .const import (
     CONF_DEVELOPMENT_MODE,
     CONF_TEST_SERVER_URL,
+    CONF_TRIR,
     DATA_STATE_CLASS_MIGRATION_DONE,
     DOMAIN,
 )
@@ -56,7 +58,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
        if entry.options.get(CONF_DEVELOPMENT_MODE)
         else None
     )
-    api = ConnectLifeApi(entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD], test_server_url)  # type: ignore[arg-type]
+    api = create_api(
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        trir=entry.data.get(CONF_TRIR, False),
+        test_server_url=test_server_url,
+    )
     try:
         await api.login()
     except LifeConnectAuthError as ex:

--- a/custom_components/connectlife/client.py
+++ b/custom_components/connectlife/client.py
@@ -1,0 +1,19 @@
+"""Backend selection for the ConnectLife integration."""
+
+from __future__ import annotations
+
+from connectlife.api import ConnectLifeApi
+from connectlife.trir import TrirConnectLifeApi
+
+
+def create_api(
+    username: str,
+    password: str,
+    *,
+    trir: bool = False,
+    test_server_url: str | None = None,
+) -> ConnectLifeApi:
+    """Create a ConnectLife API client for the configured backend."""
+    if trir:
+        return TrirConnectLifeApi(username, password, test_server_url)  # type: ignore[arg-type]
+    return ConnectLifeApi(username, password, test_server_url)  # type: ignore[arg-type]

--- a/custom_components/connectlife/config_flow.py
+++ b/custom_components/connectlife/config_flow.py
@@ -19,22 +19,31 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 
+from .client import create_api
 from .const import (
     CONF_DEVICES,
     CONF_DEVELOPMENT_MODE,
     CONF_DISABLE_BEEP,
     CONF_EXPOSE_OFFLINE_STATE,
     CONF_TEST_SERVER_URL,
+    CONF_TRIR,
     DOMAIN,
 )
-from connectlife.api import ConnectLifeApi
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
+# Reauth only re-collects credentials; the backend (CONF_TRIR) is preserved
+# from the existing entry, so it must not appear in the reauth form.
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+STEP_USER_DATA_SCHEMA = STEP_REAUTH_DATA_SCHEMA.extend(
+    {
+        vol.Optional(CONF_TRIR, default=False): bool,
     }
 )
 
@@ -43,7 +52,12 @@ async def validate_input(data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
 
     test_server_url = data[CONF_TEST_SERVER_URL] if CONF_TEST_SERVER_URL in data else None
-    api = ConnectLifeApi(data[CONF_USERNAME], data[CONF_PASSWORD], test_server_url)  # type: ignore[arg-type]
+    api = create_api(
+        data[CONF_USERNAME],
+        data[CONF_PASSWORD],
+        trir=data.get(CONF_TRIR, False),
+        test_server_url=test_server_url,
+    )
 
     if not await api.authenticate():
         raise InvalidAuth
@@ -112,7 +126,7 @@ class ConnectLifeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
             errors=errors,
         )
 

--- a/custom_components/connectlife/const.py
+++ b/custom_components/connectlife/const.py
@@ -11,6 +11,7 @@ CONF_DEVELOPMENT_MODE = "development_mode"
 CONF_DISABLE_BEEP = "disable_beep"
 CONF_EXPOSE_OFFLINE_STATE = "expose_offline_state"
 CONF_TEST_SERVER_URL = "test_server_url"
+CONF_TRIR = "trir"
 
 OFFLINE_STATE = "offline_state"
 

--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
-  "requirements": ["connectlife==0.7.2"],
+  "requirements": ["connectlife==0.8.0"],
   "version": "0.39.0"
 }

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -20,7 +20,11 @@
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",
+          "trir": "ConnectLife.TRIR (Russia/CIS) — experimental",
           "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "trir": "Enable only if you sign in with the ConnectLife.TRIR app used in Russia/CIS. Experimental."
         }
       }
     }

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -20,7 +20,7 @@
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",
-          "trir": "ConnectLife.TRIR (Russia/CIS) — experimental",
+          "trir": "ConnectLife.TRIR (Russia/CIS) \u2014 experimental",
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -20,7 +20,11 @@
       "user": {
         "data": {
           "password": "Password",
+          "trir": "ConnectLife.TRIR (Russia/CIS) \u2014 experimental",
           "username": "Username"
+        },
+        "data_description": {
+          "trir": "Enable only if you sign in with the ConnectLife.TRIR app used in Russia/CIS. Experimental."
         }
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Custom Home Assistant component for ConnectLife devices"
 readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
-    "connectlife==0.7.1",
+    "connectlife==0.8.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -556,15 +556,15 @@ wheels = [
 
 [[package]]
 name = "connectlife"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/7c/950ab71197d5a42101999acd657d94326f321a4b2d32d70eb45d2c71628c/connectlife-0.7.1.tar.gz", hash = "sha256:b574fbdac1c8c635d9dea17c114e04714e8710eab05d8ee2cfe571f9d8f985b5", size = 136172 }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/3f/48f9c946e7c3389f1f232eaba45e0ca31972ca86681168fab40daa89bcd5/connectlife-0.8.0.tar.gz", hash = "sha256:9d798249d99afcb9db6cd02f943afcfd77779c5373bd40f10eb8dc3b55a3578b", size = 151251 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/42/4dfbe9abeadd7666ea7188b66abcb08b70f0946d608f6825b0b47d81af67/connectlife-0.7.1-py3-none-any.whl", hash = "sha256:0af3f2d5c49a71d2b5cabf0d98bc51e3f697f577dbe60b14ad2a9b7cdc157580", size = 30077 },
+    { url = "https://files.pythonhosted.org/packages/ce/c9/c45d130ec02f71f3976b1a31f1a38979c2730448adb7e0afcea7ec026829/connectlife-0.8.0-py3-none-any.whl", hash = "sha256:b26841385211946c1b53907472fdf80999f6986080c6dedba4f4c7c06d818deb", size = 41886 },
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "connectlife", specifier = "==0.7.1" }]
+requires-dist = [{ name = "connectlife", specifier = "==0.8.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Adds an opt-in **ConnectLife.TRIR** backend for accounts in Russia/CIS, which authenticate and list devices via a separate gateway. The backend itself lives in the `connectlife` library (0.8.0); this wires it into the integration.

> [!WARNING]
> **Experimental.** Login, device listing, and energy are confirmed against a live server. The token-refresh success path and expiry semantics, the randStr error code, and write-back (set property) are not yet confirmed by a TRIR user.

## What this adds

- **config_flow**: an opt-in "TRIR" checkbox in the user step (default off). Reauth uses a credentials-only schema so it cannot silently change an existing entry's backend.
- **client**: a `create_api()` factory that builds the default or TRIR client from the configured flag; both config flow and setup go through it.
- **__init__**: builds the API via the factory using the stored `CONF_TRIR`.
- **strings**: label and description for the TRIR option.
- **dependency**: bump `connectlife` to `0.8.0` (manifest, pyproject, lockfile), which ships the TRIR backend.

The TRIR backend is a `ConnectLifeApi` subclass, so the coordinator and all platforms are unchanged.

Reverse engineering by @vit9696. See #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
