### PR TITLE
Add connectlife to manifest loggers for integration debug logging

### DIFF
--- a/custom_components/connectlife/manifest.json
+++ b/custom_components/connectlife/manifest.json
@@ -8,6 +8,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/oyvindwe/connectlife-ha/issues",
+  "loggers": ["connectlife"],
   "requirements": ["connectlife==0.9.0"],
   "version": "0.40.0"
 }


### PR DESCRIPTION
Without a loggers entry, HA's 'Enable debug logging' button only raises custom_components.connectlife; the connectlife library's request/response logs stay silent. Declaring the library logger lets the UI toggle capture the raw gateway responses, which is what's needed to debug device payloads.