### PR TITLE
Add device 007-499 (Hisense HD5026TLP dehumidifier)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -17,6 +17,7 @@
 |                          | Dehumidifier             | 007              | 407                         |
 |                          | Dehumidifier             | 007              | 408                         |
 |                          | Dehumidifier             | 007              | 409                         |
+| Hisense HD5026TLP        | Dehumidifier             | 007              | 499                         |
 |                          | Air conditioner          | 008              | 300                         |
 |                          | Air conditioner          | 008              | 301                         |
 |                          | Air conditioner          | 008              | 302                         |

--- a/custom_components/connectlife/data_dictionaries/007-499.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-499.yaml
@@ -1,2 +1,14 @@
-# Dehumidifier — HiSense HD5026TLP (Matter-bridged)
-# Uses default mappings
+# Dehumidifier — HiSense HD5026TLP (Matter-bridged); no auto fan speed, no clothes-dry mode
+properties:
+  - property: t_fan_speed
+    select:
+      options:
+        0: low
+        1: high
+        3: medium
+  - property: t_work_mode
+    humidifier:
+      options:
+        0: continuous
+        1: manual
+        2: auto

--- a/custom_components/connectlife/data_dictionaries/007-499.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-499.yaml
@@ -1,0 +1,2 @@
+# Dehumidifier — HiSense HD5026TLP (Matter-bridged)
+# Uses default mappings

--- a/custom_components/connectlife/data_dictionaries/007.yaml
+++ b/custom_components/connectlife/data_dictionaries/007.yaml
@@ -3,7 +3,31 @@ statistics:
   source: energy_consumption_curve
   daily_energy_kwh: true
 properties:
+  - property: f_e_drive
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_e_eeprom
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
   - property: f_e_filterclean
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_e_incom
     binary_sensor:
       device_class: problem
       options:
@@ -77,6 +101,21 @@ properties:
   - property: f_humidity
     humidifier:
       target: current_humidity
+  - property: f_matterOriginalProductId
+    sensor:
+      read_only: true
+    optional: true
+    entity_category: diagnostic
+  - property: f_matterOriginalVendorId
+    sensor:
+      read_only: true
+    optional: true
+    entity_category: diagnostic
+  - property: f_matterUniqueId
+    sensor:
+      read_only: true
+    optional: true
+    entity_category: diagnostic
   - property: f_power_consumption
     sensor:
       device_class: energy
@@ -98,6 +137,11 @@ properties:
       state_class: measurement
     optional: true
     entity_category: diagnostic
+  - property: t_anion
+    switch:
+      device_class: switch
+    icon: mdi:air-purifier
+    optional: true
   - property: t_beep
     binary_sensor:
       options:

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -841,8 +841,14 @@
       "f_e_arkgrille": {
         "name": "Cabinet grille protection alarm"
       },
+      "f_e_drive": {
+        "name": "Drive"
+      },
       "f_e_dwmachine": {
         "name": "Lower machine failure"
+      },
+      "f_e_eeprom": {
+        "name": "EEPROM"
       },
       "f_e_filterclean": {
         "name": "Filter clean"
@@ -8687,6 +8693,9 @@
       },
       "t_air": {
         "name": "Air"
+      },
+      "t_anion": {
+        "name": "Ioniser"
       },
       "t_dal": {
         "name": "DAL"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -841,8 +841,14 @@
       "f_e_arkgrille": {
         "name": "Cabinet grille protection alarm"
       },
+      "f_e_drive": {
+        "name": "Drive"
+      },
       "f_e_dwmachine": {
         "name": "Lower machine failure"
+      },
+      "f_e_eeprom": {
+        "name": "EEPROM"
       },
       "f_e_filterclean": {
         "name": "Filter clean"
@@ -8687,6 +8693,9 @@
       },
       "t_air": {
         "name": "Air"
+      },
+      "t_anion": {
+        "name": "Ioniser"
       },
       "t_dal": {
         "name": "DAL"


### PR DESCRIPTION
Adds a mapping for the Hisense HD5026TLP dehumidifier (`007-499`), a Matter-bridged model reported in #546.

New properties hoisted into the default `007.yaml` mapping (ignored by variants that don't expose them):

- `f_e_drive`, `f_e_eeprom` — fault flags (`binary_sensor`, `problem`)
- `f_e_incom` — communication fault flag (`binary_sensor`, `problem`)
- `f_matterOriginalProductId` / `VendorId` / `UniqueId` — Matter identifiers (diagnostic sensors)
- `t_anion` — ioniser on/off (`switch`)

`007-499.yaml` narrows the fan-speed and operating-mode option sets to what this model actually offers (confirmed by users in #546):

- fan speed: Low / High / Medium (no Auto)
- mode: Continuous / Manual / Auto (no clothes-dry)

Note: no ioniser control is surfaced in the app or manual for this model, but `t_anion` is retained as a switch.

Closes #546