### PR TITLE
Add daily energy and water consumption sensors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Device-level platforms (climate, humidifier, water_heater) create one entity per
 
 ### Statistics (daily energy/water) sensors
 
-A second coordinator, `ConnectLifeEnergyCoordinator` (`coordinator.py`), runs alongside the main
+A second coordinator, `ConnectLifeStatisticsCoordinator` (`coordinator.py`), runs alongside the main
 one and powers the daily energy/water consumption sensors. These are **not** derived from
 `status_list`; they come from separate ConnectLife cloud statistics endpoints.
 
@@ -83,7 +83,7 @@ one and powers the daily energy/water consumption sensors. These are **not** der
   sensor defs.
 - **Lifecycle**: `__init__.py` creates the energy coordinator only if at least one appliance has
   an enabled statistics sensor (otherwise it would poll nothing); stored under
-  `hass.data[DOMAIN][f"{entry_id}_energy"]`. It polls every `ENERGY_UPDATE_INTERVAL` (10 minutes),
+  `hass.data[DOMAIN][f"{entry_id}_statistics"]`. It polls every `STATISTICS_UPDATE_INTERVAL` (10 minutes),
   storing `dict[device_id, EnergyResult | None]`. On `LifeConnectAuthError` it stops the cycle
   (no per-appliance re-login storm).
 - **Sensors** (`ConnectLifeStatisticsSensor` in `sensor.py`): generic, configured from a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,29 @@ for appliance in coordinator.data.values():
 
 Device-level platforms (climate, humidifier, water_heater) create one entity per appliance when any property has that platform type.
 
+### Statistics (daily energy/water) sensors
+
+A second coordinator, `ConnectLifeEnergyCoordinator` (`coordinator.py`), runs alongside the main
+one and powers the daily energy/water consumption sensors. These are **not** derived from
+`status_list`; they come from separate ConnectLife cloud statistics endpoints.
+
+- **Opt-in via the data dictionary**: a top-level `statistics` block (`source` +
+  per-sensor boolean flags `daily_energy_kwh` / `daily_water_consumption`) selects the endpoint
+  and which sensors to create. Parsed in `dictionaries.py` onto `Dictionary.statistics_source` /
+  `Dictionary.statistics_sensors`. Both flags default to off — explicit `true` is required.
+- **Registry** (`statistics_sources.py`): maps each `source` (`air_duct_energy` for air
+  conditioners, `energy_consumption_curve` for other appliances) to its endpoint fetch and its
+  `StatisticsSensorDef`s. `enabled_sensors(source, flags)` returns only the explicitly-enabled
+  sensor defs.
+- **Lifecycle**: `__init__.py` creates the energy coordinator only if at least one appliance has
+  an enabled statistics sensor (otherwise it would poll nothing); stored under
+  `hass.data[DOMAIN][f"{entry_id}_energy"]`. It polls every `ENERGY_UPDATE_INTERVAL` (10 minutes),
+  storing `dict[device_id, EnergyResult | None]`. On `LifeConnectAuthError` it stops the cycle
+  (no per-appliance re-login storm).
+- **Sensors** (`ConnectLifeStatisticsSensor` in `sensor.py`): generic, configured from a
+  `StatisticsSensorDef`; unique ID `{device_id}-{sensor.key}`. Unlike status entities they are
+  **not** gated on offline state — cloud-side statistics remain available while the device is offline.
+
 ### Key Design Decisions
 
 - **Unique ID format**: `{device_id}-{property_name}` (or `{device_id}-climate` etc. for device-level entities)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ This adds a `connectivity` binary sensor (a diagnostic entity) reporting whether
 the device's other entities from going unavailable while it is offline — they keep their last reported values
 until the device comes back online.
 
+## Daily energy and water consumption sensors
+
+For supported device types, the integration exposes a **daily energy** sensor (kWh) and, for
+wet appliances such as dishwashers and washing machines, a **daily water consumption** sensor (L).
+Air conditioners report energy via the cloud `air_duct_energy` endpoint; other appliances
+(dishwashers, washing machines, dryers, ovens, …) report energy — and where applicable water —
+via the `energyConsumptionCurve` endpoint.
+
+No configuration is needed: these sensors are created automatically for device types whose mapping
+opts in (see the `statistics` block in the
+[data dictionary docs](custom_components/connectlife/data_dictionaries/README.md#statistics)).
+The statistics are fetched from a separate cloud endpoint, polled every 10 minutes, and — unlike
+the regular status entities — they stay available even while the appliance is offline.
+
 ## Service to set property values on sensors
 
 Entity service `connectlife.set_value` can be used to set values. Use with caution, as there is **no** validation

--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -21,7 +21,9 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
+from .dictionaries import Dictionaries
 from .services import async_setup_services
+from .statistics_sources import enabled_sensors
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -72,10 +74,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from ex
     coordinator = ConnectLifeCoordinator(hass, api)
     await coordinator.async_config_entry_first_refresh()
-    energy_coordinator = ConnectLifeEnergyCoordinator(hass, api, coordinator)
-    await energy_coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
-    hass.data[DOMAIN][f"{entry.entry_id}_energy"] = energy_coordinator
+
+    # Only create the statistics coordinator if some device opts into a statistics
+    # endpoint with at least one sensor enabled (otherwise it would poll nothing).
+    has_statistics = any(
+        enabled_sensors(
+            Dictionaries.get_dictionary(appliance).statistics_source,
+            Dictionaries.get_dictionary(appliance).statistics_sensors,
+        )
+        for appliance in coordinator.data.values()
+    )
+    if has_statistics:
+        energy_coordinator = ConnectLifeEnergyCoordinator(hass, api, coordinator)
+        await energy_coordinator.async_config_entry_first_refresh()
+        hass.data[DOMAIN][f"{entry.entry_id}_energy"] = energy_coordinator
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 

--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -20,7 +20,7 @@ from .const import (
     DATA_STATE_CLASS_MIGRATION_DONE,
     DOMAIN,
 )
-from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
+from .coordinator import ConnectLifeCoordinator, ConnectLifeStatisticsCoordinator
 from .dictionaries import Dictionaries
 from .services import async_setup_services
 from .statistics_sources import enabled_sensors
@@ -79,16 +79,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Only create the statistics coordinator if some device opts into a statistics
     # endpoint with at least one sensor enabled (otherwise it would poll nothing).
     has_statistics = any(
-        enabled_sensors(
-            Dictionaries.get_dictionary(appliance).statistics_source,
-            Dictionaries.get_dictionary(appliance).statistics_sensors,
-        )
+        enabled_sensors(d.statistics_source, d.statistics_sensors)
         for appliance in coordinator.data.values()
+        if (d := Dictionaries.get_dictionary(appliance))
     )
     if has_statistics:
-        energy_coordinator = ConnectLifeEnergyCoordinator(hass, api, coordinator)
-        await energy_coordinator.async_config_entry_first_refresh()
-        hass.data[DOMAIN][f"{entry.entry_id}_energy"] = energy_coordinator
+        statistics_coordinator = ConnectLifeStatisticsCoordinator(hass, api, coordinator)
+        await statistics_coordinator.async_config_entry_first_refresh()
+        hass.data[DOMAIN][f"{entry.entry_id}_statistics"] = statistics_coordinator
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
@@ -112,6 +110,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
-        hass.data[DOMAIN].pop(f"{entry.entry_id}_energy", None)
+        hass.data[DOMAIN].pop(f"{entry.entry_id}_statistics", None)
 
     return unload_ok

--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Mapping
 from datetime import timedelta
 
-from connectlife.api import LifeConnectAuthError, LifeConnectError, ConnectLifeApi
+from connectlife.api import LifeConnectAuthError, LifeConnectError, ConnectLifeApi, EnergyResult
 from connectlife.appliance import ConnectLifeAppliance
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.statistics import list_statistic_ids
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DATA_STATE_CLASS_MIGRATION_DONE, DOMAIN
 from .dictionaries import Dictionaries
 from .messages import format_retry_message
+from .statistics_sources import STATISTICS_SOURCES, enabled_sensors
 
 MAX_RETRIES = 3
 ENERGY_UPDATE_INTERVAL = timedelta(minutes=10)
@@ -208,8 +209,10 @@ class ConnectLifeCoordinator(DataUpdateCoordinator[dict[str, ConnectLifeApplianc
         )
 
 
-class ConnectLifeEnergyCoordinator(DataUpdateCoordinator[dict[str, float | None]]):
-    """ConnectLife energy coordinator. Polls daily energy usage every 10 minutes."""
+class ConnectLifeEnergyCoordinator(DataUpdateCoordinator[dict[str, EnergyResult | None]]):
+    """ConnectLife statistics coordinator. Polls each appliance's statistics endpoint
+    (selected per device type via the data dictionary ``statistics_source``) every 10
+    minutes. Stores the fetched result per device; sensors extract their datapoint."""
 
     def __init__(self, hass, api: ConnectLifeApi, appliance_coordinator: ConnectLifeCoordinator):
         """Initialize energy coordinator."""
@@ -222,19 +225,26 @@ class ConnectLifeEnergyCoordinator(DataUpdateCoordinator[dict[str, float | None]
             update_interval=ENERGY_UPDATE_INTERVAL,
         )
 
-    async def _async_update_data(self) -> dict[str, float | None]:
-        """Fetch daily energy for all appliances."""
-        result: dict[str, float | None] = {}
+    async def _async_update_data(self) -> dict[str, EnergyResult | None]:
+        """Fetch statistics for appliances whose data dictionary opts into an endpoint."""
+        result: dict[str, EnergyResult | None] = {}
         for device_id, appliance in self.appliance_coordinator.data.items():
+            dictionary = Dictionaries.get_dictionary(appliance)
+            source = STATISTICS_SOURCES.get(dictionary.statistics_source or "")
+            if source is None or not enabled_sensors(
+                dictionary.statistics_source, dictionary.statistics_sensors
+            ):
+                continue
             try:
-                result[device_id] = await self.api.get_daily_energy_kwh(
-                    appliance.puid,
-                    appliance.device_type_code,
-                    appliance.device_feature_code,
-                )
+                result[device_id] = await source.fetch(self.api, appliance)
+            except LifeConnectAuthError:
+                # Token is rejected; stop rather than hammering the gateway (and any
+                # re-login) for every remaining device. Recovers on the next cycle.
+                _LOGGER.debug("Statistics auth failed; skipping remaining devices this cycle")
+                break
             except Exception:
                 _LOGGER.debug(
-                    "Failed to fetch daily energy for %s",
+                    "Failed to fetch statistics for %s",
                     appliance.device_nickname,
                     exc_info=True,
                 )

--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -18,7 +18,7 @@ from .messages import format_retry_message
 from .statistics_sources import STATISTICS_SOURCES, enabled_sensors
 
 MAX_RETRIES = 3
-ENERGY_UPDATE_INTERVAL = timedelta(minutes=10)
+STATISTICS_UPDATE_INTERVAL = timedelta(minutes=10)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -209,20 +209,20 @@ class ConnectLifeCoordinator(DataUpdateCoordinator[dict[str, ConnectLifeApplianc
         )
 
 
-class ConnectLifeEnergyCoordinator(DataUpdateCoordinator[dict[str, EnergyResult | None]]):
+class ConnectLifeStatisticsCoordinator(DataUpdateCoordinator[dict[str, EnergyResult | None]]):
     """ConnectLife statistics coordinator. Polls each appliance's statistics endpoint
     (selected per device type via the data dictionary ``statistics_source``) every 10
     minutes. Stores the fetched result per device; sensors extract their datapoint."""
 
     def __init__(self, hass, api: ConnectLifeApi, appliance_coordinator: ConnectLifeCoordinator):
-        """Initialize energy coordinator."""
+        """Initialize statistics coordinator."""
         self.api = api
         self.appliance_coordinator = appliance_coordinator
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN}_energy",
-            update_interval=ENERGY_UPDATE_INTERVAL,
+            name=f"{DOMAIN}_statistics",
+            update_interval=STATISTICS_UPDATE_INTERVAL,
         )
 
     async def _async_update_data(self) -> dict[str, EnergyResult | None]:

--- a/custom_components/connectlife/data_dictionaries/003.yaml
+++ b/custom_components/connectlife/data_dictionaries/003.yaml
@@ -1,4 +1,8 @@
 # Washing machine
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
+  daily_water_consumption: true
 properties:
   - property: ACTION
     disable: true

--- a/custom_components/connectlife/data_dictionaries/004.yaml
+++ b/custom_components/connectlife/data_dictionaries/004.yaml
@@ -1,4 +1,7 @@
 # Tumble dryer
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: ACTION
     disable: true

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -1,4 +1,7 @@
 # Portable air conditioner
+statistics:
+  source: air_duct_energy
+  daily_energy_kwh: true
 properties:
   - property: f-filter
     binary_sensor:

--- a/custom_components/connectlife/data_dictionaries/007.yaml
+++ b/custom_components/connectlife/data_dictionaries/007.yaml
@@ -1,4 +1,7 @@
 # Dehumidifier
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: f_e_filterclean
     binary_sensor:

--- a/custom_components/connectlife/data_dictionaries/008.yaml
+++ b/custom_components/connectlife/data_dictionaries/008.yaml
@@ -1,4 +1,7 @@
 # Window air conditioner
+statistics:
+  source: air_duct_energy
+  daily_energy_kwh: true
 properties:
   - property: f-filter
     binary_sensor:

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -1,3 +1,6 @@
+statistics:
+  source: air_duct_energy
+  daily_energy_kwh: true
 properties:
   - property: aus_zone1_opencontrol
     number:

--- a/custom_components/connectlife/data_dictionaries/010.yaml
+++ b/custom_components/connectlife/data_dictionaries/010.yaml
@@ -1,4 +1,7 @@
 # Induction hob
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: Air_dry_function
     hide: true

--- a/custom_components/connectlife/data_dictionaries/012.yaml
+++ b/custom_components/connectlife/data_dictionaries/012.yaml
@@ -1,4 +1,7 @@
 # Hood
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   # Top-level operating state
   - property: DeviceStatus

--- a/custom_components/connectlife/data_dictionaries/013.yaml
+++ b/custom_components/connectlife/data_dictionaries/013.yaml
@@ -1,4 +1,7 @@
 # Oven
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
 - property: Actions
   select:

--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -1,3 +1,7 @@
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
+  daily_water_consumption: true
 properties:
   - property: ADO_allowed
     binary_sensor:

--- a/custom_components/connectlife/data_dictionaries/016.yaml
+++ b/custom_components/connectlife/data_dictionaries/016.yaml
@@ -1,3 +1,6 @@
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: f_ecm
     # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1

--- a/custom_components/connectlife/data_dictionaries/020.yaml
+++ b/custom_components/connectlife/data_dictionaries/020.yaml
@@ -1,4 +1,7 @@
 # Induction hob
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: Alarm_Hob_Hood_Started
     optional: true

--- a/custom_components/connectlife/data_dictionaries/023.yaml
+++ b/custom_components/connectlife/data_dictionaries/023.yaml
@@ -1,4 +1,7 @@
 # Oven
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: Actions
     select:

--- a/custom_components/connectlife/data_dictionaries/025.yaml
+++ b/custom_components/connectlife/data_dictionaries/025.yaml
@@ -1,4 +1,8 @@
 # Washing Machine
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
+  daily_water_consumption: true
 properties:
   - property: Door_status
     icon: mdi:door

--- a/custom_components/connectlife/data_dictionaries/026.yaml
+++ b/custom_components/connectlife/data_dictionaries/026.yaml
@@ -1,4 +1,7 @@
 # Refrigerator
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: AIR_FRESHNESS
     optional: true

--- a/custom_components/connectlife/data_dictionaries/027.yaml
+++ b/custom_components/connectlife/data_dictionaries/027.yaml
@@ -1,4 +1,8 @@
 # Washing machine
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
+  daily_water_consumption: true
 properties:
 - property: Child_lock_status_status
   icon: 'mdi:lock'

--- a/custom_components/connectlife/data_dictionaries/030.yaml
+++ b/custom_components/connectlife/data_dictionaries/030.yaml
@@ -1,4 +1,7 @@
 # Tumble dryer
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: Actions
     # Sample value: 0

--- a/custom_components/connectlife/data_dictionaries/032.yaml
+++ b/custom_components/connectlife/data_dictionaries/032.yaml
@@ -1,4 +1,7 @@
 # Tumble dryer
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
 properties:
   - property: Actions
     select:

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -91,6 +91,7 @@ The file contains these top level items:
 - `climate`: top level [`Climate`](#presets) configuration.
 - `properties`: list of [`Property`](#property)
 - `buttons`: list of [`Button`](#buttons) entities for write-only commands
+- `statistics`: opt the device type into [daily energy/water statistics](#statistics) sensors
 
 To make a property visible by default, just add the property to the list. Note that properties you do not map are still
 mapped to [sensor](#type-sensor) entities, but registered as disabled by default.
@@ -473,6 +474,45 @@ Example feature override disabling pause on a variant that doesn't support `Acti
 buttons:
   - key: pause
     disable: true
+```
+
+## Statistics
+
+The top-level `statistics` block opts the device type into **daily energy and water
+consumption** sensors. These are not mapped from `status_list` properties; instead the
+integration polls a separate ConnectLife cloud statistics endpoint (every 10 minutes) and
+exposes the daily totals. Because the data is cloud-side, these sensors stay available even
+when the appliance is offline.
+
+Set this block on the **base** device-type file (e.g. `015.yaml`), not on feature overrides.
+Omit the whole block for device types that have no statistics endpoint.
+
+| Item                      | Type                                            | Description                                                                                                                                            |
+|---------------------------|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `source`                  | `air_duct_energy`, `energy_consumption_curve`   | Required. Which cloud endpoint to poll: `air_duct_energy` for air conditioners, `energy_consumption_curve` for other appliances (dishwashers, washing machines, dryers, …). |
+| `daily_energy_kwh`        | `true`, `false`                                 | Set `true` to create the daily energy sensor (kWh). Defaults to `false`.                                                                                |
+| `daily_water_consumption` | `true`, `false`                                 | Set `true` to create the daily water consumption sensor (L), for wet appliances. Defaults to `false`.                                                   |
+
+Both sensor flags default to off, so each must be explicitly enabled with `true`.
+`daily_water_consumption` is only meaningful for the `energy_consumption_curve` source.
+
+Example for a dishwasher:
+
+```yaml
+# 015.yaml (base)
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
+  daily_water_consumption: true
+```
+
+Example for an air conditioner:
+
+```yaml
+# 009.yaml (base)
+statistics:
+  source: air_duct_energy
+  daily_energy_kwh: true
 ```
 
 ## Type `WaterHeater`

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -6,6 +6,25 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "statistics": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source"],
+          "properties": {
+            "source": {
+              "enum": ["air_duct_energy", "energy_consumption_curve"],
+              "description": "Which cloud statistics endpoint to poll: air_duct_energy (air conditioners) or energy_consumption_curve (other appliances). Set on the base device-type file; omit the whole block for types with no statistics endpoint."
+            },
+            "daily_energy_kwh": {
+              "type": "boolean",
+              "description": "Set true to create the daily energy sensor."
+            },
+            "daily_water_consumption": {
+              "type": "boolean",
+              "description": "Set true to create the daily water consumption sensor (wet appliances)."
+            }
+          }
+        },
         "climate": {
           "$ref": "#/$defs/ClimateDevice"
         },

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -1,6 +1,6 @@
 import yaml
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import pkgutil
 from typing import Any, TypedDict
@@ -33,6 +33,8 @@ BUTTONS = "buttons"
 COMMAND = "command"
 DEVICE = "device"
 DEVICE_CLASS = "device_class"
+STATISTICS = "statistics"
+SOURCE = "source"
 DISABLE = "disable"
 HIDE = "hide"
 ICON = "icon"
@@ -427,6 +429,13 @@ class Dictionary:
     climate: dict | None
     properties: dict[str, Property]
     buttons: list[Button]
+    # Cloud statistics endpoint for this device family (None = none): "air_duct_energy"
+    # (air conditioners) or "energy_consumption_curve" (appliances). Dispatched via the
+    # statistics_sources registry.
+    statistics_source: str | None = None
+    # Per-sensor flags from the `statistics` block (sensor key -> create?). A sensor is
+    # created only when listed true here; omitted or false means not created.
+    statistics_sensors: dict[str, bool] = field(default_factory=dict)
 
 
 PLATFORM_KEYS = (
@@ -521,6 +530,7 @@ class Dictionaries:
             return cls.dictionaries[key]
 
         climate: dict | None = None
+        statistics: dict | None = None
         raw_entries: dict[str, dict] = {}
         raw_buttons: list[dict] = []
 
@@ -529,6 +539,7 @@ class Dictionaries:
             f"data_dictionaries/{appliance.device_type_code}.yaml"
         )
         if base_data is not None:
+            statistics = _val(base_data, STATISTICS, statistics)
             if PROPERTIES in base_data and base_data[PROPERTIES] is not None:
                 for prop in base_data[PROPERTIES]:
                     raw_entries[prop[PROPERTY]] = prop
@@ -543,6 +554,7 @@ class Dictionaries:
                 key,
             )
         if sub_data is not None:
+            statistics = _val(sub_data, STATISTICS, statistics)
             if Platform.CLIMATE in sub_data:
                 climate = sub_data[Platform.CLIMATE]
             if PROPERTIES in sub_data and sub_data[PROPERTIES] is not None:
@@ -565,6 +577,20 @@ class Dictionaries:
 
         buttons = [Button(b) for b in raw_buttons]
 
-        dictionary = Dictionary(climate=climate, properties=properties, buttons=buttons)
+        statistics = statistics or {}
+        statistics_source = _val(statistics, SOURCE)
+        statistics_sensors = {
+            sensor_key: bool(create)
+            for sensor_key, create in statistics.items()
+            if sensor_key != SOURCE
+        }
+
+        dictionary = Dictionary(
+            climate=climate,
+            properties=properties,
+            buttons=buttons,
+            statistics_source=statistics_source,
+            statistics_sensors=statistics_sensors,
+        )
         cls.dictionaries[key] = dictionary
         return dictionary

--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
-  "requirements": ["connectlife==0.8.0"],
+  "requirements": ["connectlife==0.9.0"],
   "version": "0.40.0"
 }

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -21,7 +21,7 @@ from .const import (
     DOMAIN,
     SW_VERSION_PROPERTY,
 )
-from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
+from .coordinator import ConnectLifeCoordinator, ConnectLifeStatisticsCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from .statistics_sources import StatisticsSensorDef, enabled_sensors
@@ -40,7 +40,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up ConnectLife sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    energy_coordinator = hass.data[DOMAIN].get(f"{config_entry.entry_id}_energy")
+    statistics_coordinator = hass.data[DOMAIN].get(f"{config_entry.entry_id}_statistics")
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
@@ -64,11 +64,11 @@ async def async_setup_entry(
                 for src in prop.combine
             )
         )
-    if energy_coordinator is not None:
+    if statistics_coordinator is not None:
         for appliance in coordinator.data.values():
             dictionary = Dictionaries.get_dictionary(appliance)
             async_add_entities(
-                ConnectLifeStatisticsSensor(coordinator, energy_coordinator, appliance, sensor)
+                ConnectLifeStatisticsSensor(coordinator, statistics_coordinator, appliance, sensor)
                 for sensor in enabled_sensors(
                     dictionary.statistics_source, dictionary.statistics_sensors
                 )
@@ -193,7 +193,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         await self.async_update_device({self.status: value})
 
 
-class ConnectLifeStatisticsSensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], SensorEntity):
+class ConnectLifeStatisticsSensor(CoordinatorEntity[ConnectLifeStatisticsCoordinator], SensorEntity):
     """Sensor derived from a ConnectLife statistics endpoint.
 
     The endpoint (and the sensor set) is selected per device type via the data dictionary
@@ -206,12 +206,12 @@ class ConnectLifeStatisticsSensor(CoordinatorEntity[ConnectLifeEnergyCoordinator
     def __init__(
         self,
         appliance_coordinator: ConnectLifeCoordinator,
-        energy_coordinator: ConnectLifeEnergyCoordinator,
+        statistics_coordinator: ConnectLifeStatisticsCoordinator,
         appliance: ConnectLifeAppliance,
         sensor: StatisticsSensorDef,
     ):
         """Initialize the statistics sensor."""
-        super().__init__(energy_coordinator)
+        super().__init__(statistics_coordinator)
         self._device_id = appliance.device_id
         self._sensor = sensor
         self._attr_translation_key = sensor.key

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -5,12 +5,11 @@ import logging
 import voluptuous as vol
 from homeassistant.components.sensor import (
     SensorEntity,
-    SensorStateClass,
     SensorDeviceClass,
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform, UnitOfEnergy
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -19,14 +18,13 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    CONF_DEVICES,
-    CONF_EXPOSE_OFFLINE_STATE,
     DOMAIN,
     SW_VERSION_PROPERTY,
 )
 from .coordinator import ConnectLifeCoordinator, ConnectLifeEnergyCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
+from .statistics_sources import StatisticsSensorDef, enabled_sensors
 from connectlife.appliance import ConnectLifeAppliance, MAX_DATETIME
 from .utils import has_platform, to_unit
 
@@ -42,7 +40,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up ConnectLife sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    energy_coordinator = hass.data[DOMAIN][f"{config_entry.entry_id}_energy"]
+    energy_coordinator = hass.data[DOMAIN].get(f"{config_entry.entry_id}_energy")
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
         async_add_entities(
@@ -66,10 +64,15 @@ async def async_setup_entry(
                 for src in prop.combine
             )
         )
-    async_add_entities(
-        ConnectLifeEnergySensor(coordinator, energy_coordinator, appliance)
-        for appliance in coordinator.data.values()
-    )
+    if energy_coordinator is not None:
+        for appliance in coordinator.data.values():
+            dictionary = Dictionaries.get_dictionary(appliance)
+            async_add_entities(
+                ConnectLifeStatisticsSensor(coordinator, energy_coordinator, appliance, sensor)
+                for sensor in enabled_sensors(
+                    dictionary.statistics_source, dictionary.statistics_sensors
+                )
+            )
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
@@ -190,42 +193,47 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
         await self.async_update_device({self.status: value})
 
 
-class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], SensorEntity):
-    """Sensor for daily energy consumption from the ConnectLife energy endpoint."""
+class ConnectLifeStatisticsSensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], SensorEntity):
+    """Sensor derived from a ConnectLife statistics endpoint.
+
+    The endpoint (and the sensor set) is selected per device type via the data dictionary
+    ``statistics_source``; see :mod:`.statistics_sources`. The energy coordinator stores
+    the fetched result per device and this sensor extracts its datapoint via ``sensor.value``.
+    """
 
     _attr_has_entity_name = True
-    _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_translation_key = "daily_energy_kwh"
 
     def __init__(
         self,
         appliance_coordinator: ConnectLifeCoordinator,
         energy_coordinator: ConnectLifeEnergyCoordinator,
         appliance: ConnectLifeAppliance,
+        sensor: StatisticsSensorDef,
     ):
-        """Initialize the energy sensor."""
+        """Initialize the statistics sensor."""
         super().__init__(energy_coordinator)
         self._device_id = appliance.device_id
-        self._appliance_coordinator = appliance_coordinator
-        self._attr_unique_id = f"{appliance.device_id}-daily_energy_kwh"
+        self._sensor = sensor
+        self._attr_translation_key = sensor.key
+        self._attr_unique_id = f"{appliance.device_id}-{sensor.key}"
+        self._attr_device_class = sensor.device_class
+        self._attr_native_unit_of_measurement = sensor.unit
+        self._attr_state_class = sensor.state_class
+        if sensor.icon:
+            self._attr_icon = sensor.icon
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, appliance.device_id)},
         )
-        device = appliance_coordinator.config_entry.options.get(CONF_DEVICES, {}).get(self._device_id, {})
-        self._expose_offline_state = device.get(CONF_EXPOSE_OFFLINE_STATE, False)
         appliance_coordinator.add_entity(self._attr_unique_id, Platform.SENSOR)
         self._update_native_value()
 
     @property
     def available(self) -> bool:
-        appliance = self._appliance_coordinator.data.get(self._device_id)
-        if appliance is None:
-            return False
+        # Cloud-side period statistics stay available even when the appliance is offline
+        # (unlike status sensors), so this is not gated on offline_state — only on the
+        # coordinator having a fetched result for this device.
         return (
             super().available
-            and (self._expose_offline_state or appliance.offline_state == 1)
             and self.coordinator.data is not None
             and self.coordinator.data.get(self._device_id) is not None
         )
@@ -237,8 +245,6 @@ class ConnectLifeEnergySensor(CoordinatorEntity[ConnectLifeEnergyCoordinator], S
         self.async_write_ha_state()
 
     def _update_native_value(self) -> None:
-        """Update native value from energy coordinator data."""
-        if self.coordinator.data and self._device_id in self.coordinator.data:
-            self._attr_native_value = self.coordinator.data[self._device_id]
-        else:
-            self._attr_native_value = None
+        """Extract this sensor's datapoint from the fetched statistics result."""
+        result = self.coordinator.data.get(self._device_id) if self.coordinator.data else None
+        self._attr_native_value = self._sensor.value(result) if result is not None else None

--- a/custom_components/connectlife/statistics_sources.py
+++ b/custom_components/connectlife/statistics_sources.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-import datetime as dt
 from typing import Any
 
 from connectlife.api import ConnectLifeApi, EnergyResult
 from connectlife.appliance import ConnectLifeAppliance
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfVolume
+from homeassistant.util import dt as dt_util
 
 
 def _as_float(value: Any) -> float | None:
@@ -29,10 +29,14 @@ def _as_float(value: Any) -> float | None:
 
 
 def _curve_today(curve: dict[str, Any] | None) -> float | None:
-    """Today's value from a per-day curve keyed by ISO date (e.g. the week response)."""
+    """Today's value from a per-day curve keyed by ISO date (e.g. the week response).
+
+    "Today" uses Home Assistant's configured timezone (``dt_util.now()``) so the lookup
+    matches the user's local day boundary, not the server's.
+    """
     if not curve:
         return None
-    return _as_float(curve.get(dt.date.today().isoformat()))
+    return _as_float(curve.get(dt_util.now().date().isoformat()))
 
 
 @dataclass(frozen=True)

--- a/custom_components/connectlife/statistics_sources.py
+++ b/custom_components/connectlife/statistics_sources.py
@@ -1,0 +1,138 @@
+"""Registry mapping a data dictionary ``statistics_source`` to a cloud endpoint.
+
+Each :class:`StatisticsSource` knows how to fetch from one ConnectLife statistics
+endpoint and which sensors to derive from it. Adding a new endpoint is: a new library
+method, a ``StatisticsSource`` entry here, and setting ``statistics_source`` in the
+relevant base data dictionaries — no coordinator/platform changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import datetime as dt
+from typing import Any
+
+from connectlife.api import ConnectLifeApi, EnergyResult
+from connectlife.appliance import ConnectLifeAppliance
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy, UnitOfVolume
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _curve_today(curve: dict[str, Any] | None) -> float | None:
+    """Today's value from a per-day curve keyed by ISO date (e.g. the week response)."""
+    if not curve:
+        return None
+    return _as_float(curve.get(dt.date.today().isoformat()))
+
+
+@dataclass(frozen=True)
+class StatisticsSensorDef:
+    """One sensor derived from a statistics endpoint result.
+
+    ``key`` is both the translation key and the unique-id suffix (and the per-sensor key
+    in the data dictionary ``statistics`` block — a sensor is created only when the block
+    lists ``<key>: true``). ``value`` extracts the sensor's native value from the fetched
+    result (an ``EnergyResult`` subclass).
+    """
+
+    key: str
+    device_class: SensorDeviceClass
+    unit: str
+    state_class: SensorStateClass
+    value: Callable[[Any], float | None]
+    icon: str | None = None
+
+
+class StatisticsSource:
+    """Base class: fetch one endpoint and declare its sensors."""
+
+    key: str
+    sensors: tuple[StatisticsSensorDef, ...]
+
+    async def fetch(
+        self, api: ConnectLifeApi, appliance: ConnectLifeAppliance
+    ) -> EnergyResult | None:
+        raise NotImplementedError
+
+
+class AirDuctStatisticsSource(StatisticsSource):
+    """``air_duct_energy`` (air conditioners). Today's total via ``statType=day``."""
+
+    key = "air_duct_energy"
+    sensors = (
+        StatisticsSensorDef(
+            "daily_energy_kwh",
+            SensorDeviceClass.ENERGY,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            SensorStateClass.TOTAL_INCREASING,
+            lambda r: r.electric_total,
+        ),
+    )
+
+    async def fetch(self, api, appliance):
+        return await api.get_air_duct_energy(
+            appliance.puid, appliance.device_type_code, appliance.device_feature_code
+        )
+
+
+class ConsumptionStatisticsSource(StatisticsSource):
+    """``energyConsumptionCurve`` (dishwashers / washing machines).
+
+    The endpoint has no ``statType=day``; today's values come from the week response's
+    per-day ``electricCurve`` / ``waterCurve`` (``curve[today]``).
+    """
+
+    key = "energy_consumption_curve"
+    sensors = (
+        StatisticsSensorDef(
+            "daily_energy_kwh",
+            SensorDeviceClass.ENERGY,
+            UnitOfEnergy.KILO_WATT_HOUR,
+            SensorStateClass.TOTAL_INCREASING,
+            lambda r: _curve_today(r.electric_curve),
+        ),
+        StatisticsSensorDef(
+            "daily_water_consumption",
+            SensorDeviceClass.WATER,
+            UnitOfVolume.LITERS,
+            SensorStateClass.TOTAL_INCREASING,
+            lambda r: _curve_today(r.water_curve),
+            icon="mdi:water",
+        ),
+    )
+
+    async def fetch(self, api, appliance):
+        return await api.get_energy_consumption_curve(
+            appliance.puid, appliance.device_type_code, appliance.device_feature_code
+        )
+
+
+STATISTICS_SOURCES: dict[str, StatisticsSource] = {
+    source.key: source
+    for source in (AirDuctStatisticsSource(), ConsumptionStatisticsSource())
+}
+
+
+def enabled_sensors(
+    statistics_source: str | None, enabled: dict[str, bool]
+) -> list[StatisticsSensorDef]:
+    """The sensor defs to create for a device.
+
+    ``enabled`` are the per-sensor booleans from the data dictionary ``statistics`` block
+    (key -> create?). A sensor is created only when listed ``true``; omitted or ``false``
+    means not created.
+    """
+    source = STATISTICS_SOURCES.get(statistics_source or "")
+    if source is None:
+        return []
+    return [s for s in source.sensors if enabled.get(s.key, False)]

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -3450,6 +3450,9 @@
       "daily_energy_kwh": {
         "name": "Daily energy"
       },
+      "daily_water_consumption": {
+        "name": "Daily water consumption"
+      },
       "darhcdq": {
         "name": "Darhcdq"
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -3450,6 +3450,9 @@
       "daily_energy_kwh": {
         "name": "Daily energy"
       },
+      "daily_water_consumption": {
+        "name": "Daily water consumption"
+      },
       "darhcdq": {
         "name": "Darhcdq"
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Custom Home Assistant component for ConnectLife devices"
 readme = "README.md"
 requires-python = ">=3.13.2"
 dependencies = [
-    "connectlife==0.8.0",
+    "connectlife==0.9.0",
 ]
 
 [dependency-groups]

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -55,7 +55,7 @@ def main(basedir):
         strings = json.load(f)
     # Entities not created based on status_list properties
     valid_properties = {
-        "sensor": {"daily_energy_kwh"},
+        "sensor": {"daily_energy_kwh", "daily_water_consumption"},
         "binary_sensor": {"offline_state"},
     }
     valid_options = {}

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from custom_components.connectlife.dictionaries import (
+    Dictionaries,
     Property,
     Sensor,
     _merge_property,
 )
+
+
+def _dictionary_for(device_type_code: str, device_feature_code: str):
+    """Load a real data dictionary via a minimal appliance stub."""
+    Dictionaries.dictionaries.clear()  # avoid cross-test cache hits
+    appliance = SimpleNamespace(
+        device_type_code=device_type_code,
+        device_feature_code=device_feature_code,
+        device_nickname="test",
+    )
+    return Dictionaries.get_dictionary(appliance)  # type: ignore[arg-type]
 
 
 def test_override_with_no_platform_inherits_everything():
@@ -271,3 +285,29 @@ def test_optional_parsing():
     assert Property({"property": "p", "optional": False}).optional is False
     assert Property({"property": "p", "optional": True}).optional is True
     assert Property({"property": "p"}).optional is False
+
+
+def test_statistics_source_air_duct_for_air_conditioners():
+    # AC families opt into the air_duct_energy endpoint (inherited by feature variants).
+    assert _dictionary_for("009", "100").statistics_source == "air_duct_energy"
+    assert _dictionary_for("006", "200").statistics_source == "air_duct_energy"
+    assert _dictionary_for("008", "399").statistics_source == "air_duct_energy"
+
+
+def test_statistics_source_consumption_curve_for_wet_appliances():
+    assert _dictionary_for("015", "000").statistics_source == "energy_consumption_curve"
+    assert _dictionary_for("027", "000").statistics_source == "energy_consumption_curve"
+
+
+def test_statistics_source_defaults_none():
+    # An unmapped device type (no base file) has no statistics endpoint.
+    assert _dictionary_for("999", "000").statistics_source is None
+
+
+def test_statistics_sensors_explicitly_listed():
+    # Sensors are created only when listed true; wet appliances add water.
+    assert _dictionary_for("015", "000").statistics_sensors == {
+        "daily_energy_kwh": True,
+        "daily_water_consumption": True,
+    }
+    assert _dictionary_for("009", "100").statistics_sensors == {"daily_energy_kwh": True}

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,244 @@
+"""Tests for the statistics sources, coordinator fetch loop, and sensor."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from connectlife.api import LifeConnectAuthError
+from homeassistant.util import dt as dt_util
+
+from custom_components.connectlife.coordinator import ConnectLifeStatisticsCoordinator
+from custom_components.connectlife.dictionaries import Dictionaries
+from custom_components.connectlife.sensor import ConnectLifeStatisticsSensor
+from custom_components.connectlife.statistics_sources import (
+    AirDuctStatisticsSource,
+    ConsumptionStatisticsSource,
+    _as_float,
+    _curve_today,
+    enabled_sensors,
+)
+
+
+def _today_key() -> str:
+    return dt_util.now().date().isoformat()
+
+
+# -- pure helpers ----------------------------------------------------------
+
+
+def test_as_float():
+    assert _as_float(None) is None
+    assert _as_float("1.5") == 1.5
+    assert _as_float(2) == 2.0
+    assert _as_float("not a number") is None
+
+
+def test_curve_today_returns_value_for_today():
+    curve = {_today_key(): "1.5", "2000-01-01": "9.9"}
+    assert _curve_today(curve) == 1.5
+
+
+def test_curve_today_missing_today_is_none():
+    assert _curve_today({"2000-01-01": "9.9"}) is None
+
+
+def test_curve_today_empty_or_none_is_none():
+    assert _curve_today(None) is None
+    assert _curve_today({}) is None
+
+
+def test_curve_today_non_numeric_is_none():
+    assert _curve_today({_today_key(): "n/a"}) is None
+
+
+# -- enabled_sensors -------------------------------------------------------
+
+
+def test_enabled_sensors_unknown_source_is_empty():
+    assert enabled_sensors(None, {}) == []
+    assert enabled_sensors("does_not_exist", {"daily_energy_kwh": True}) == []
+
+
+def test_enabled_sensors_only_listed_true_are_created():
+    assert [s.key for s in enabled_sensors("air_duct_energy", {"daily_energy_kwh": True})] == [
+        "daily_energy_kwh"
+    ]
+    assert enabled_sensors("air_duct_energy", {"daily_energy_kwh": False}) == []
+    assert enabled_sensors("air_duct_energy", {}) == []
+
+
+def test_enabled_sensors_consumption_energy_and_water():
+    both = enabled_sensors(
+        "energy_consumption_curve",
+        {"daily_energy_kwh": True, "daily_water_consumption": True},
+    )
+    assert [s.key for s in both] == ["daily_energy_kwh", "daily_water_consumption"]
+
+    energy_only = enabled_sensors("energy_consumption_curve", {"daily_energy_kwh": True})
+    assert [s.key for s in energy_only] == ["daily_energy_kwh"]
+
+
+# -- coordinator fetch loop ------------------------------------------------
+
+
+class _FakeApi:
+    """Records calls; optionally raises per endpoint."""
+
+    def __init__(self, *, air_duct=None, consumption=None, air_duct_exc=None):
+        self._air_duct = air_duct
+        self._consumption = consumption
+        self._air_duct_exc = air_duct_exc
+        self.air_duct_calls = 0
+        self.consumption_calls = 0
+
+    async def get_air_duct_energy(self, *_args):
+        self.air_duct_calls += 1
+        if self._air_duct_exc is not None:
+            raise self._air_duct_exc
+        return self._air_duct
+
+    async def get_energy_consumption_curve(self, *_args):
+        self.consumption_calls += 1
+        return self._consumption
+
+
+def _appliance(device_id: str, type_code: str, feature: str):
+    return SimpleNamespace(
+        device_id=device_id,
+        device_type_code=type_code,
+        device_feature_code=feature,
+        puid=f"puid{device_id}",
+        device_nickname=f"dev-{device_id}",
+    )
+
+
+def _coordinator(api, data: dict):
+    # Bypass DataUpdateCoordinator.__init__ (needs hass); the fetch loop only uses
+    # self.api and self.appliance_coordinator.data.
+    coord = ConnectLifeStatisticsCoordinator.__new__(ConnectLifeStatisticsCoordinator)
+    coord.api = api  # type: ignore[assignment]
+    coord.appliance_coordinator = SimpleNamespace(data=data)  # type: ignore[assignment]
+    return coord
+
+
+@pytest.fixture(autouse=True)
+def _clear_dictionary_cache():
+    Dictionaries.dictionaries.clear()
+    yield
+    Dictionaries.dictionaries.clear()
+
+
+async def test_coordinator_stores_results_per_device():
+    api = _FakeApi(
+        air_duct=SimpleNamespace(electric_total=2.0),
+        consumption=SimpleNamespace(
+            electric_curve={_today_key(): "1.0"}, water_curve={_today_key(): "11.0"}
+        ),
+    )
+    data = {"ac": _appliance("ac", "009", "100"), "wm": _appliance("wm", "015", "000")}
+    result = await _coordinator(api, data)._async_update_data()
+
+    assert set(result) == {"ac", "wm"}
+    assert result["ac"] is not None and result["ac"].electric_total == 2.0
+    assert api.air_duct_calls == 1
+    assert api.consumption_calls == 1
+
+
+async def test_coordinator_auth_error_breaks_remaining_devices():
+    # AC fetched first and raises auth error -> loop breaks before the washing machine.
+    api = _FakeApi(air_duct_exc=LifeConnectAuthError("token rejected"))
+    data = {"ac": _appliance("ac", "009", "100"), "wm": _appliance("wm", "015", "000")}
+    result = await _coordinator(api, data)._async_update_data()
+
+    assert result == {}
+    assert api.air_duct_calls == 1
+    assert api.consumption_calls == 0  # never reached
+
+
+async def test_coordinator_generic_error_yields_none_and_continues():
+    api = _FakeApi(
+        air_duct_exc=ValueError("boom"),
+        consumption=SimpleNamespace(
+            electric_curve={_today_key(): "1.0"}, water_curve={}
+        ),
+    )
+    data = {"ac": _appliance("ac", "009", "100"), "wm": _appliance("wm", "015", "000")}
+    result = await _coordinator(api, data)._async_update_data()
+
+    assert result["ac"] is None  # generic error -> None, not a break
+    assert result["wm"] is not None and result["wm"].electric_curve  # later device still fetched
+    assert api.consumption_calls == 1
+
+
+async def test_coordinator_skips_device_without_statistics_source():
+    api = _FakeApi()
+    data = {"x": _appliance("x", "999", "000")}  # unmapped type -> no source
+    result = await _coordinator(api, data)._async_update_data()
+
+    assert result == {}
+    assert api.air_duct_calls == 0
+    assert api.consumption_calls == 0
+
+
+# -- sensor ----------------------------------------------------------------
+
+
+class _FakeStatsCoordinator:
+    def __init__(self, data, last_update_success=True):
+        self.data = data
+        self.last_update_success = last_update_success
+
+
+def _energy_sensor_def():
+    return ConsumptionStatisticsSource().sensors[0]  # daily_energy_kwh
+
+
+def _make_sensor(coordinator, device_id="dev1", sensor_def=None):
+    appliance_coordinator = SimpleNamespace(add_entity=lambda *a, **k: None)
+    appliance = SimpleNamespace(device_id=device_id)
+    return ConnectLifeStatisticsSensor(
+        appliance_coordinator,  # type: ignore[arg-type]
+        coordinator,  # type: ignore[arg-type]
+        appliance,  # type: ignore[arg-type]
+        sensor_def or _energy_sensor_def(),
+    )
+
+
+def test_sensor_extracts_value_and_is_available():
+    coord = _FakeStatsCoordinator(
+        {"dev1": SimpleNamespace(electric_curve={_today_key(): "1.5"})}
+    )
+    sensor = _make_sensor(coord)
+    assert sensor.native_value == 1.5
+    assert sensor.available is True
+
+
+def test_sensor_air_duct_value():
+    coord = _FakeStatsCoordinator({"dev1": SimpleNamespace(electric_total=2.0)})
+    sensor = _make_sensor(coord, sensor_def=AirDuctStatisticsSource().sensors[0])
+    assert sensor.native_value == 2.0
+    assert sensor.available is True
+
+
+def test_sensor_unavailable_when_result_none():
+    coord = _FakeStatsCoordinator({"dev1": None})
+    sensor = _make_sensor(coord)
+    assert sensor.native_value is None
+    assert sensor.available is False
+
+
+def test_sensor_unavailable_when_device_missing():
+    coord = _FakeStatsCoordinator({})
+    sensor = _make_sensor(coord)
+    assert sensor.native_value is None
+    assert sensor.available is False
+
+
+def test_sensor_unavailable_when_last_update_failed():
+    coord = _FakeStatsCoordinator(
+        {"dev1": SimpleNamespace(electric_curve={_today_key(): "1.5"})},
+        last_update_success=False,
+    )
+    sensor = _make_sensor(coord)
+    assert sensor.available is False

--- a/uv.lock
+++ b/uv.lock
@@ -556,15 +556,15 @@ wheels = [
 
 [[package]]
 name = "connectlife"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/3f/48f9c946e7c3389f1f232eaba45e0ca31972ca86681168fab40daa89bcd5/connectlife-0.8.0.tar.gz", hash = "sha256:9d798249d99afcb9db6cd02f943afcfd77779c5373bd40f10eb8dc3b55a3578b", size = 151251 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/6c/97aff6f6757cb376da2f0d1d6c5d4e5e1d65b6b923280b76e3e2e236b412/connectlife-0.9.0.tar.gz", hash = "sha256:f0d2c6cfa27922d0760f3bffc6ded803421198659c4fd65245a715e8352e4a45", size = 155217 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/c9/c45d130ec02f71f3976b1a31f1a38979c2730448adb7e0afcea7ec026829/connectlife-0.8.0-py3-none-any.whl", hash = "sha256:b26841385211946c1b53907472fdf80999f6986080c6dedba4f4c7c06d818deb", size = 41886 },
+    { url = "https://files.pythonhosted.org/packages/5f/95/d8fc53151b5ebd9865794e325f8bacdce658ebbf18f2239bad23a2f5dc30/connectlife-0.9.0-py3-none-any.whl", hash = "sha256:dce7e63952525892801768096e63c65612d80d853577df210855d942eb6d8fca", size = 45713 },
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "connectlife", specifier = "==0.8.0" }]
+requires-dist = [{ name = "connectlife", specifier = "==0.9.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Expose **daily energy** (kWh) and, for wet appliances, **daily water consumption** (L) sensors sourced from the ConnectLife cloud statistics endpoints, instead of from `status_list` (which devices report as `0`).

- A second coordinator (`ConnectLifeEnergyCoordinator`) polls `air_duct_energy` for air conditioners and `energyConsumptionCurve` for other appliances every 10 minutes.
- Unlike status entities, these stay available while the appliance is offline (the data is cloud-side).
- Requires `connectlife==0.9.0`.

## Mapping configuration

Device types opt in through a top-level `statistics` block in their **base** data-dictionary file (e.g. `015.yaml`), not in feature overrides. Omit the block for device types with no statistics endpoint.

| Field | Values | Meaning |
|-------|--------|---------|
| `source` | `air_duct_energy` \| `energy_consumption_curve` | Which cloud endpoint to poll. `air_duct_energy` for air conditioners; `energy_consumption_curve` for other appliances. **Required.** |
| `daily_energy_kwh` | `true` / `false` | Create the daily energy sensor (kWh). Defaults to `false`. |
| `daily_water_consumption` | `true` / `false` | Create the daily water consumption sensor (L), for wet appliances. Defaults to `false`. |

Both sensor flags default to off, so each must be explicitly set to `true`. `daily_water_consumption` is only meaningful for `energy_consumption_curve`.

Example (dishwasher):

```yaml
# 015.yaml (base)
statistics:
  source: energy_consumption_curve
  daily_energy_kwh: true
  daily_water_consumption: true
```

Example (air conditioner):

```yaml
# 009.yaml (base)
statistics:
  source: air_duct_energy
  daily_energy_kwh: true
```

### Device types configured in this PR

- **`air_duct_energy`** (energy only): `006`, `008`, `009`
- **`energy_consumption_curve`** (energy + water): `003`, `015`, `025`, `027`
- **`energy_consumption_curve`** (energy only): `004`, `007`, `010`, `012`, `013`, `016`, `020`, `023`, `026`, `030`, `032`

## Implementation

- Parsed in `dictionaries.py` onto `Dictionary.statistics_source` / `Dictionary.statistics_sensors`; schema in `properties-schema.json`.
- `statistics_sources.py` maps each `source` to its endpoint fetch and `StatisticsSensorDef`s; `enabled_sensors()` returns only the explicitly-enabled defs.
- `__init__.py` creates the energy coordinator only when at least one appliance has an enabled statistics sensor.
- On `LifeConnectAuthError` the coordinator stops the cycle rather than re-logging in per appliance.

## Docs

`statistics` block in the data-dictionary authoring guide, a feature section in the README, and architecture notes in `CLAUDE.md`.

Closes #318
Closes #390
Closes #540

Note on #540: this restores the **Daily energy** value. The separate "Electricity" entity is a device *status* property — if the appliance reports it as `0`, that is device-side and unaffected by this change.