### PR TITLE
Honor disable flag in all entity-creation paths

### DIFF
--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -31,7 +31,7 @@ from .const import (
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary
 from .entity import ConnectLifeEntity
-from .utils import to_temperature_map, normalize_temperature_unit
+from .utils import has_platform, to_temperature_map, normalize_temperature_unit
 from connectlife.appliance import ConnectLifeAppliance
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ async def async_setup_entry(
 
 def is_climate(dictionary: Dictionary):
     for prop in dictionary.properties.values():
-        if hasattr(prop, Platform.CLIMATE):
+        if has_platform(Platform.CLIMATE, prop):
             return True
     return False
 
@@ -147,7 +147,7 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
         self.unknown_values = {}
 
         for dd_entry in data_dictionary.properties.values():
-            if hasattr(dd_entry, Platform.CLIMATE) and dd_entry.name in appliance.status_list and dd_entry.climate.target is not None:
+            if has_platform(Platform.CLIMATE, dd_entry) and dd_entry.name in appliance.status_list and dd_entry.climate.target is not None:
                 target = dd_entry.climate.target
                 if target in self.target_map:
                     _LOGGER.warning(

--- a/custom_components/connectlife/humidifier.py
+++ b/custom_components/connectlife/humidifier.py
@@ -22,6 +22,7 @@ from .const import (
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary
 from .entity import ConnectLifeEntity
+from .utils import has_platform
 from connectlife.appliance import ConnectLifeAppliance
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,7 +45,7 @@ async def async_setup_entry(
 
 def is_humidifier(dictionary: Dictionary):
     for prop in dictionary.properties.values():
-        if hasattr(prop, Platform.HUMIDIFIER):
+        if has_platform(Platform.HUMIDIFIER, prop):
             return True
     return False
 
@@ -74,7 +75,7 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
 
         device_class = None
         for prop in data_dictionary.properties.values():
-            if hasattr(prop, Platform.HUMIDIFIER):
+            if has_platform(Platform.HUMIDIFIER, prop):
                 if prop.humidifier.device_class is not None:
                     device_class = prop.humidifier.device_class
                     break
@@ -87,7 +88,7 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
         )
 
         for dd_entry in data_dictionary.properties.values():
-            if hasattr(dd_entry, Platform.HUMIDIFIER) and dd_entry.name in appliance.status_list and dd_entry.humidifier.target is not None:
+            if has_platform(Platform.HUMIDIFIER, dd_entry) and dd_entry.name in appliance.status_list and dd_entry.humidifier.target is not None:
                 target = dd_entry.humidifier.target
                 if target in self.target_map:
                     _LOGGER.warning(

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -58,7 +58,7 @@ async def async_setup_entry(
             for name, prop in dictionary.properties.items()
             if prop.combine
             and name not in appliance.status_list
-            and hasattr(prop, Platform.SENSOR)
+            and has_platform(Platform.SENSOR, prop)
             and any(
                 src["property"] in appliance.status_list
                 for src in prop.combine

--- a/custom_components/connectlife/water_heater.py
+++ b/custom_components/connectlife/water_heater.py
@@ -30,7 +30,7 @@ from .const import (
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary
 from .entity import ConnectLifeEntity
-from .utils import to_temperature_map, normalize_temperature_unit
+from .utils import has_platform, to_temperature_map, normalize_temperature_unit
 from connectlife.appliance import ConnectLifeAppliance
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ async def async_setup_entry(
 
 def is_water_heater(dictionary: Dictionary):
     for prop in dictionary.properties.values():
-        if hasattr(prop, Platform.WATER_HEATER):
+        if has_platform(Platform.WATER_HEATER, prop):
             return True
     return False
 
@@ -108,7 +108,7 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
         self.unknown_values = {}
 
         for dd_entry in data_dictionary.properties.values():
-            if hasattr(dd_entry, Platform.WATER_HEATER) and dd_entry.name in appliance.status_list and dd_entry.water_heater.target is not None:
+            if has_platform(Platform.WATER_HEATER, dd_entry) and dd_entry.name in appliance.status_list and dd_entry.water_heater.target is not None:
                 target = dd_entry.water_heater.target
                 if target in self.target_map:
                     _LOGGER.warning(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,9 +9,10 @@ from homeassistant.components.climate import ClimateEntityFeature, HVACMode
 from custom_components.connectlife.climate import (
     ConnectLifeClimate,
     _add_hvac_mode_mapping,
+    is_climate,
 )
 from custom_components.connectlife.const import HVAC_MODE, IS_ON
-from custom_components.connectlife.dictionaries import Dictionaries
+from custom_components.connectlife.dictionaries import Dictionaries, Dictionary, Property
 
 
 def test_hvac_mode_alias_does_not_override_canonical_reverse_mapping() -> None:
@@ -52,6 +53,60 @@ async def test_set_hvac_mode_writes_canonical_cool_value() -> None:
     await climate.async_set_hvac_mode(HVACMode.COOL)
 
     assert requests == [{"t_power": 1, "t_work_mode": 2}]
+
+
+def test_disabled_climate_property_is_not_exposed() -> None:
+    """A climate-mapped property with `disable: true` must be dropped.
+
+    Regression test: the climate platform previously only checked
+    `hasattr(prop, climate)` and ignored `disable`, so a disabled swing axis
+    still leaked onto the entity. (A ducted AC variant relies on this to
+    suppress the swing controls inherited from its base mapping.)
+    """
+    dictionary = Dictionary(
+        climate=None,
+        properties={
+            "t_power": Property(
+                {"property": "t_power", "climate": {"target": "is_on"}}
+            ),
+            "t_swing_angle": Property(
+                {
+                    "property": "t_swing_angle",
+                    "disable": True,
+                    "climate": {
+                        "target": "swing_mode",
+                        "options": {0: "off", 1: "on"},
+                    },
+                }
+            ),
+        },
+        buttons=[],
+    )
+
+    # Still a climate device (t_power is enabled) ...
+    assert is_climate(dictionary)
+
+    appliance = SimpleNamespace(
+        device_id="dev1",
+        device_nickname="Duct AC",
+        device_feature_name="ducted",
+        device_type_code="009",
+        device_feature_code="19901",
+        room_name="Living Room",
+        status_list={"t_power": 0, "t_swing_angle": 0},
+    )
+    coordinator = SimpleNamespace(
+        data={appliance.device_id: appliance},
+        config_entry=SimpleNamespace(options={}, entry_id="e"),
+        hass=None,
+        last_update_success=True,
+        add_entity=lambda *a, **k: None,
+    )
+    climate = ConnectLifeClimate(coordinator, appliance, dictionary)
+
+    # ... but the disabled swing axis is not exposed.
+    assert "swing_mode" not in climate.target_map
+    assert not climate._attr_supported_features & ClimateEntityFeature.SWING_MODE
 
 
 def test_008_399_eco_preset_writes_raw_eco_mode() -> None:


### PR DESCRIPTION
## Problem

`disable: true` was silently ignored for several entity-creation paths:

- The **device-level platforms** (climate, humidifier, water_heater) build their entity by scanning every property for a matching platform block via `hasattr(prop, Platform.X)`, and never consulted the property's `disable` flag. So `disable: true` on a property mapped to one of these still produced the sub-feature (e.g. a swing axis on the climate entity).
- The **combined-sensor loop** in `sensor.py` did the same (`hasattr(prop, Platform.SENSOR)`).

This diverged from the per-property platforms (switch/select/number/sensor/binary_sensor), which already gate creation through `has_platform()` (`hasattr() and not disable`).

## Fix

Route every such scan through `has_platform()`. A feature-variant mapping can now suppress an inherited device-level sub-feature with a plain `disable: true`, without having to re-platform the property onto a dummy `sensor:`.

Touched: `climate.py`, `humidifier.py`, `water_heater.py`, and the combine loop in `sensor.py`.

(`coordinator.py` has a `hasattr(prop, Platform.SENSOR)` check too, but it's a repair-issue scanner, not entity creation — a disabled sensor has no registry entry, so the subsequent lookup already excludes it. Left as-is.)

## Test

Adds a self-contained regression test that builds a climate `Dictionary` inline with one enabled (`t_power`) and one disabled (swing) climate property, and asserts the disabled axis is not exposed (no swing target, `SWING_MODE` feature absent). It does not depend on any mapping file.

## Audit

Verified against all current mappings (122 subtype variants + 18 base files, merged as the runtime does): **no existing mapping sets `disable: true` on a climate/humidifier/water_heater property or a combine-target sensor**, so this changes behavior for zero existing entities.

## Related

The ducted-AC mapping in #589 is the first consumer of this — it disables the inherited swing controls. Merge this PR first.