### PR TITLE
Add start/stop buttons for 015 (dishwasher)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -2,6 +2,19 @@
 # same device that later identifies as 015-dishwasher-60.2)
 #
 # See 015-dishwasher-60.2.yaml for the per-program mode availability notes.
+# pause (Actions: 3) and open_door (Actions: 4) have no effect on this
+# firmware, so only stop and start are exposed.
+buttons:
+  - key: stop
+    icon: mdi:stop
+    write:
+      Actions: 1
+  - key: start
+    icon: mdi:play
+    available_when:
+      Remote_control_monitoring_set_commands_actions: 2
+    write:
+      Actions: 2
 properties:
   - property: Selected_program_id_status
     select:

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
@@ -1,4 +1,15 @@
-# Pelgrim GVWC330L
+# Pelgrim GVWC330L; also reported by Hisense HV673B66
+#
+# Action codes differ from other 015 variants: start is Actions: 3 (not 2),
+# and no Actions value opens the door on this firmware. Only start is exposed
+# until the remaining codes are confirmed.
+buttons:
+  - key: start
+    icon: mdi:play
+    available_when:
+      Remote_control_monitoring_set_commands_actions: 2
+    write:
+      Actions: 3
 properties:
   - property: Selected_program_id_status
     select:

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -8,6 +8,19 @@
 #
 # Modes "none", "green", "intensive", "uv", "heat_boost", "storage" were
 # never offered by this device — excluded from the select.
+# pause (Actions: 3) and open_door (Actions: 4) have no effect on this
+# firmware, so only stop and start are exposed.
+buttons:
+  - key: stop
+    icon: mdi:stop
+    write:
+      Actions: 1
+  - key: start
+    icon: mdi:play
+    available_when:
+      Remote_control_monitoring_set_commands_actions: 2
+    write:
+      Actions: 2
 properties:
   - property: Selected_program_id_status
     select:

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1878,6 +1878,14 @@
         "name": "Wine sensor failure"
       }
     },
+    "button": {
+      "start": {
+        "name": "Start"
+      },
+      "stop": {
+        "name": "Stop"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1145,6 +1145,14 @@
         "name": "Weinsensorfehler"
       }
     },
+    "button": {
+      "start": {
+        "name": "Start"
+      },
+      "stop": {
+        "name": "Stopp"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1878,6 +1878,14 @@
         "name": "Wine sensor failure"
       }
     },
+    "button": {
+      "start": {
+        "name": "Start"
+      },
+      "stop": {
+        "name": "Stop"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -590,6 +590,14 @@
         "name": "Compartimento de agua lleno"
       }
     },
+    "button": {
+      "start": {
+        "name": "Iniciar"
+      },
+      "stop": {
+        "name": "Detener"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -305,6 +305,14 @@
         "name": "D\u00e9faut sonde cave \u00e0 vin"
       }
     },
+    "button": {
+      "start": {
+        "name": "D\u00e9marrer"
+      },
+      "stop": {
+        "name": "Arr\u00eater"
+      }
+    },
     "number": {
       "delayendtime": {
         "name": "Fin diff\u00e9r\u00e9e"

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -194,6 +194,14 @@
         "name": "Beep"
       }
     },
+    "button": {
+      "start": {
+        "name": "Avvia"
+      },
+      "stop": {
+        "name": "Arresta"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1573,6 +1573,14 @@
         "name": "Wijnsensor storing"
       }
     },
+    "button": {
+      "start": {
+        "name": "Start"
+      },
+      "stop": {
+        "name": "Stop"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1573,6 +1573,14 @@
         "name": "Feil p\u00e5 vinsensor"
       }
     },
+    "button": {
+      "start": {
+        "name": "Start"
+      },
+      "stop": {
+        "name": "Stopp"
+      }
+    },
     "climate": {
       "connectlife": {
         "state_attributes": {


### PR DESCRIPTION
Exposes the write-only `Actions` command as Home Assistant buttons for dishwashers.

The `Actions` codes turned out to be firmware-specific (see #577), so the buttons live in the per-feature files rather than the base `015.yaml`:

- **015-000** and **015-dishwasher-60.2** (same device, pre/post firmware update): **stop** (`Actions: 1`) and **start** (`Actions: 2`). `pause` (3) and `open_door` (4) have no effect on this firmware and are not exposed.
- **015-dishwasher-50.2t** (Hisense HV673B66, Pelgrim GVWC330L): **start** is `Actions: 3` here, not 2, and no `Actions` value opens the door — so only **start** is exposed.

`start` is gated on remote control being enabled (`Remote_control_monitoring_set_commands_actions: 2`).

Button names (`start`/`stop`) added for all included languages: en, de, es, fr, it, nl, no.

Closes #181, #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)