### PR TITLE
Expose 007-499 dehumidifier pump as a read-only binary sensor

### DIFF
--- a/custom_components/connectlife/data_dictionaries/007-499.yaml
+++ b/custom_components/connectlife/data_dictionaries/007-499.yaml
@@ -6,6 +6,16 @@ properties:
         0: low
         1: high
         3: medium
+  - property: t_pump
+    # Exposed read-only rather than as a switch: on this model the pump appears
+    # to run automatically whenever the unit moves water (to the tank or through
+    # a drain hose), with no documented way to control it. Toggling produced only
+    # an acknowledgement beep with no confirmed effect, so a writable switch would
+    # be misleading and potentially harmful if changed by accident.
+    binary_sensor:
+      options:
+        0: off
+        1: on
   - property: t_work_mode
     humidifier:
       options:

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1814,6 +1814,9 @@
       "t_beep": {
         "name": "Beep"
       },
+      "t_pump": {
+        "name": "Pump"
+      },
       "test_mode": {
         "name": "Test mode"
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1814,6 +1814,9 @@
       "t_beep": {
         "name": "Beep"
       },
+      "t_pump": {
+        "name": "Pump"
+      },
       "test_mode": {
         "name": "Test mode"
       },

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1509,6 +1509,9 @@
       "t_beep": {
         "name": "Piep"
       },
+      "t_pump": {
+        "name": "Pomp"
+      },
       "test_mode": {
         "name": "Testmodus"
       },

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1509,6 +1509,9 @@
       "t_beep": {
         "name": "Pip"
       },
+      "t_pump": {
+        "name": "Pumpe"
+      },
       "test_mode": {
         "name": "Testmodus"
       },


### PR DESCRIPTION
Follow-up to #546. A user reports that on the Hisense HD5026TLP (`007-499`) the pump appears to run automatically whenever the unit moves water (to the tank or through a drain hose), with no documented way to control it — toggling the switch only produced an acknowledgement beep with no confirmed effect.

To avoid offering a control that does nothing useful and could be changed by accident, this overrides `t_pump` to a **read-only binary sensor** for this feature code only. The default `007.yaml` mapping keeps the switch for other variants.

Also aligns the `Pump` entity name across the en/nl/no translations (the new binary-sensor entry reuses the existing translations).