### PR TITLE
Fix 015 dishwasher stop/start actions and hoist buttons to default

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-000.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-000.yaml
@@ -2,19 +2,6 @@
 # same device that later identifies as 015-dishwasher-60.2)
 #
 # See 015-dishwasher-60.2.yaml for the per-program mode availability notes.
-# pause (Actions: 3) and open_door (Actions: 4) have no effect on this
-# firmware, so only stop and start are exposed.
-buttons:
-  - key: stop
-    icon: mdi:stop
-    write:
-      Actions: 1
-  - key: start
-    icon: mdi:play
-    available_when:
-      Remote_control_monitoring_set_commands_actions: 2
-    write:
-      Actions: 2
 properties:
   - property: Selected_program_id_status
     select:

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-50.2t.yaml
@@ -1,15 +1,6 @@
 # Pelgrim GVWC330L; also reported by Hisense HV673B66
 #
-# Action codes differ from other 015 variants: start is Actions: 3 (not 2),
-# and no Actions value opens the door on this firmware. Only start is exposed
-# until the remaining codes are confirmed.
-buttons:
-  - key: start
-    icon: mdi:play
-    available_when:
-      Remote_control_monitoring_set_commands_actions: 2
-    write:
-      Actions: 3
+# stop/start buttons are inherited from the default 015 mapping.
 properties:
   - property: Selected_program_id_status
     select:

--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.2.yaml
@@ -8,19 +8,6 @@
 #
 # Modes "none", "green", "intensive", "uv", "heat_boost", "storage" were
 # never offered by this device — excluded from the select.
-# pause (Actions: 3) and open_door (Actions: 4) have no effect on this
-# firmware, so only stop and start are exposed.
-buttons:
-  - key: stop
-    icon: mdi:stop
-    write:
-      Actions: 1
-  - key: start
-    icon: mdi:play
-    available_when:
-      Remote_control_monitoring_set_commands_actions: 2
-    write:
-      Actions: 2
 properties:
   - property: Selected_program_id_status
     select:

--- a/custom_components/connectlife/data_dictionaries/015.yaml
+++ b/custom_components/connectlife/data_dictionaries/015.yaml
@@ -2,6 +2,20 @@ statistics:
   source: energy_consumption_curve
   daily_energy_kwh: true
   daily_water_consumption: true
+# stop (Actions: 1) and start (Actions: 2) are confirmed across most 015 models.
+# pause (Actions: 3) and open_door (Actions: 4) have no effect on the firmware
+# seen so far, so they are not exposed.
+buttons:
+  - key: stop
+    icon: mdi:stop
+    write:
+      Actions: 1
+  - key: start
+    icon: mdi:play
+    available_when:
+      Remote_control_monitoring_set_commands_actions: 2
+    write:
+      Actions: 2
 properties:
   - property: ADO_allowed
     binary_sensor:


### PR DESCRIPTION
The 015-dishwasher-50.2t variant was mapped with start = `Actions: 3`, based on an initial report that was later corrected on the issue: the action codes are in fact standard — `1` stops, `2` starts, and `3`/`4` have no effect. This fixes 50.2t to stop(1)/start(2) like the other variants.

Since stop and start are now confirmed consistent across the 015 variants, the button definitions move into the default `015.yaml` mapping and the per-variant copies are dropped. Variants that previously had no buttons now inherit them too.

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)