### PR TITLE
Add support for 009-19901 (HACZ01+HAAZ01 ducted AC)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -62,7 +62,7 @@
 |                          | Air conditioner          | 009              | 128                         |
 |                          | Air conditioner          | 009              | 129                         |
 |                          | Air conditioner          | 009              | 199                         |
-|                          | Air conditioner          | 009              | 19901                       |
+| HACZ01+HAAZ01            | Air conditioner          | 009              | 19901                       |
 | HI21472SV                | Induction hob            | 010              | hob-pind                    |
 |                          | Hood                     | 012              | 000                         |
 |                          | Hood                     | 012              | hood-aa-lightfeedback       |

--- a/custom_components/connectlife/data_dictionaries/009-19901.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-19901.yaml
@@ -1,1 +1,14 @@
-# No overrides needed; all properties covered by default 009.yaml.
+# Model: HACZ01+HAAZ01 ducted zone controller.
+# The API exposes directional controls, but they do not exist on the device,
+# so we need to explicitly disable them.
+properties:
+  - property: t_swing_angle
+    disable: true
+  - property: t_swing_direction
+    disable: true
+  - property: t_swing_follow
+    disable: true
+  - property: t_left_right
+    disable: true
+  - property: t_up_down
+    disable: true

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -74,12 +74,28 @@ properties:
   - property: aus_zone8_power
     switch:
       device_class: switch
+  - property: f-filter
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    icon: mdi:air-filter
+    entity_category: diagnostic
   - property: f_cool_qvalue
     sensor:
       unit: BTU/h
       state_class: measurement
     icon: mdi:snowflake
   - property: f_e_arkgrille
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_e_dwmachine
     binary_sensor:
       device_class: problem
       options:
@@ -207,8 +223,40 @@ properties:
         1: true
     hide: true
     entity_category: diagnostic
+  - property: f_e_over_cold
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_e_over_hot
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
   - property: f_e_push
     disable: true
+  - property: f_e_upmachine
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
+  - property: f_e_waterfull
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+    hide: true
+    entity_category: diagnostic
   - property: f_ecm
     # f_ecm: appears to indicate which unit f_electricity uses (f_ecm=1
     # has been observed alongside mA current values; absent in 009-104,
@@ -426,3 +474,10 @@ properties:
         2: cool
         3: dry
         4: auto
+  # Observed on some units (e.g. 009-19901, 009-109, 009-117) but their
+  # meaning and value range are not yet known, so they are intentionally
+  # left unmapped (they surface as generic diagnostic sensors). Map them
+  # once their semantics are confirmed from a device that actually uses them:
+  #   - t_dal
+  #   - t_demand_response  (likely utility demand-response, unconfirmed)
+  #   - t_talr

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -568,8 +568,14 @@
       "existing_sr_mode": {
         "name": "Aktueller SR-Modus"
       },
+      "f-filter": {
+        "name": "Filter"
+      },
       "f_e_arkgrille": {
         "name": "Schutzalarm f\u00fcr Kabinengrill"
+      },
+      "f_e_dwmachine": {
+        "name": "Fehler untere Einheit"
       },
       "f_e_filterclean": {
         "name": "Filter reinigen"
@@ -619,6 +625,12 @@
       "f_e_outtemp": {
         "name": "Fehler des Au\u00dfentemperatursensors"
       },
+      "f_e_over_cold": {
+        "name": "Unterk\u00fchlungsschutz"
+      },
+      "f_e_over_hot": {
+        "name": "\u00dcberhitzungsschutz"
+      },
       "f_e_pump": {
         "name": "Pumpe"
       },
@@ -627,6 +639,9 @@
       },
       "f_e_tubetemp": {
         "name": "Temperatur der R\u00f6hre"
+      },
+      "f_e_upmachine": {
+        "name": "Fehler obere Einheit"
       },
       "f_e_waterfull": {
         "name": "Wasser voll"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -262,8 +262,20 @@
       "error_9": {
         "name": "Error 9"
       },
+      "f-filter": {
+        "name": "Filtro"
+      },
+      "f_e_dwmachine": {
+        "name": "Fallo de la unidad inferior"
+      },
       "f_e_filterclean": {
         "name": "Limpiar filtro"
+      },
+      "f_e_over_cold": {
+        "name": "Protecci\u00f3n contra sobreenfriamiento"
+      },
+      "f_e_over_hot": {
+        "name": "Protecci\u00f3n contra sobrecalentamiento"
       },
       "f_e_pump": {
         "name": "Bomba"
@@ -273,6 +285,9 @@
       },
       "f_e_tubetemp": {
         "name": "Temperatura tubo"
+      },
+      "f_e_upmachine": {
+        "name": "Fallo de la unidad superior"
       },
       "f_e_waterfull": {
         "name": "Agua llena"

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -94,6 +94,24 @@
       "existing_sr_mode": {
         "name": "Super-refroidissement disponible"
       },
+      "f-filter": {
+        "name": "Filtre"
+      },
+      "f_e_dwmachine": {
+        "name": "D\u00e9faut de l'unit\u00e9 inf\u00e9rieure"
+      },
+      "f_e_over_cold": {
+        "name": "Protection contre le froid excessif"
+      },
+      "f_e_over_hot": {
+        "name": "Protection contre la surchauffe"
+      },
+      "f_e_upmachine": {
+        "name": "D\u00e9faut de l'unit\u00e9 sup\u00e9rieure"
+      },
+      "f_e_waterfull": {
+        "name": "R\u00e9servoir d'eau plein"
+      },
       "free_defrosting_failure": {
         "name": "D\u00e9faut d\u00e9givrage cong\u00e9lateur"
       },

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -37,6 +37,24 @@
       "delaystart_delayend_mode": {
         "name": "Partenza ritardata"
       },
+      "f-filter": {
+        "name": "Filtro"
+      },
+      "f_e_dwmachine": {
+        "name": "Guasto unit\u00e0 inferiore"
+      },
+      "f_e_over_cold": {
+        "name": "Protezione da sovraraffreddamento"
+      },
+      "f_e_over_hot": {
+        "name": "Protezione da surriscaldamento"
+      },
+      "f_e_upmachine": {
+        "name": "Guasto unit\u00e0 superiore"
+      },
+      "f_e_waterfull": {
+        "name": "Acqua piena"
+      },
       "selected_program_anticrease_status": {
         "name": "Antipiega"
       },


### PR DESCRIPTION
Resolves the mapping side of #347 (HACZ01+HAAZ01 ducted zone controller).

## Changes

**`009-19901.yaml`** — the ducted zone controller has no directional louvers, so the swing/direction controls inherited from `009.yaml` are not functional on this device. Disable them: `t_swing_angle`, `t_swing_direction` (climate swing axes), `t_swing_follow`, `t_left_right`, `t_up_down`. The per-zone dampers (`aus_zone*`) are the real airflow control and stay.

**`009.yaml`** — adds six properties the device reports that weren't mapped (they otherwise surface as raw auto-generated sensors), following the existing diagnostic pattern:
- `f-filter` → filter indicator (visible diagnostic `problem` binary sensor)
- `f_e_dwmachine`, `f_e_over_cold`, `f_e_over_hot`, `f_e_upmachine`, `f_e_waterfull` → hidden diagnostic `problem` binary sensors

**Translations** — adds the new binary-sensor names to `de`, `es`, `fr`, `it` (`en`/`nl`/`no` already had them).

## Notes

- Disabling the climate swing axes relies on device-level platforms honoring `disable:`, fixed in #588 — **merge that first**.
- The earlier "climate unavailable / everything goes unavailable after inactivity" reports in #347 were the old bapi gateway and are addressed by the HijuConn migration (v0.27.0); not a mapping issue.
- `t_dal`, `t_demand_response`, `t_talr` remain unmapped pending identification.

Validated: `validate_mappings`, `gen_strings` clean.