### PR TITLE
Map modes and swing for 006-299 (HIAP0825TWD)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/006-299.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-299.yaml
@@ -1,0 +1,17 @@
+# Portable air conditioner — cool-only (no heat mode)
+properties:
+  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
+  # map it to the vertical swing_mode control instead of the default switch.
+  - property: t_up_down
+    climate:
+      target: swing_mode
+      options:
+        0: "off"
+        1: "on"
+  - property: t_work_mode
+    climate:
+      options:
+        0: fan_only
+        2: cool
+        3: dry
+        4: auto


### PR DESCRIPTION
Solution for https://github.com/oyvindwe/connectlife-ha/issues/581, where Vertical Swing lost it's nesting under the Climate card on 006-299 (HIAP0825TWD). Seems it just needs a device-specific yaml. 

This model lacks Heat mode as well, setting Heat Mode via the integration will update the ConnectLife app's meter to the orange color, but the mode is not labeled and the unit falls back to fan mode. This should clean that up as well, I've tested to ensure the connectlife app reflects each of the 4 statuses once set in the integration (Auto, Fan, Cool, Dry). 

Let me know if we need additional information, thanks! 