### PR TITLE
Add device_name placeholder to translated configure_device descriptions (#573)

### DIFF
--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -3874,7 +3874,7 @@
         "data": {
           "disable_beep": "Signalton deaktivieren"
         },
-        "description": "Ein Ger\u00e4t konfigurieren."
+        "description": "{device_name} konfigurieren."
       },
       "init": {
         "data": {

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -1685,7 +1685,7 @@
         "data": {
           "disable_beep": "Deshabilitar beep"
         },
-        "description": "Configurar un dispositivo."
+        "description": "Configurar {device_name}."
       },
       "init": {
         "data": {

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -1254,7 +1254,7 @@
         "data": {
           "disable_beep": "D\u00e9sactiver le bip"
         },
-        "description": "Configurer un appareil."
+        "description": "Configurer {device_name}."
       },
       "init": {
         "data": {

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -651,7 +651,7 @@
         "data": {
           "disable_beep": "Disattiva beep"
         },
-        "description": "Configura un dispositivo."
+        "description": "Configura {device_name}."
       },
       "init": {
         "data": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -8123,7 +8123,7 @@
         "data": {
           "disable_beep": "Pieptoon uitschakelen"
         },
-        "description": "Configureer een apparaat."
+        "description": "{device_name} configureren."
       },
       "init": {
         "data": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -8123,7 +8123,7 @@
         "data": {
           "disable_beep": "Deaktiver pip"
         },
-        "description": "Konfigurer en enhet."
+        "description": "Konfigurer {device_name}."
       },
       "init": {
         "data": {


### PR DESCRIPTION
## Summary

Fixes #573.

The English source string for the options flow was changed to `Configure {device_name}.` (placeholder supplied at `config_flow.py:283`), but the six non-English translations still read "Configure a device." with no placeholder. Home Assistant 2026.6.0 validates that each localized string contains the same placeholders as the source, so it logged:

```
Validation of translation placeholders for localized (it) string
component.connectlife.options.step.configure_device.description failed: (set() != {'device_name'})
```

The reporter saw this for `it`, but all six non-English locales (de/es/fr/it/nl/no) were affected.

## Changes

Added the `{device_name}` placeholder to `options.step.configure_device.description` in each translation:

| File | New string |
|------|-----------|
| de.json | `{device_name} konfigurieren.` |
| es.json | `Configurar {device_name}.` |
| fr.json | `Configurer {device_name}.` |
| it.json | `Configura {device_name}.` |
| nl.json | `{device_name} configureren.` |
| no.json | `Konfigurer {device_name}.` |

The `init.description` strings are intentionally left without a placeholder, matching the English source.