### PR TITLE
Expose vertical swing angle in the climate card (#562)

### DIFF
--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -148,7 +148,14 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
 
         for dd_entry in data_dictionary.properties.values():
             if hasattr(dd_entry, Platform.CLIMATE) and dd_entry.name in appliance.status_list and dd_entry.climate.target is not None:
-                self.target_map[dd_entry.climate.target] = dd_entry.name
+                target = dd_entry.climate.target
+                if target in self.target_map:
+                    _LOGGER.warning(
+                        "%s and %s both map to climate %s for %s; using %s. "
+                        "The device exposes more properties than its mapping expects — please report it.",
+                        self.target_map[target], dd_entry.name, target, self.nickname, dd_entry.name,
+                    )
+                self.target_map[target] = dd_entry.name
 
         hvac_modes: list[HVACMode] = []
         for target, status in self.target_map.items():

--- a/custom_components/connectlife/data_dictionaries/006-201.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-201.yaml
@@ -1,1 +1,10 @@
 # Portable air conditioner — uses default mappings
+properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"

--- a/custom_components/connectlife/data_dictionaries/006-202.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-202.yaml
@@ -1,5 +1,13 @@
 # Portable air conditioner — cool-only (no heat mode)
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/006-203.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-203.yaml
@@ -1,1 +1,10 @@
 # Portable air conditioner — uses default mappings
+properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -283,7 +283,8 @@ properties:
       device_class: switch
     icon: mdi:run-fast
   - property: t_swing_angle
-    select:
+    climate:
+      target: swing_mode
       options:
         0: swing
         1: auto
@@ -293,7 +294,6 @@ properties:
         5: mid_high
         6: high
         7: top
-    icon: mdi:arrow-oscillating
   - property: t_swing_direction
     climate:
       target: swing_horizontal_mode
@@ -355,11 +355,9 @@ properties:
     switch:
       device_class: switch
   - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
+    switch:
+      device_class: switch
+    icon: mdi:arrow-oscillating
   - property: t_work_mode
     climate:
       target: hvac_mode

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -286,6 +286,7 @@ properties:
     climate:
       target: swing_mode
       options:
+        # Ordered logically, not by key
         0: swing
         1: auto
         7: top
@@ -298,6 +299,7 @@ properties:
     climate:
       target: swing_horizontal_mode
       options:
+        # Ordered logically, not by key
         3: swing
         2: both_sides
         4: left

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -288,21 +288,21 @@ properties:
       options:
         0: swing
         1: auto
-        2: bottom
-        3: low
-        4: mid_low
-        5: mid_high
-        6: high
         7: top
+        6: high
+        5: mid_high
+        4: mid_low
+        3: low
+        2: bottom
   - property: t_swing_direction
     climate:
       target: swing_horizontal_mode
       options:
+        3: swing
+        2: both_sides
+        4: left
         0: forward
         1: right
-        2: both_sides
-        3: swing
-        4: left
   - property: t_swing_follow
     select:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-100.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-100.yaml
@@ -70,3 +70,12 @@ climate:
       t_sleep: 4
       t_super: 0
       preset: eco_sleep_4
+properties:
+  # This device exposes only t_up_down (no t_swing_angle), so map it to the
+  # vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009-101.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-101.yaml
@@ -1,4 +1,12 @@
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-102.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-102.yaml
@@ -1,1 +1,10 @@
 # No overrides needed; all properties covered by default 009.yaml.
+properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009-103.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-103.yaml
@@ -1,4 +1,12 @@
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -77,3 +77,11 @@ properties:
       state_class: measurement
       unit: kW
       multiplier: 0.1
+  # This device exposes only t_up_down (no t_swing_angle), so map it to the
+  # vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009-105.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-105.yaml
@@ -72,6 +72,14 @@ climate:
       t_fan_mute: 0
       t_super: 0
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-107.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-107.yaml
@@ -1,4 +1,12 @@
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-120.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-120.yaml
@@ -1,4 +1,12 @@
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_temp
     climate:
       max_value:

--- a/custom_components/connectlife/data_dictionaries/009-121.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-121.yaml
@@ -1,5 +1,13 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-122.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-122.yaml
@@ -1,5 +1,13 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-125.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-125.yaml
@@ -1,5 +1,13 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-126.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-126.yaml
@@ -1,5 +1,13 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-127.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-127.yaml
@@ -1,4 +1,12 @@
 properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
   - property: t_temp
     climate:
       max_value:

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -8,3 +8,12 @@ climate:
       t_fan_speed: 0 # auto
       t_power: 1
       preset: mute
+properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -356,21 +356,21 @@ properties:
       options:
         0: swing
         1: auto
-        2: bottom
-        3: low
-        4: mid_low
-        5: mid_high
-        6: high
         7: top
+        6: high
+        5: mid_high
+        4: mid_low
+        3: low
+        2: bottom
   - property: t_swing_direction
     climate:
       target: swing_horizontal_mode
       options:
+        3: swing
+        2: both_sides
+        4: left
         0: forward
         1: right
-        2: both_sides
-        3: swing
-        4: left
   - property: t_up_down
     switch:
       device_class: switch

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -351,7 +351,8 @@ properties:
         2: not_follow
     icon: mdi:account-arrow-right
   - property: t_swing_angle
-    select:
+    climate:
+      target: swing_mode
       options:
         0: swing
         1: auto
@@ -361,7 +362,6 @@ properties:
         5: mid_high
         6: high
         7: top
-    icon: mdi:arrow-oscillating
   - property: t_swing_direction
     climate:
       target: swing_horizontal_mode
@@ -372,11 +372,9 @@ properties:
         3: swing
         4: left
   - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
+    switch:
+      device_class: switch
+    icon: mdi:arrow-oscillating
   - property: t_temp
     climate:
       target: target_temperature

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -354,6 +354,7 @@ properties:
     climate:
       target: swing_mode
       options:
+        # Ordered logically, not by key
         0: swing
         1: auto
         7: top
@@ -366,6 +367,7 @@ properties:
     climate:
       target: swing_horizontal_mode
       options:
+        # Ordered logically, not by key
         3: swing
         2: both_sides
         4: left

--- a/custom_components/connectlife/humidifier.py
+++ b/custom_components/connectlife/humidifier.py
@@ -88,7 +88,14 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
 
         for dd_entry in data_dictionary.properties.values():
             if hasattr(dd_entry, Platform.HUMIDIFIER) and dd_entry.name in appliance.status_list and dd_entry.humidifier.target is not None:
-                self.target_map[dd_entry.humidifier.target] = dd_entry.name
+                target = dd_entry.humidifier.target
+                if target in self.target_map:
+                    _LOGGER.warning(
+                        "%s and %s both map to humidifier %s for %s; using %s. "
+                        "The device exposes more properties than its mapping expects — please report it.",
+                        self.target_map[target], dd_entry.name, target, self.nickname, dd_entry.name,
+                    )
+                self.target_map[target] = dd_entry.name
 
         for target, status in self.target_map.items():
             if target == ACTION:

--- a/custom_components/connectlife/icons.json
+++ b/custom_components/connectlife/icons.json
@@ -11,8 +11,20 @@
           },
           "swing_mode": {
             "state": {
-              "both_sides": "mdi:arrow-left-right",
-              "forward": "mdi:arrow-down",
+              "auto": "mdi:autorenew",
+              "bottom": "mdi:chevron-double-down",
+              "high": "mdi:chevron-up",
+              "low": "mdi:chevron-down",
+              "mid_high": "mdi:menu-up",
+              "mid_low": "mdi:menu-down",
+              "swing": "mdi:arrow-oscillating",
+              "top": "mdi:chevron-double-up"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "both_sides": "mdi:arrow-expand-horizontal",
+              "forward": "mdi:arrow-up",
               "left": "mdi:arrow-left",
               "right": "mdi:arrow-right",
               "swing": "mdi:arrow-oscillating"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1893,7 +1893,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Auto",
+              "bottom": "Bottom",
+              "high": "High",
+              "low": "Low",
+              "mid_high": "Mid-High",
+              "mid_low": "Mid-Low",
+              "swing": "Swing",
+              "top": "Top"
+            }
           }
         }
       }
@@ -2726,19 +2735,6 @@
           "for_young": "For young",
           "general": "General",
           "off": "Off"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Vertical swing angle",
-        "state": {
-          "auto": "Auto",
-          "bottom": "Bottom",
-          "high": "High",
-          "low": "Low",
-          "mid_high": "Mid-High",
-          "mid_low": "Mid-Low",
-          "swing": "Swing",
-          "top": "Top"
         }
       },
       "t_swing_follow": {
@@ -8729,6 +8725,9 @@
       },
       "t_tms": {
         "name": "AI"
+      },
+      "t_up_down": {
+        "name": "Vertical swing"
       },
       "tab_setting_status": {
         "name": "Detergent TAB"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1173,7 +1173,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Automatisch",
+              "bottom": "Unten",
+              "high": "Hoch",
+              "low": "Niedrig",
+              "mid_high": "Mittelhoch",
+              "mid_low": "Mittelniedrig",
+              "swing": "Schwenken",
+              "top": "Oben"
+            }
           }
         }
       }
@@ -1829,19 +1838,6 @@
           "for_young": "F\u00fcr junge Menschen",
           "general": "Allgemein",
           "off": "Aus"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Vertikaler Schwenkwinkel",
-        "state": {
-          "auto": "Automatisch",
-          "bottom": "Unten",
-          "high": "Hoch",
-          "low": "Niedrig",
-          "mid_high": "Mittelhoch",
-          "mid_low": "Mittelniedrig",
-          "swing": "Schwenken",
-          "top": "Oben"
         }
       },
       "t_swing_follow": {
@@ -3814,6 +3810,9 @@
       },
       "t_tms": {
         "name": "KI"
+      },
+      "t_up_down": {
+        "name": "Vertikales Schwenken"
       },
       "tab_setting_status": {
         "name": "Tab-Einstellung"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1893,7 +1893,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Auto",
+              "bottom": "Bottom",
+              "high": "High",
+              "low": "Low",
+              "mid_high": "Mid-High",
+              "mid_low": "Mid-Low",
+              "swing": "Swing",
+              "top": "Top"
+            }
           }
         }
       }
@@ -2726,19 +2735,6 @@
           "for_young": "For young",
           "general": "General",
           "off": "Off"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Vertical swing angle",
-        "state": {
-          "auto": "Auto",
-          "bottom": "Bottom",
-          "high": "High",
-          "low": "Low",
-          "mid_high": "Mid-High",
-          "mid_low": "Mid-Low",
-          "swing": "Swing",
-          "top": "Top"
         }
       },
       "t_swing_follow": {
@@ -8729,6 +8725,9 @@
       },
       "t_tms": {
         "name": "AI"
+      },
+      "t_up_down": {
+        "name": "Vertical swing"
       },
       "tab_setting_status": {
         "name": "Detergent TAB"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -608,7 +608,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Auto",
+              "bottom": "Abajo",
+              "high": "Alto",
+              "low": "Bajo",
+              "mid_high": "Medio-alto",
+              "mid_low": "Medio-bajo",
+              "swing": "balanceo",
+              "top": "Arriba"
+            }
           }
         }
       }
@@ -811,19 +820,6 @@
           "for_young": "Para jovenes",
           "general": "General",
           "off": "Apagado"
-        }
-      },
-      "t_swing_angle": {
-        "name": "\u00c1ngulo de oscilaci\u00f3n vertical",
-        "state": {
-          "auto": "Auto",
-          "bottom": "Abajo",
-          "high": "Alto",
-          "low": "Bajo",
-          "mid_high": "Medio-alto",
-          "mid_low": "Medio-bajo",
-          "swing": "balanceo",
-          "top": "Arriba"
         }
       },
       "t_swing_follow": {
@@ -1637,6 +1633,9 @@
       },
       "t_tms": {
         "name": "AI"
+      },
+      "t_up_down": {
+        "name": "Oscilaci\u00f3n vertical"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -212,7 +212,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Auto",
+              "bottom": "In basso",
+              "high": "Alto",
+              "low": "Basso",
+              "mid_high": "Medio-alto",
+              "mid_low": "Medio-basso",
+              "swing": "Oscillazione",
+              "top": "In alto"
+            }
           }
         }
       }
@@ -251,19 +260,6 @@
           "for_young": "Per Giovani",
           "general": "Generale",
           "off": "Spento"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Angolo di oscillazione verticale",
-        "state": {
-          "auto": "Auto",
-          "bottom": "In basso",
-          "high": "Alto",
-          "low": "Basso",
-          "mid_high": "Medio-alto",
-          "mid_low": "Medio-basso",
-          "swing": "Oscillazione",
-          "top": "In alto"
         }
       },
       "t_swing_follow": {
@@ -627,6 +623,9 @@
       },
       "t_tms": {
         "name": "AI"
+      },
+      "t_up_down": {
+        "name": "Oscillazione verticale"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1598,7 +1598,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Automatisch",
+              "bottom": "Onder",
+              "high": "Hoog",
+              "low": "Laag",
+              "mid_high": "Midden-hoog",
+              "mid_low": "Midden-laag",
+              "swing": "Zwaaien",
+              "top": "Boven"
+            }
           }
         }
       }
@@ -2356,19 +2365,6 @@
           "for_young": "Voor jongeren",
           "general": "Algemeen",
           "off": "Uit"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Verticale zwenkhoek",
-        "state": {
-          "auto": "Automatisch",
-          "bottom": "Onder",
-          "high": "Hoog",
-          "low": "Laag",
-          "mid_high": "Midden-hoog",
-          "mid_low": "Midden-laag",
-          "swing": "Zwaaien",
-          "top": "Boven"
         }
       },
       "t_swing_follow": {
@@ -8016,6 +8012,9 @@
       },
       "t_tms": {
         "name": "AI"
+      },
+      "t_up_down": {
+        "name": "Verticaal zwenken"
       },
       "tab_setting_status": {
         "name": "Tab-instelling"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1598,7 +1598,16 @@
             }
           },
           "swing_mode": {
-            "state": {}
+            "state": {
+              "auto": "Auto",
+              "bottom": "Nederst",
+              "high": "H\u00f8y",
+              "low": "Lav",
+              "mid_high": "Middels h\u00f8y",
+              "mid_low": "Middels lav",
+              "swing": "Sving",
+              "top": "\u00d8verst"
+            }
           }
         }
       }
@@ -2356,19 +2365,6 @@
           "for_young": "For ungdom",
           "general": "Generell",
           "off": "Av"
-        }
-      },
-      "t_swing_angle": {
-        "name": "Vertikal svingvinkel",
-        "state": {
-          "auto": "Auto",
-          "bottom": "Nederst",
-          "high": "H\u00f8y",
-          "low": "Lav",
-          "mid_high": "Middels h\u00f8y",
-          "mid_low": "Middels lav",
-          "swing": "Sving",
-          "top": "\u00d8verst"
         }
       },
       "t_swing_follow": {
@@ -8016,6 +8012,9 @@
       },
       "t_tms": {
         "name": "AI"
+      },
+      "t_up_down": {
+        "name": "Vertikal sving"
       },
       "tab_setting_status": {
         "name": "Vaskemiddel-TAB"

--- a/custom_components/connectlife/water_heater.py
+++ b/custom_components/connectlife/water_heater.py
@@ -109,7 +109,14 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
 
         for dd_entry in data_dictionary.properties.values():
             if hasattr(dd_entry, Platform.WATER_HEATER) and dd_entry.name in appliance.status_list and dd_entry.water_heater.target is not None:
-                self.target_map[dd_entry.water_heater.target] = dd_entry.name
+                target = dd_entry.water_heater.target
+                if target in self.target_map:
+                    _LOGGER.warning(
+                        "%s and %s both map to water_heater %s for %s; using %s. "
+                        "The device exposes more properties than its mapping expects — please report it.",
+                        self.target_map[target], dd_entry.name, target, self.nickname, dd_entry.name,
+                    )
+                self.target_map[target] = dd_entry.name
 
         for target, status in self.target_map.items():
             if target == IS_ON:


### PR DESCRIPTION
Addresses item (3) of #562: get the vertical swing angle into the main climate card.

## What changed

- **Map `t_swing_angle` to the climate `swing_mode` attribute** (was a standalone `select`), so the vertical swing position — `swing`/`auto` plus six fixed angles (bottom…top) — shows in the main climate card instead of only the device view.
- **`t_up_down` now defaults to a `switch`.** Featuresets that expose only `t_up_down` (no `t_swing_angle`) override it back to `swing_mode`, so they keep an on/off vertical swing control in the card.
- **On devices that expose both**, `t_swing_angle` takes the single HA `swing_mode` slot and `t_up_down` is shown as a switch — avoiding a collision on the one `swing_mode` control.
- **Icons**: added state icons for the vertical `swing_mode` positions, and moved the horizontal direction icons (`forward`/`left`/`right`/`both_sides`/`swing`) to the `swing_horizontal_mode` attribute, where they actually apply (they were previously filed under `swing_mode` and didn't render).
- Regenerated `strings.json` and translations (de/en/es/it/nl/no), carrying over the existing angle-label translations and naming the new `t_up_down` switch.

## Which devices get the override

`t_up_down` → `swing_mode` is applied to up_down-only featuresets:
- 009-100, 009-104, 009-101/102/103/105/107/120/121/122/125/126/127/128, 006-201/202/203

Featuresets that are known to report both (e.g. 009-106, 009-109, 006-200) keep the base mapping, so the angle wins the climate control and `t_up_down` appears as a switch.

## Verification

- `uv run python -m scripts.validate_mappings` passes.
- `uv run python -m scripts.gen_strings` is idempotent after the change.
- `swing_mode` resolution checked against the available device dumps: up_down-only devices resolve to `t_up_down` (on/off); both-devices resolve to `t_swing_angle` (positions) with `t_up_down` as a switch.
