### PR TITLE
Rename t_swing_angle to vertical swing angle with position labels

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -287,12 +287,12 @@ properties:
       options:
         0: swing
         1: auto
-        2: angle_1
-        3: angle_2
-        4: angle_3
-        5: angle_4
-        6: angle_5
-        7: angle_6
+        2: bottom
+        3: low
+        4: mid_low
+        5: mid_high
+        6: high
+        7: top
     icon: mdi:arrow-oscillating
   - property: t_swing_direction
     climate:

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -355,12 +355,12 @@ properties:
       options:
         0: swing
         1: auto
-        2: angle_1
-        3: angle_2
-        4: angle_3
-        5: angle_4
-        6: angle_5
-        7: angle_6
+        2: bottom
+        3: low
+        4: mid_low
+        5: mid_high
+        6: high
+        7: top
     icon: mdi:arrow-oscillating
   - property: t_swing_direction
     climate:

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2729,16 +2729,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Swing angle",
+        "name": "Vertical swing angle",
         "state": {
-          "angle_1": "Angle 1",
-          "angle_2": "Angle 2",
-          "angle_3": "Angle 3",
-          "angle_4": "Angle 4",
-          "angle_5": "Angle 5",
-          "angle_6": "Angle 6",
           "auto": "Auto",
-          "swing": "Swing"
+          "bottom": "Bottom",
+          "high": "High",
+          "low": "Low",
+          "mid_high": "Mid-High",
+          "mid_low": "Mid-Low",
+          "swing": "Swing",
+          "top": "Top"
         }
       },
       "t_swing_follow": {

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1832,16 +1832,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Schwenkwinkel",
+        "name": "Vertikaler Schwenkwinkel",
         "state": {
-          "angle_1": "Winkel 1",
-          "angle_2": "Winkel 2",
-          "angle_3": "Winkel 3",
-          "angle_4": "Winkel 4",
-          "angle_5": "Winkel 5",
-          "angle_6": "Winkel 6",
           "auto": "Automatisch",
-          "swing": "Schwenken"
+          "bottom": "Unten",
+          "high": "Hoch",
+          "low": "Niedrig",
+          "mid_high": "Mittelhoch",
+          "mid_low": "Mittelniedrig",
+          "swing": "Schwenken",
+          "top": "Oben"
         }
       },
       "t_swing_follow": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2729,16 +2729,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Swing angle",
+        "name": "Vertical swing angle",
         "state": {
-          "angle_1": "Angle 1",
-          "angle_2": "Angle 2",
-          "angle_3": "Angle 3",
-          "angle_4": "Angle 4",
-          "angle_5": "Angle 5",
-          "angle_6": "Angle 6",
           "auto": "Auto",
-          "swing": "Swing"
+          "bottom": "Bottom",
+          "high": "High",
+          "low": "Low",
+          "mid_high": "Mid-High",
+          "mid_low": "Mid-Low",
+          "swing": "Swing",
+          "top": "Top"
         }
       },
       "t_swing_follow": {

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -814,16 +814,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Modo balanceo",
+        "name": "\u00c1ngulo de oscilaci\u00f3n vertical",
         "state": {
-          "angle_1": "Anglulo 1",
-          "angle_2": "Anglulo 2",
-          "angle_3": "Anglulo 3",
-          "angle_4": "Anglulo 4",
-          "angle_5": "Anglulo 5",
-          "angle_6": "Anglulo 6",
           "auto": "Auto",
-          "swing": "balanceo"
+          "bottom": "Abajo",
+          "high": "Alto",
+          "low": "Bajo",
+          "mid_high": "Medio-alto",
+          "mid_low": "Medio-bajo",
+          "swing": "balanceo",
+          "top": "Arriba"
         }
       },
       "t_swing_follow": {

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -254,16 +254,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Flusso d'aria",
+        "name": "Angolo di oscillazione verticale",
         "state": {
-          "angle_1": "Posizione 1",
-          "angle_2": "Posizione 2",
-          "angle_3": "Posizione 3",
-          "angle_4": "Posizione 4",
-          "angle_5": "Posizione 5",
-          "angle_6": "Posizione 6",
           "auto": "Auto",
-          "swing": "Oscillazione"
+          "bottom": "In basso",
+          "high": "Alto",
+          "low": "Basso",
+          "mid_high": "Medio-alto",
+          "mid_low": "Medio-basso",
+          "swing": "Oscillazione",
+          "top": "In alto"
         }
       },
       "t_swing_follow": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -2359,16 +2359,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Zwenkhoek",
+        "name": "Verticale zwenkhoek",
         "state": {
-          "angle_1": "Hoek 1",
-          "angle_2": "Hoek 2",
-          "angle_3": "Hoek 3",
-          "angle_4": "Hoek 4",
-          "angle_5": "Hoek 5",
-          "angle_6": "Hoek 6",
           "auto": "Automatisch",
-          "swing": "Zwaaien"
+          "bottom": "Onder",
+          "high": "Hoog",
+          "low": "Laag",
+          "mid_high": "Midden-hoog",
+          "mid_low": "Midden-laag",
+          "swing": "Zwaaien",
+          "top": "Boven"
         }
       },
       "t_swing_follow": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -2359,16 +2359,16 @@
         }
       },
       "t_swing_angle": {
-        "name": "Svingvinkel",
+        "name": "Vertikal svingvinkel",
         "state": {
-          "angle_1": "Vinkel 1",
-          "angle_2": "Vinkel 2",
-          "angle_3": "Vinkel 3",
-          "angle_4": "Vinkel 4",
-          "angle_5": "Vinkel 5",
-          "angle_6": "Vinkel 6",
           "auto": "Auto",
-          "swing": "Sving"
+          "bottom": "Nederst",
+          "high": "H\u00f8y",
+          "low": "Lav",
+          "mid_high": "Middels h\u00f8y",
+          "mid_low": "Middels lav",
+          "swing": "Sving",
+          "top": "\u00d8verst"
         }
       },
       "t_swing_follow": {


### PR DESCRIPTION
Addresses points 1 and 2 of #562.

The `t_swing_angle` select on air conditioners (006, 009 families) is always the vertical louver angle, but was labelled generically as "Swing angle" with "Angle 1"…"Angle 6" options.

Changes:
- Rename the entity to **"Vertical swing angle"**.
- Replace the `angle_1`…`angle_6` option keys with the physical positions `bottom` / `low` / `mid_low` / `mid_high` / `high` / `top` (`swing`/`auto` unchanged).
- Regenerate `en.json` and add translations for de/es/it/nl/no.
