### PR TITLE
Decouple unit tests from shipped mapping files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@ The API library is published to PyPI as `connectlife` and developed in a separat
 
 See `custom_components/connectlife/data_dictionaries/README.md` for the authoring workflow (skeleton generation, tips, translation strings). After editing YAML, run `uv run python -m scripts.validate_mappings` and `uv run python -m scripts.gen_strings`.
 
+Mappings are data, validated by `validate_mappings` (schema) and PR review — don't add unit tests asserting a specific mapping's *content*.
+
 ## Git and pull requests
 
 - **Don't amend, drop, or squash commits on an open PR.** Once a branch has an

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import custom_components.connectlife.dictionaries as dictmod
+
+
+@pytest.fixture
+def build_dictionary():
+    """Factory to build a ``Dictionary`` from inline mapping data.
+
+    Runs the real ``Dictionaries.get_dictionary`` parser/merge over data passed
+    in-process instead of reading any shipped YAML file, so tests exercise the
+    parsing and inheritance logic without coupling to specific device mappings.
+
+    Pass already-parsed mapping dicts (as ``yaml.safe_load`` would return):
+    ``base`` for ``{type_code}.yaml`` and/or ``sub`` for the
+    ``{type_code}-{feature}.yaml`` feature override.
+    """
+    created: list[str] = []
+
+    def _build(*, base=None, sub=None, type_code="999", feature="000"):
+        files: dict[str, object] = {}
+        if base is not None:
+            files[f"data_dictionaries/{type_code}.yaml"] = base
+        if sub is not None:
+            files[f"data_dictionaries/{type_code}-{feature}.yaml"] = sub
+
+        def fake_load(path):
+            if path in files:
+                return True, files[path]
+            return False, None
+
+        key = f"{type_code}-{feature}"
+        dictmod.Dictionaries.dictionaries.pop(key, None)
+        created.append(key)
+        with patch.object(dictmod, "_load_yaml", side_effect=fake_load):
+            return dictmod.Dictionaries.get_dictionary(
+                SimpleNamespace(
+                    device_type_code=type_code,
+                    device_feature_code=feature,
+                    device_nickname="test",
+                )
+            )
+
+    yield _build
+    for key in created:
+        dictmod.Dictionaries.dictionaries.pop(key, None)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -12,7 +12,7 @@ from custom_components.connectlife.climate import (
     is_climate,
 )
 from custom_components.connectlife.const import HVAC_MODE, IS_ON
-from custom_components.connectlife.dictionaries import Dictionaries, Dictionary, Property
+from custom_components.connectlife.dictionaries import Dictionary, Property
 
 
 def test_hvac_mode_alias_does_not_override_canonical_reverse_mapping() -> None:
@@ -107,20 +107,3 @@ def test_disabled_climate_property_is_not_exposed() -> None:
     # ... but the disabled swing axis is not exposed.
     assert "swing_mode" not in climate.target_map
     assert not climate._attr_supported_features & ClimateEntityFeature.SWING_MODE
-
-
-def test_008_399_eco_preset_writes_raw_eco_mode() -> None:
-    Dictionaries.dictionaries.pop("008-399", None)
-    appliance = SimpleNamespace(
-        device_type_code="008",
-        device_feature_code="399",
-        device_nickname="Ultraslim AC",
-    )
-
-    dictionary = Dictionaries.get_dictionary(appliance)
-
-    assert {
-        "preset": "eco",
-        "t_power": 1,
-        "t_work_mode": 5,
-    } in dictionary.climate["presets"]

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -2,25 +2,14 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 from custom_components.connectlife.dictionaries import (
-    Dictionaries,
     Property,
     Sensor,
     _merge_property,
 )
 
-
-def _dictionary_for(device_type_code: str, device_feature_code: str):
-    """Load a real data dictionary via a minimal appliance stub."""
-    Dictionaries.dictionaries.clear()  # avoid cross-test cache hits
-    appliance = SimpleNamespace(
-        device_type_code=device_type_code,
-        device_feature_code=device_feature_code,
-        device_nickname="test",
-    )
-    return Dictionaries.get_dictionary(appliance)  # type: ignore[arg-type]
+# Minimal property list so a parsed mapping is well-formed.
+_MINIMAL_PROPS = [{"property": "t_power", "switch": None}]
 
 
 def test_override_with_no_platform_inherits_everything():
@@ -287,27 +276,70 @@ def test_optional_parsing():
     assert Property({"property": "p"}).optional is False
 
 
-def test_statistics_source_air_duct_for_air_conditioners():
-    # AC families opt into the air_duct_energy endpoint (inherited by feature variants).
-    assert _dictionary_for("009", "100").statistics_source == "air_duct_energy"
-    assert _dictionary_for("006", "200").statistics_source == "air_duct_energy"
-    assert _dictionary_for("008", "399").statistics_source == "air_duct_energy"
+def test_statistics_block_parsed(build_dictionary):
+    # A statistics block is parsed into source + per-sensor flags.
+    d = build_dictionary(
+        base={
+            "statistics": {"source": "air_duct_energy", "daily_energy_kwh": True},
+            "properties": _MINIMAL_PROPS,
+        }
+    )
+    assert d.statistics_source == "air_duct_energy"
+    assert d.statistics_sensors == {"daily_energy_kwh": True}
 
 
-def test_statistics_source_consumption_curve_for_wet_appliances():
-    assert _dictionary_for("015", "000").statistics_source == "energy_consumption_curve"
-    assert _dictionary_for("027", "000").statistics_source == "energy_consumption_curve"
+def test_statistics_absent_defaults_to_none(build_dictionary):
+    # No statistics block -> no endpoint and no sensors.
+    d = build_dictionary(base={"properties": _MINIMAL_PROPS})
+    assert d.statistics_source is None
+    assert d.statistics_sensors == {}
 
 
-def test_statistics_source_defaults_none():
-    # An unmapped device type (no base file) has no statistics endpoint.
-    assert _dictionary_for("999", "000").statistics_source is None
+def test_statistics_flag_false_is_kept_as_false(build_dictionary):
+    # An explicit false flag is preserved (not dropped), so the sensor is not created.
+    d = build_dictionary(
+        base={
+            "statistics": {"source": "air_duct_energy", "daily_energy_kwh": False},
+            "properties": _MINIMAL_PROPS,
+        }
+    )
+    assert d.statistics_sensors == {"daily_energy_kwh": False}
 
 
-def test_statistics_sensors_explicitly_listed():
-    # Sensors are created only when listed true; wet appliances add water.
-    assert _dictionary_for("015", "000").statistics_sensors == {
+def test_statistics_block_inherited_by_feature_override(build_dictionary):
+    # A feature override with no statistics block inherits the base's.
+    d = build_dictionary(
+        base={
+            "statistics": {
+                "source": "energy_consumption_curve",
+                "daily_energy_kwh": True,
+                "daily_water_consumption": True,
+            },
+            "properties": _MINIMAL_PROPS,
+        },
+        sub={"properties": _MINIMAL_PROPS},
+    )
+    assert d.statistics_source == "energy_consumption_curve"
+    assert d.statistics_sensors == {
         "daily_energy_kwh": True,
         "daily_water_consumption": True,
     }
-    assert _dictionary_for("009", "100").statistics_sensors == {"daily_energy_kwh": True}
+
+
+def test_statistics_block_replaced_by_feature_override(build_dictionary):
+    # A feature override with its own statistics block replaces the base's entirely.
+    d = build_dictionary(
+        base={
+            "statistics": {"source": "air_duct_energy", "daily_energy_kwh": True},
+            "properties": _MINIMAL_PROPS,
+        },
+        sub={
+            "statistics": {
+                "source": "energy_consumption_curve",
+                "daily_water_consumption": True,
+            },
+            "properties": _MINIMAL_PROPS,
+        },
+    )
+    assert d.statistics_source == "energy_consumption_curve"
+    assert d.statistics_sensors == {"daily_water_consumption": True}

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -9,7 +9,7 @@ from connectlife.api import LifeConnectAuthError
 from homeassistant.util import dt as dt_util
 
 from custom_components.connectlife.coordinator import ConnectLifeStatisticsCoordinator
-from custom_components.connectlife.dictionaries import Dictionaries
+from custom_components.connectlife.dictionaries import Dictionaries, Dictionary
 from custom_components.connectlife.sensor import ConnectLifeStatisticsSensor
 from custom_components.connectlife.statistics_sources import (
     AirDuctStatisticsSource,
@@ -122,9 +122,34 @@ def _coordinator(api, data: dict):
     return coord
 
 
+# Synthetic device codes, seeded with statistics dictionaries below so the
+# coordinator's source lookup doesn't depend on any shipped mapping file.
+_AC = ("ac_type", "ac_feat")        # air_duct_energy
+_WM = ("wm_type", "wm_feat")        # energy_consumption_curve
+_NO_STATS = ("plain_type", "plain")  # no statistics endpoint
+
+
+def _dictionary(source, sensors):
+    return Dictionary(
+        climate=None,
+        properties={},
+        buttons=[],
+        statistics_source=source,
+        statistics_sensors=sensors,
+    )
+
+
 @pytest.fixture(autouse=True)
-def _clear_dictionary_cache():
+def _seed_dictionaries():
     Dictionaries.dictionaries.clear()
+    Dictionaries.dictionaries[f"{_AC[0]}-{_AC[1]}"] = _dictionary(
+        "air_duct_energy", {"daily_energy_kwh": True}
+    )
+    Dictionaries.dictionaries[f"{_WM[0]}-{_WM[1]}"] = _dictionary(
+        "energy_consumption_curve",
+        {"daily_energy_kwh": True, "daily_water_consumption": True},
+    )
+    Dictionaries.dictionaries[f"{_NO_STATS[0]}-{_NO_STATS[1]}"] = _dictionary(None, {})
     yield
     Dictionaries.dictionaries.clear()
 
@@ -136,7 +161,7 @@ async def test_coordinator_stores_results_per_device():
             electric_curve={_today_key(): "1.0"}, water_curve={_today_key(): "11.0"}
         ),
     )
-    data = {"ac": _appliance("ac", "009", "100"), "wm": _appliance("wm", "015", "000")}
+    data = {"ac": _appliance("ac", *_AC), "wm": _appliance("wm", *_WM)}
     result = await _coordinator(api, data)._async_update_data()
 
     assert set(result) == {"ac", "wm"}
@@ -148,7 +173,7 @@ async def test_coordinator_stores_results_per_device():
 async def test_coordinator_auth_error_breaks_remaining_devices():
     # AC fetched first and raises auth error -> loop breaks before the washing machine.
     api = _FakeApi(air_duct_exc=LifeConnectAuthError("token rejected"))
-    data = {"ac": _appliance("ac", "009", "100"), "wm": _appliance("wm", "015", "000")}
+    data = {"ac": _appliance("ac", *_AC), "wm": _appliance("wm", *_WM)}
     result = await _coordinator(api, data)._async_update_data()
 
     assert result == {}
@@ -163,7 +188,7 @@ async def test_coordinator_generic_error_yields_none_and_continues():
             electric_curve={_today_key(): "1.0"}, water_curve={}
         ),
     )
-    data = {"ac": _appliance("ac", "009", "100"), "wm": _appliance("wm", "015", "000")}
+    data = {"ac": _appliance("ac", *_AC), "wm": _appliance("wm", *_WM)}
     result = await _coordinator(api, data)._async_update_data()
 
     assert result["ac"] is None  # generic error -> None, not a break
@@ -173,7 +198,7 @@ async def test_coordinator_generic_error_yields_none_and_continues():
 
 async def test_coordinator_skips_device_without_statistics_source():
     api = _FakeApi()
-    data = {"x": _appliance("x", "999", "000")}  # unmapped type -> no source
+    data = {"x": _appliance("x", *_NO_STATS)}  # dictionary has no statistics source
     result = await _coordinator(api, data)._async_update_data()
 
     assert result == {}


### PR DESCRIPTION
Tests that loaded real data dictionaries broke on unrelated mapping edits and coupled the unit suite to specific device content. Rework them to test **code, not data**.

## Changes

- **`tests/conftest.py`** (new) — a `build_dictionary` fixture that runs the real `Dictionaries.get_dictionary` parser/merge over inline mapping data (via a patched `_load_yaml`), reading no shipped file. Keeps parse/inherit/override logic under test.
- **`test_dictionaries.py`** — replace the "device X → source Y" content assertions with statistics-block logic tests: parsing, absent-defaults, explicit-`false` flag preserved, inheritance by feature override, and full replacement by feature override.
- **`test_statistics.py`** — the coordinator fetch-loop tests now seed synthetic `Dictionary` objects under fake device codes, instead of relying on `009.yaml` / `015.yaml`.
- **`test_climate.py`** — drop `test_008_399_eco_preset`: it asserted shipped-file *content* (covered by `validate_mappings` + review), not code behavior.
- **`AGENTS.md`** — document that mappings are data (schema- and review-validated), not unit-tested for content.

## Verification

- 47 tests pass.
- A `pkgutil.get_data` spy confirms **0 `data_dictionaries` files are read** across `test_dictionaries` / `test_statistics` / `test_climate`. The only `get_dictionary` call left is inside the fixture, with the loader patched.