### PR TITLE
Set units on refrigerator compressor frequency and voltage sensors

### DIFF
--- a/custom_components/connectlife/data_dictionaries/026.yaml
+++ b/custom_components/connectlife/data_dictionaries/026.yaml
@@ -99,6 +99,8 @@ properties:
   - property: compressor_frequency
     optional: true
     sensor:
+      device_class: frequency
+      unit: Hz
       state_class: measurement
   - property: condensation_fan_failure_status
     hide: true
@@ -699,6 +701,8 @@ properties:
   - property: power_voltage
     optional: true
     sensor:
+      device_class: voltage
+      unit: V
       state_class: measurement
   - property: quiet_mode_status
     optional: true


### PR DESCRIPTION
Adds `device_class`/`unit` to two sensors in the 026 refrigerator mapping that previously had only `state_class` and rendered as bare numbers:

- `compressor_frequency` → `frequency` / **Hz**
- `power_voltage` → `voltage` / **V**

Related to #350 (request for sensor units on type 026 fridges).

**Caveat:** both properties read `0` in the dumps available (compressor off / not reporting), so the 1:1 encoding is unconfirmed. Hz is the standard convention for inverter-compressor frequency (typical running range ~10–120 Hz); if a device reports values in the thousands it would actually be rpm. Worth confirming against a live reading.