### PR TITLE
Add device 034 (Hisense RW3N122GSLF wine cooler)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/034-1j0122z0035j.yaml
+++ b/custom_components/connectlife/data_dictionaries/034-1j0122z0035j.yaml
@@ -13,3 +13,21 @@ properties:
     disable: true
   - property: refrigerator_sensor_real_temperature
     disable: true
+  # Single physical door, reported via refr_room_open / open_refrigerator_door_alarm.
+  # The variation-door entities never change on this model (owner-confirmed).
+  - property: vari_room_open
+    disable: true
+  - property: open_variation_door_alarm
+    disable: true
+  # Not present on this model (owner-confirmed): no standby mode, and no wine-light
+  # on/off (only the dimmable interior light works).
+  - property: standby_mode_status
+    disable: true
+  - property: wine_light
+    disable: true
+  # Redundant: the Sabbath switch already exposes its state
+  - property: sabbath_mode_status
+    disable: true
+  # Not meaningful on this model.
+  - property: temperature_room_judge
+    disable: true

--- a/custom_components/connectlife/data_dictionaries/034-1j0122z0035j.yaml
+++ b/custom_components/connectlife/data_dictionaries/034-1j0122z0035j.yaml
@@ -1,0 +1,15 @@
+# Model: Hisense Wine Cooler RW3N122GSLF
+# 2-zone wine cooler. Zone C (freeze_*) is not fitted on this model.
+properties:
+  - property: freeze_real_temperature
+    disable: true
+  - property: freeze_sensor_real_temperature
+    disable: true
+  - property: freeze_temperature
+    disable: true
+  # Sensors permanently at the -40 "no reading" sentinel on this model: no ambient
+  # sensor, and (unlike zone A) no zone B evaporator sensor.
+  - property: environment_real_temperature
+    disable: true
+  - property: refrigerator_sensor_real_temperature
+    disable: true

--- a/custom_components/connectlife/data_dictionaries/034.yaml
+++ b/custom_components/connectlife/data_dictionaries/034.yaml
@@ -1,0 +1,712 @@
+# Wine cooler
+statistics:
+  source: energy_consumption_curve
+  daily_energy_kwh: true
+properties:
+  - property: AIR_FRESHNESS
+    disable: true
+  - property: ODOR_SENSOR_FAULT_FLAG
+    disable: true
+  - property: ODOR_SENSOR_NO_DISTURB_MODE_STATUS
+    disable: true
+  - property: ODOR_SENSOR_SENSITIVITY
+    disable: true
+  - property: ODOR_SENSOR_SWITHC_STATUS
+    disable: true
+  - property: STERI_PURI_CYCLE_FLAG
+    disable: true
+  - property: alarm_key
+    disable: true
+  - property: alarm_sound_volume
+    disable: true
+  - property: ali_wifi_fault_flag
+    disable: true
+  - property: automatic_ice_making
+    disable: true
+  - property: camera_state
+    disable: true
+  - property: charcoal_filter_expiration_alarm
+    disable: true
+  - property: charcoal_filter_surplus_time
+    disable: true
+  - property: charcoal_filter_time_reset
+    disable: true
+  - property: child_lock_open_alarm
+    disable: true
+  - property: child_lock_open_door_sound_alarm
+    disable: true
+  - property: child_lock_switch_exist
+    disable: true
+  - property: child_lock_switch_status
+    entity_category: config
+    switch:
+      command:
+        name: SET_CHILD_LOCK_SWITCH
+  - property: commodity_inspection
+    disable: true
+  - property: compressor_condition
+    disable: true
+  - property: compressor_frequency
+    disable: true
+  - property: compressor_operating_max_frequency
+    disable: true
+  - property: compressor_operating_min_frequency
+    disable: true
+  - property: condensation_fan_failure_status
+    disable: true
+  - property: control_failure_status
+    disable: true
+  - property: custard_room
+    disable: true
+  - property: date_display_format_status
+    disable: true
+  - property: date_format_status
+    disable: true
+  - property: date_time_format_day_state
+    disable: true
+  - property: date_time_format_month_state
+    disable: true
+  - property: date_time_format_year_state
+    disable: true
+  - property: dbd_clean_mode
+    disable: true
+  - property: debacilli_mode
+    disable: true
+  - property: display_panel_ronshen
+    disable: true
+  - property: displayboard_brand
+    disable: true
+  - property: displayboard_key_setting
+    disable: true
+  - property: displayboard_type
+    disable: true
+  - property: displayboard_version
+    disable: true
+  - property: door_close_light_status
+    disable: true
+  - property: door_close_ui_display_status
+    disable: true
+  - property: door_open_light_status
+    disable: true
+  - property: door_open_ui_display_status
+    disable: true
+  - property: electric_current
+    disable: true
+  - property: electric_energy_one_tenths_value
+    disable: true
+  - property: electric_energy_percentile_thousands_value
+    disable: true
+  - property: envi_temp_sens_head_failure
+    disable: true
+  - property: environment_humidity
+    disable: true
+  - property: environment_real_temperature
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: existing_fuzzy_mode
+    disable: true
+  - property: existing_holiday_mode
+    disable: true
+  - property: existing_lock_fresh_mode
+    disable: true
+  - property: existing_save_mode
+    disable: true
+  - property: existing_sf_mode
+    disable: true
+  - property: existing_sr_mode
+    disable: true
+  - property: fast_store_mode_exist
+    disable: true
+  - property: fast_store_mode_status
+    disable: true
+  - property: filter_alarm_time
+    disable: true
+  - property: filter_state
+    disable: true
+  - property: free_defrosting_failure
+    disable: true
+  - property: free_evap_temp_sens_head_failure
+    disable: true
+  - property: free_fan_failure
+    disable: true
+  - property: free_key
+    disable: true
+  - property: free_room
+    disable: true
+  - property: free_room_open
+    disable: true
+  - property: free_room_open_2
+    disable: true
+  - property: free_room_over_temp_alarm_failure
+    disable: true
+  - property: free_temp_sens_head_failure
+    disable: true
+  - property: freeze_door_open_time
+    disable: true
+  - property: freeze_max_temperature
+    disable: true
+  - property: freeze_min_temperature
+    disable: true
+  - property: freeze_poweroff_ad
+    disable: true
+  - property: freeze_poweron_ad
+    disable: true
+  - property: freeze_real_temperature
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: freeze_sensor_real_temperature
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: freeze_temperature
+    unavailable: -40
+    number:
+      device_class: temperature
+      unit: °C
+      min_value: 5
+      max_value: 20
+      command:
+        name: SET_FREEZE_TEMPERATURE
+  - property: frost_state
+    disable: true
+  - property: froze_convert_to_refri_switch_status
+    disable: true
+  - property: fruit_vegetables_temperature
+    disable: true
+  - property: fuzzy_mode
+    disable: true
+  - property: gold_water_supply_mode
+    disable: true
+  - property: high_humidity
+    disable: true
+  - property: high_temperature
+    disable: true
+  - property: holiday_mode
+    disable: true
+  - property: human_on_off_status
+    disable: true
+  - property: human_sense_light_status
+    disable: true
+  - property: human_sense_ui_display_state
+    disable: true
+  - property: human_sensor_switch_exist
+    disable: true
+  - property: humdy_test_switch_state
+    disable: true
+  - property: humidity_sensor_failure
+    disable: true
+  - property: ice_making_b_switch_status
+    disable: true
+  - property: ice_making_full_status
+    disable: true
+  - property: ice_making_machine_failure
+    disable: true
+  - property: ice_making_state
+    disable: true
+  - property: ice_sensor_failure_flag
+    disable: true
+  - property: ice_temperature_sensor_header_failure_flag
+    disable: true
+  - property: inlet_pipe_temp_sens_head_failure
+    disable: true
+  - property: key_press_sound_volume
+    disable: true
+  - property: language_select
+    disable: true
+  - property: load_operation_status2
+    disable: true
+  - property: lock_fresh_mode
+    disable: true
+  - property: lock_key
+    disable: true
+  - property: low_humidity
+    disable: true
+  - property: low_temperature
+    disable: true
+  - property: low_wine_area_c_evaporator_fault
+    disable: true
+  - property: low_wine_area_c_fan_fault
+    disable: true
+  - property: low_wine_area_c_humdy_fault
+    disable: true
+  - property: low_wine_area_c_temp_fault
+    disable: true
+  - property: lumin_value_of_interior_light
+    optional: true
+  - property: mainboard_type
+    disable: true
+  - property: mainboard_version
+    disable: true
+  - property: market_mode_exist
+    disable: true
+  - property: measured_vibrations
+    disable: true
+  - property: medium_humidity
+    disable: true
+  - property: medium_temperature
+    disable: true
+  - property: micro_water_supply_mode
+    disable: true
+  - property: mid_wine_area_b_evaporator_fault
+    disable: true
+  - property: mid_wine_area_b_fan_fault
+    disable: true
+  - property: mid_wine_area_b_humdy_fault
+    disable: true
+  - property: mid_wine_area_b_temp_fault
+    disable: true
+  - property: mode_key
+    disable: true
+  - property: model_type
+    disable: true
+  - property: monitor
+    disable: true
+  - property: monitor_set
+    disable: true
+  - property: monitor_set_act
+    disable: true
+  - property: night_mode_end_hour
+    disable: true
+  - property: night_mode_end_min
+    disable: true
+  - property: night_mode_light_dark_level
+    disable: true
+  - property: night_mode_screen_dark_level
+    disable: true
+  - property: night_mode_start_hour
+    disable: true
+  - property: night_mode_start_min
+    disable: true
+  - property: night_mode_status
+    disable: true
+  - property: normal_sound_size
+    disable: true
+  - property: not_active
+    disable: true
+  - property: open_freeze_door_alarm
+    disable: true
+  - property: open_refrigerator_door_alarm
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+  - property: open_the_door_alarm
+    disable: true
+  - property: open_variation_door_alarm
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+  - property: pairing
+    disable: true
+  - property: pairing_active
+    disable: true
+  - property: power_hundred_ten_value
+    disable: true
+  - property: power_one_tenths_value
+    disable: true
+  - property: power_voltage
+    disable: true
+  - property: quiet_mode_status
+    disable: true
+  - property: real_humidity
+    disable: true
+  - property: real_humidity_b
+    disable: true
+  - property: real_humidity_c
+    disable: true
+  - property: ref_light
+    disable: true
+  - property: refr_defrosting_failure
+    disable: true
+  - property: refr_dry_wet_room_sens_failure
+    disable: true
+  - property: refr_evap_temp_sens_head_failure
+    disable: true
+  - property: refr_fan_failure
+    disable: true
+  - property: refr_key
+    disable: true
+  - property: refr_room
+    disable: true
+  - property: refr_room_open
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: door
+      options:
+        0: false
+        1: true
+  - property: refr_room_over_temp_alarm
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+  - property: refr_temp_sens_head_failure
+    disable: true
+  - property: refr_var_room_sens_failure
+    disable: true
+  - property: refrigerator_door_open_time
+    disable: true
+  - property: refrigerator_freeze_swith
+    disable: true
+  - property: refrigerator_freeze_swith_state
+    disable: true
+  - property: refrigerator_max_temperature
+    disable: true
+  - property: refrigerator_min_temperature
+    disable: true
+  - property: refrigerator_poweroff_ad
+    disable: true
+  - property: refrigerator_poweron_ad
+    disable: true
+  - property: refrigerator_real_temperature
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: refrigerator_sensor_real_temperature
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: refrigerator_temperature
+    unavailable: -40
+    number:
+      device_class: temperature
+      unit: °C
+      min_value: 5
+      max_value: 20
+      command:
+        name: SET_REFRIGERATOR_TEMPERATURE
+  - property: reserve45
+    disable: true
+  - property: reserve46
+    disable: true
+  - property: reserve47
+    disable: true
+  - property: reserve48
+    disable: true
+  - property: reserve49
+    disable: true
+  - property: reserve50
+    disable: true
+  - property: reserve51
+    disable: true
+  - property: reserve52
+    disable: true
+  - property: reserve53
+    disable: true
+  - property: reserve54
+    disable: true
+  - property: reserve55
+    disable: true
+  - property: reserve56
+    disable: true
+  - property: reserve57
+    disable: true
+  - property: reserve58
+    disable: true
+  - property: reserve59
+    disable: true
+  - property: reserve60
+    disable: true
+  - property: reserve61
+    disable: true
+  - property: reserve62
+    disable: true
+  - property: reserve63
+    disable: true
+  - property: reserve64
+    disable: true
+  - property: reserve65
+    disable: true
+  - property: reserve66
+    disable: true
+  - property: reserve67
+    disable: true
+  - property: reserve68
+    disable: true
+  - property: reserve69
+    disable: true
+  - property: reserve70
+    disable: true
+  - property: reserve71
+    disable: true
+  - property: reserve72
+    disable: true
+  - property: rgb_atmosphere_mode_b_value
+    disable: true
+  - property: rgb_atmosphere_mode_g_value
+    disable: true
+  - property: rgb_atmosphere_mode_r_value
+    disable: true
+  - property: rgb_function_mode_b_value
+    disable: true
+  - property: rgb_function_mode_g_value
+    disable: true
+  - property: rgb_function_mode_r_value
+    disable: true
+  - property: rgb_light_atmosphere_brightness
+    disable: true
+  - property: rgb_light_atmosphere_on_time
+    disable: true
+  - property: rgb_light_function_brightness
+    disable: true
+  - property: rgb_light_function_on_time
+    disable: true
+  - property: rgb_light_normal_brightness
+    disable: true
+  - property: rgb_light_state
+    disable: true
+  - property: rgb_normal_mode_b_value
+    disable: true
+  - property: rgb_normal_mode_g_value
+    disable: true
+  - property: rgb_normal_mode_r_value
+    disable: true
+  - property: right_free_sensor_failure
+    disable: true
+  - property: run_status_flag_5
+    disable: true
+  - property: running_status
+    disable: true
+  - property: running_status3
+    disable: true
+  - property: rx_failure
+    disable: true
+  - property: sabbath_mode_status
+    optional: true
+  - property: sabbath_mode_switch_status
+    entity_category: config
+    switch:
+      command:
+        name: SET_SABBATH_MODE
+  - property: save_mode
+    disable: true
+  - property: screen_display_brightness
+    disable: true
+  - property: screen_display_lock
+    disable: true
+  - property: screen_to_clock_time
+    disable: true
+  - property: screen_to_standby_time
+    disable: true
+  - property: sensor_failure_status
+    disable: true
+  - property: sensor_failure_status2
+    disable: true
+  - property: sf_mode
+    disable: true
+  - property: sf_sr_mutex_mode
+    disable: true
+  - property: shelf_light_a_state
+    disable: true
+  - property: shelf_light_atmosphere_mode_brightness
+    disable: true
+  - property: shelf_light_b_state
+    disable: true
+  - property: shelf_light_c_state
+    disable: true
+  - property: shelf_light_function_mode_brightness
+    disable: true
+  - property: shelf_light_function_on_time
+    disable: true
+  - property: shelf_light_normal_on_time
+    disable: true
+  - property: show_mode
+    disable: true
+  - property: special_space
+    disable: true
+  - property: sr_mode
+    disable: true
+  - property: standby_mode_state
+    disable: true
+  - property: standby_mode_status
+    entity_category: config
+    optional: true
+    switch:
+      command:
+        name: SET_STANDBY_MODE
+  - property: standby_mode_valid
+    disable: true
+  - property: super_water_supply_mode
+    disable: true
+  - property: temp_auto_ctrl_mode_exist
+    disable: true
+  - property: temp_auto_ctrl_mode_state
+    disable: true
+  - property: temperature_room_judge
+    optional: true
+  - property: temperature_unit
+    entity_category: config
+    optional: true
+    select:
+      options:
+        0: celsius
+        1: fahrenheit
+      command:
+        name: SET_TEMPERATURE_UNIT
+  - property: theme_color
+    disable: true
+  - property: tx_failure
+    disable: true
+  - property: unfreeze_run_status
+    disable: true
+  - property: unfreeze_switch_status
+    disable: true
+  - property: unpair_all_users
+    disable: true
+  - property: up_wine_area_a_evaporator_fault
+    disable: true
+  - property: up_wine_area_a_fan_fault
+    disable: true
+  - property: up_wine_area_a_humdy_fault
+    disable: true
+  - property: up_wine_area_a_temp_fault
+    disable: true
+  - property: user_debacilli_mode
+    disable: true
+  - property: vacuum_on_off_status
+    disable: true
+  - property: var_room_open_2
+    disable: true
+  - property: var_room_over_temp_alarm
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
+  - property: vari_evap_temp_sens_head_failure
+    disable: true
+  - property: vari_key
+    disable: true
+  - property: vari_room
+    disable: true
+  - property: vari_room_open
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: door
+      options:
+        0: false
+        1: true
+  - property: vari_temp_sens_head_failure
+    disable: true
+  - property: variable_fan_failure_status
+    disable: true
+  - property: variable_heater_failure_status
+    disable: true
+  - property: variable_temperature_space
+    disable: true
+  - property: variation_door_open_time
+    disable: true
+  - property: variation_max_temperature
+    disable: true
+  - property: variation_min_temperature
+    disable: true
+  - property: variation_poweroff_ad
+    disable: true
+  - property: variation_poweron_ad
+    disable: true
+  - property: variation_real_temperature
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: variation_sensor_real_temperature
+    optional: true
+    entity_category: diagnostic
+    sensor:
+      device_class: temperature
+      unit: °C
+      state_class: measurement
+      unknown_value: -40
+  - property: variation_temperature
+    unavailable: -40
+    number:
+      device_class: temperature
+      unit: °C
+      min_value: 5
+      max_value: 20
+      command:
+        name: SET_VARIATION_TEMPERATURE
+  - property: vibration_alarm
+    disable: true
+  - property: vibration_sensor_fault
+    disable: true
+  - property: water_box_alarm_switch_state
+    disable: true
+  - property: water_box_lack_status
+    disable: true
+  - property: water_box_mode_status
+    disable: true
+  - property: water_filter_surplus_time
+    disable: true
+  - property: water_filter_time_reset
+    disable: true
+  - property: water_tank_install_state
+    disable: true
+  - property: wet_and_dry_space
+    disable: true
+  - property: wifi_fault_flag
+    disable: true
+  - property: wifi_handshake_fault_flag
+    disable: true
+  - property: wifi_next_sendtime
+    disable: true
+  - property: wifi_rx_fault_flag
+    disable: true
+  - property: wifi_setting
+    disable: true
+  - property: wifi_tx_fault_flag
+    disable: true
+  - property: will_fresh_light_status
+    disable: true
+  - property: will_fress_light_exist
+    disable: true
+  - property: will_light_market_mode_state
+    disable: true
+  - property: will_light_mode_exist
+    disable: true
+  - property: will_light_mode_state
+    disable: true
+  - property: will_light_switch_state
+    disable: true
+  - property: wine_area_switch_status
+    disable: true
+  - property: wine_b_switch__area
+    disable: true
+  - property: wine_light
+    entity_category: config
+    switch:
+      command:
+        name: SET_WINE_LIGHT
+  - property: wine_sensor_failure_flag
+    disable: true
+  - property: work_mode1
+    disable: true
+  - property: work_mode2
+    disable: true

--- a/custom_components/connectlife/data_dictionaries/034.yaml
+++ b/custom_components/connectlife/data_dictionaries/034.yaml
@@ -1,7 +1,8 @@
 # Wine cooler
-statistics:
-  source: energy_consumption_curve
-  daily_energy_kwh: true
+#
+# Zones reuse the refrigerator property namespace: upper = variation_*, lower =
+# refrigerator_*, zone C = freeze_*. Entity names stay generic until custom
+# translation keys are supported; the upper/lower split is noted in comments below.
 properties:
   - property: AIR_FRESHNESS
     disable: true
@@ -26,9 +27,19 @@ properties:
   - property: camera_state
     disable: true
   - property: charcoal_filter_expiration_alarm
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: charcoal_filter_surplus_time
-    disable: true
+    entity_category: config
+    number:
+      min_value: 4
+      max_value: 12
+      command:
+        name: SET_CHARCOAL_FILTER_TIME
   - property: charcoal_filter_time_reset
     disable: true
   - property: child_lock_open_alarm
@@ -53,7 +64,12 @@ properties:
   - property: compressor_operating_min_frequency
     disable: true
   - property: condensation_fan_failure_status
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: control_failure_status
     disable: true
   - property: custard_room
@@ -97,7 +113,12 @@ properties:
   - property: electric_energy_percentile_thousands_value
     disable: true
   - property: envi_temp_sens_head_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: environment_humidity
     disable: true
   - property: environment_real_temperature
@@ -127,7 +148,12 @@ properties:
   - property: filter_alarm_time
     disable: true
   - property: filter_state
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: free_defrosting_failure
     disable: true
   - property: free_evap_temp_sens_head_failure
@@ -170,6 +196,7 @@ properties:
       unit: °C
       state_class: measurement
       unknown_value: -40
+  # Zone C; not fitted on the known model (disabled in feature override).
   - property: freeze_temperature
     unavailable: -40
     number:
@@ -244,7 +271,13 @@ properties:
   - property: low_wine_area_c_temp_fault
     disable: true
   - property: lumin_value_of_interior_light
-    optional: true
+    entity_category: config
+    number:
+      unit: "%"
+      min_value: 50
+      max_value: 100
+      command:
+        name: SET_LUMIN_OF_INTERIOR_LIGHT
   - property: mainboard_type
     disable: true
   - property: mainboard_version
@@ -338,7 +371,12 @@ properties:
   - property: refr_dry_wet_room_sens_failure
     disable: true
   - property: refr_evap_temp_sens_head_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: refr_fan_failure
     disable: true
   - property: refr_key
@@ -360,7 +398,12 @@ properties:
         0: false
         1: true
   - property: refr_temp_sens_head_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: refr_var_room_sens_failure
     disable: true
   - property: refrigerator_door_open_time
@@ -377,6 +420,7 @@ properties:
     disable: true
   - property: refrigerator_poweron_ad
     disable: true
+  # Lower zone temperature.
   - property: refrigerator_real_temperature
     sensor:
       device_class: temperature
@@ -391,6 +435,7 @@ properties:
       unit: °C
       state_class: measurement
       unknown_value: -40
+  # Lower zone setpoint (reporter-confirmed lower = refrigerator_*).
   - property: refrigerator_temperature
     unavailable: -40
     number:
@@ -495,7 +540,12 @@ properties:
   - property: running_status3
     disable: true
   - property: rx_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: sabbath_mode_status
     optional: true
   - property: sabbath_mode_switch_status
@@ -571,7 +621,12 @@ properties:
   - property: theme_color
     disable: true
   - property: tx_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: unfreeze_run_status
     disable: true
   - property: unfreeze_switch_status
@@ -600,7 +655,12 @@ properties:
         0: false
         1: true
   - property: vari_evap_temp_sens_head_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: vari_key
     disable: true
   - property: vari_room
@@ -613,7 +673,12 @@ properties:
         0: false
         1: true
   - property: vari_temp_sens_head_failure
-    disable: true
+    entity_category: diagnostic
+    binary_sensor:
+      device_class: problem
+      options:
+        0: false
+        1: true
   - property: variable_fan_failure_status
     disable: true
   - property: variable_heater_failure_status
@@ -630,6 +695,7 @@ properties:
     disable: true
   - property: variation_poweron_ad
     disable: true
+  # Upper zone temperature.
   - property: variation_real_temperature
     sensor:
       device_class: temperature
@@ -644,6 +710,7 @@ properties:
       unit: °C
       state_class: measurement
       unknown_value: -40
+  # Upper zone setpoint (reporter-confirmed upper = variation_*).
   - property: variation_temperature
     unavailable: -40
     number:

--- a/custom_components/connectlife/data_dictionaries/034.yaml
+++ b/custom_components/connectlife/data_dictionaries/034.yaml
@@ -1,8 +1,9 @@
 # Wine cooler
 #
 # Zones reuse the refrigerator property namespace: upper = variation_*, lower =
-# refrigerator_*, zone C = freeze_*. Entity names stay generic until custom
-# translation keys are supported; the upper/lower split is noted in comments below.
+# refrigerator_*, zone C = freeze_*. The upper/lower zone entities use custom
+# translation keys (wine_zone_upper_* / wine_zone_lower_*) so they read as zones
+# rather than refrigerator compartments.
 properties:
   - property: AIR_FRESHNESS
     disable: true
@@ -196,7 +197,7 @@ properties:
       unit: °C
       state_class: measurement
       unknown_value: -40
-  # Zone C; not fitted on the known model (disabled in feature override).
+  # Zone C?
   - property: freeze_temperature
     unavailable: -40
     number:
@@ -420,8 +421,8 @@ properties:
     disable: true
   - property: refrigerator_poweron_ad
     disable: true
-  # Lower zone temperature.
   - property: refrigerator_real_temperature
+    translation_key: wine_zone_lower_real_temperature
     sensor:
       device_class: temperature
       unit: °C
@@ -435,8 +436,8 @@ properties:
       unit: °C
       state_class: measurement
       unknown_value: -40
-  # Lower zone setpoint (reporter-confirmed lower = refrigerator_*).
   - property: refrigerator_temperature
+    translation_key: wine_zone_lower_temperature
     unavailable: -40
     number:
       device_class: temperature
@@ -695,8 +696,8 @@ properties:
     disable: true
   - property: variation_poweron_ad
     disable: true
-  # Upper zone temperature.
   - property: variation_real_temperature
+    translation_key: wine_zone_upper_real_temperature
     sensor:
       device_class: temperature
       unit: °C
@@ -710,8 +711,8 @@ properties:
       unit: °C
       state_class: measurement
       unknown_value: -40
-  # Upper zone setpoint (reporter-confirmed upper = variation_*).
   - property: variation_temperature
+    translation_key: wine_zone_upper_temperature
     unavailable: -40
     number:
       device_class: temperature

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2062,6 +2062,12 @@
       },
       "volume_setting": {
         "name": "Volume"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Lower zone"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Upper zone"
       }
     },
     "select": {
@@ -8437,6 +8443,12 @@
       },
       "wine_light": {
         "name": "Wine light"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Lower zone temperature"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Upper zone temperature"
       },
       "work_mode1": {
         "name": "Work mode 1"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -935,6 +935,9 @@
       "fill_salt": {
         "name": "Fill salt"
       },
+      "filter_state": {
+        "name": "Filter status"
+      },
       "float_switch": {
         "name": "Float switch"
       },
@@ -1991,6 +1994,9 @@
       "brightness_setting": {
         "name": "Brightness"
       },
+      "charcoal_filter_surplus_time": {
+        "name": "Charcoal filter time"
+      },
       "delayendtime": {
         "name": "Delay end time"
       },
@@ -2020,6 +2026,9 @@
       },
       "lightcolortemperature": {
         "name": "Light color temperature"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Interior light brightness"
       },
       "programoptiontimestartdelayhour": {
         "name": "Start delay hours"

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -5454,6 +5454,9 @@
       "sabbath_mode_settingstart_timeminute": {
         "name": "Sabbath mode setting start time minute"
       },
+      "sabbath_mode_status": {
+        "name": "Sabbath mode status"
+      },
       "sand_timer1_duration_in_seconds": {
         "name": "Sand timer 1 duration"
       },
@@ -8530,6 +8533,9 @@
       "child_lock_status_status": {
         "name": "Child lock status"
       },
+      "child_lock_switch_status": {
+        "name": "Child lock"
+      },
       "childlockenabled": {
         "name": "Child lock"
       },
@@ -8656,6 +8662,9 @@
       "proximitysensorstatus": {
         "name": "Proximity sensor"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Sabbath mode"
+      },
       "save_mode": {
         "name": "Save mode"
       },
@@ -8703,6 +8712,9 @@
       },
       "sr_mode": {
         "name": "SR mode"
+      },
+      "standby_mode_status": {
+        "name": "Standby mode"
       },
       "startdelayfunction": {
         "name": "Start delay"
@@ -8793,6 +8805,9 @@
       },
       "welcome": {
         "name": "Welcome"
+      },
+      "wine_light": {
+        "name": "Wine light"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -2440,6 +2440,9 @@
       "running_status": {
         "name": "Laufstatus"
       },
+      "sabbath_mode_status": {
+        "name": "Sabbatmodus-Status"
+      },
       "sand_timer1_duration_in_seconds": {
         "name": "Sanduhr 1 Dauer in Sekunden"
       },
@@ -3719,6 +3722,9 @@
       "child_lock_status_status": {
         "name": "Kindersicherungsstatus"
       },
+      "child_lock_switch_status": {
+        "name": "Kindersicherung"
+      },
       "cleaning_reminder_setting": {
         "name": "Reinigungserinnerung"
       },
@@ -3791,6 +3797,9 @@
       "prewash": {
         "name": "Vorw\u00e4sche"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Sabbatmodus"
+      },
       "save_mode": {
         "name": "Sparmodus"
       },
@@ -3817,6 +3826,9 @@
       },
       "sr_mode": {
         "name": "SR-Modus"
+      },
+      "standby_mode_status": {
+        "name": "Standby-Modus"
       },
       "steam": {
         "name": "Dampf"
@@ -3871,6 +3883,9 @@
       },
       "welcome": {
         "name": "Willkommen"
+      },
+      "wine_light": {
+        "name": "Weinlicht"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1296,6 +1296,12 @@
       },
       "volume_setting": {
         "name": "Lautst\u00e4rke"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Untere Zone"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Obere Zone"
       }
     },
     "select": {
@@ -3692,6 +3698,12 @@
           "not_detected": "Nicht erkannt",
           "present": "Vorhanden"
         }
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Temperatur untere Zone"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Temperatur obere Zone"
       },
       "zone_number": {
         "name": "Anzahl der Zonen"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -652,6 +652,9 @@
       "fill_salt": {
         "name": "Salz nachf\u00fcllen"
       },
+      "filter_state": {
+        "name": "Filterstatus"
+      },
       "float_switch": {
         "name": "Schwimmerschalter"
       },
@@ -1249,6 +1252,9 @@
       "brightness_setting": {
         "name": "Helligkeit"
       },
+      "charcoal_filter_surplus_time": {
+        "name": "Kohlefilter-Zeit"
+      },
       "freeze_max_temperature": {
         "name": "Maximale Gefriertemperatur"
       },
@@ -1263,6 +1269,9 @@
       },
       "gratin_function_set_time_in_seconds": {
         "name": "Gratin Zeiteinstellung"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Helligkeit Innenbeleuchtung"
       },
       "refrigerator_max_temperature": {
         "name": "Maximale K\u00fchlschranktemperatur"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2062,6 +2062,12 @@
       },
       "volume_setting": {
         "name": "Volume"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Lower zone"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Upper zone"
       }
     },
     "select": {
@@ -8437,6 +8443,12 @@
       },
       "wine_light": {
         "name": "Wine light"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Lower zone temperature"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Upper zone temperature"
       },
       "work_mode1": {
         "name": "Work mode 1"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -935,6 +935,9 @@
       "fill_salt": {
         "name": "Fill salt"
       },
+      "filter_state": {
+        "name": "Filter status"
+      },
       "float_switch": {
         "name": "Float switch"
       },
@@ -1991,6 +1994,9 @@
       "brightness_setting": {
         "name": "Brightness"
       },
+      "charcoal_filter_surplus_time": {
+        "name": "Charcoal filter time"
+      },
       "delayendtime": {
         "name": "Delay end time"
       },
@@ -2020,6 +2026,9 @@
       },
       "lightcolortemperature": {
         "name": "Light color temperature"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Interior light brightness"
       },
       "programoptiontimestartdelayhour": {
         "name": "Start delay hours"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -5454,6 +5454,9 @@
       "sabbath_mode_settingstart_timeminute": {
         "name": "Sabbath mode setting start time minute"
       },
+      "sabbath_mode_status": {
+        "name": "Sabbath mode status"
+      },
       "sand_timer1_duration_in_seconds": {
         "name": "Sand timer 1 duration"
       },
@@ -8530,6 +8533,9 @@
       "child_lock_status_status": {
         "name": "Child lock status"
       },
+      "child_lock_switch_status": {
+        "name": "Child lock"
+      },
       "childlockenabled": {
         "name": "Child lock"
       },
@@ -8656,6 +8662,9 @@
       "proximitysensorstatus": {
         "name": "Proximity sensor"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Sabbath mode"
+      },
       "save_mode": {
         "name": "Save mode"
       },
@@ -8703,6 +8712,9 @@
       },
       "sr_mode": {
         "name": "SR mode"
+      },
+      "standby_mode_status": {
+        "name": "Standby mode"
       },
       "startdelayfunction": {
         "name": "Start delay"
@@ -8793,6 +8805,9 @@
       },
       "welcome": {
         "name": "Welcome"
+      },
+      "wine_light": {
+        "name": "Wine light"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -298,6 +298,9 @@
       "fill_salt": {
         "name": "Recargar sal"
       },
+      "filter_state": {
+        "name": "Estado del filtro"
+      },
       "float_switch": {
         "name": "Interruptor de flotador"
       },
@@ -681,6 +684,9 @@
       }
     },
     "number": {
+      "charcoal_filter_surplus_time": {
+        "name": "Tiempo del filtro de carb\u00f3n"
+      },
       "freeze_max_temperature": {
         "name": "Congelador temperatura m\u00e1xima"
       },
@@ -689,6 +695,9 @@
       },
       "freeze_temperature": {
         "name": "Temperatura Congelador"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Brillo de la luz interior"
       },
       "refrigerator_max_temperature": {
         "name": "Frigorifico temperatura m\u00e1xima"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -1095,6 +1095,9 @@
       "rinsenum": {
         "name": "Aclarados extra"
       },
+      "sabbath_mode_status": {
+        "name": "Estado del modo Sabbath"
+      },
       "sand_timer1_duration_in_seconds": {
         "name": "Duraci\u00f1on temporizador 1"
       },
@@ -1643,6 +1646,9 @@
       "child_lock_status_status": {
         "name": "Estado del bloqueo infantil"
       },
+      "child_lock_switch_status": {
+        "name": "Bloqueo para ni\u00f1os"
+      },
       "drum_light": {
         "name": "Luz tambor"
       },
@@ -1658,8 +1664,14 @@
       "prewash": {
         "name": "Prelavado"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Modo Sabbath"
+      },
       "save_mode": {
         "name": "Modo ahorro"
+      },
+      "standby_mode_status": {
+        "name": "Modo en espera"
       },
       "steam": {
         "name": "Vapor"
@@ -1690,6 +1702,9 @@
       },
       "t_up_down": {
         "name": "Oscilaci\u00f3n vertical"
+      },
+      "wine_light": {
+        "name": "Luz de la vinoteca"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -716,6 +716,12 @@
       },
       "variation_temperature": {
         "name": "Temperatura variaci\u00f3n"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Zona inferior"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Zona superior"
       }
     },
     "select": {
@@ -1631,6 +1637,12 @@
       },
       "water_consumption_in_running_program": {
         "name": "Agua consumida en programa actual"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Temperatura zona inferior"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Temperatura zona superior"
       },
       "zone_number": {
         "name": "N\u00famero de zonas"

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -112,6 +112,9 @@
       "f_e_waterfull": {
         "name": "R\u00e9servoir d'eau plein"
       },
+      "filter_state": {
+        "name": "\u00c9tat du filtre"
+      },
       "free_defrosting_failure": {
         "name": "D\u00e9faut d\u00e9givrage cong\u00e9lateur"
       },
@@ -344,6 +347,9 @@
       }
     },
     "number": {
+      "charcoal_filter_surplus_time": {
+        "name": "Dur\u00e9e du filtre \u00e0 charbon"
+      },
       "delayendtime": {
         "name": "Fin diff\u00e9r\u00e9e"
       },
@@ -355,6 +361,9 @@
       },
       "freeze_temperature": {
         "name": "Temp\u00e9rature cong\u00e9lateur"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Luminosit\u00e9 de l'\u00e9clairage int\u00e9rieur"
       },
       "refrigerator_max_temperature": {
         "name": "Temp\u00e9rature max frigo"

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -382,6 +382,12 @@
       },
       "variation_temperature": {
         "name": "Temp\u00e9rature zone variable"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Zone inf\u00e9rieure"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Zone sup\u00e9rieure"
       }
     },
     "select": {
@@ -1222,6 +1228,12 @@
       },
       "wine_light": {
         "name": "Voyant cave \u00e0 vin"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Temp\u00e9rature zone inf\u00e9rieure"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Temp\u00e9rature zone sup\u00e9rieure"
       },
       "work_mode1": {
         "name": "Mode de fonctionnement 1"

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -973,6 +973,9 @@
       "running_status3": {
         "name": "\u00c9tat de fonctionnement 3"
       },
+      "sabbath_mode_status": {
+        "name": "\u00c9tat du mode Sabbath"
+      },
       "screen_display_brightness": {
         "name": "Luminosit\u00e9 \u00e9cran"
       },
@@ -1237,6 +1240,9 @@
       "child_lock_status_status": {
         "name": "\u00c9tat de la s\u00e9curit\u00e9 enfant"
       },
+      "child_lock_switch_status": {
+        "name": "S\u00e9curit\u00e9 enfant"
+      },
       "extra_rinse": {
         "name": "Rin\u00e7age suppl\u00e9mentaire"
       },
@@ -1255,6 +1261,9 @@
       "prewash": {
         "name": "Pr\u00e9lavage"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Mode Sabbath"
+      },
       "save_mode": {
         "name": "Mode \u00e9co"
       },
@@ -1267,8 +1276,14 @@
       "sr_mode": {
         "name": "Super-refroidissement"
       },
+      "standby_mode_status": {
+        "name": "Mode veille"
+      },
       "steam": {
         "name": "Vapeur"
+      },
+      "wine_light": {
+        "name": "\u00c9clairage cave \u00e0 vin"
       }
     }
   },

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -372,6 +372,9 @@
           "open": "Apera"
         }
       },
+      "sabbath_mode_status": {
+        "name": "Stato modalit\u00e0 Sabbath"
+      },
       "selected_program_id": {
         "name": "Seleziona programma",
         "state": {
@@ -657,6 +660,15 @@
       "child_lock_status_status": {
         "name": "Stato blocco bambini"
       },
+      "child_lock_switch_status": {
+        "name": "Blocco bambini"
+      },
+      "sabbath_mode_switch_status": {
+        "name": "Modalit\u00e0 Sabbath"
+      },
+      "standby_mode_status": {
+        "name": "Modalit\u00e0 standby"
+      },
       "t_air": {
         "name": "Air"
       },
@@ -683,6 +695,9 @@
       },
       "t_up_down": {
         "name": "Oscillazione verticale"
+      },
+      "wine_light": {
+        "name": "Luce cantinetta"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -296,6 +296,12 @@
       },
       "lumin_value_of_interior_light": {
         "name": "Luminosit\u00e0 luce interna"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Zona inferiore"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Zona superiore"
       }
     },
     "select": {
@@ -659,6 +665,12 @@
       },
       "total_time_of_cooking_in_hours": {
         "name": "Tempo totale di cottura"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Temperatura zona inferiore"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Temperatura zona superiore"
       },
       "zone_number": {
         "name": "Number of zones"

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -55,6 +55,9 @@
       "f_e_waterfull": {
         "name": "Acqua piena"
       },
+      "filter_state": {
+        "name": "Stato del filtro"
+      },
       "selected_program_anticrease_status": {
         "name": "Antipiega"
       },
@@ -285,6 +288,14 @@
             }
           }
         }
+      }
+    },
+    "number": {
+      "charcoal_filter_surplus_time": {
+        "name": "Durata del filtro a carbone"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Luminosit\u00e0 luce interna"
       }
     },
     "select": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -4836,6 +4836,9 @@
       "sabbath_mode_settingstart_timeminute": {
         "name": "Sabbath mode setting start time minute"
       },
+      "sabbath_mode_status": {
+        "name": "Sabbatmodus status"
+      },
       "sand_timer1_duration_in_seconds": {
         "name": "Zandloper 1 duur (seconden)"
       },
@@ -7837,6 +7840,9 @@
       "child_lock_status_status": {
         "name": "Status kinderbeveiliging"
       },
+      "child_lock_switch_status": {
+        "name": "Kinderslot"
+      },
       "cleanairstatus": {
         "name": "Schone lucht"
       },
@@ -7942,6 +7948,9 @@
       "proximitysensorstatus": {
         "name": "Nabijheidssensor"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Sabbatmodus"
+      },
       "save_mode": {
         "name": "Spaarstand"
       },
@@ -7983,6 +7992,9 @@
       },
       "sr_mode": {
         "name": "SR-modus"
+      },
+      "standby_mode_status": {
+        "name": "Stand-bymodus"
       },
       "steam": {
         "name": "Stoom"
@@ -8067,6 +8079,9 @@
       },
       "welcome": {
         "name": "Welkom"
+      },
+      "wine_light": {
+        "name": "Wijnverlichting"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1751,6 +1751,12 @@
       },
       "volume_setting": {
         "name": "Volume"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Onderste zone"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "Bovenste zone"
       }
     },
     "select": {
@@ -7750,6 +7756,12 @@
       },
       "wine_light": {
         "name": "Wine light"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Temperatuur onderste zone"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Temperatuur bovenste zone"
       },
       "work_mode1": {
         "name": "Work mode 1"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -696,6 +696,9 @@
       "fill_salt": {
         "name": "Onthardingszout bijvullen"
       },
+      "filter_state": {
+        "name": "Filterstatus"
+      },
       "float_switch": {
         "name": "Vlotterschakelaar"
       },
@@ -1686,6 +1689,9 @@
       "brightness_setting": {
         "name": "Helderheid"
       },
+      "charcoal_filter_surplus_time": {
+        "name": "Koolstoffiltertijd"
+      },
       "delayendtime": {
         "name": "Delay end time"
       },
@@ -1715,6 +1721,9 @@
       },
       "lightcolortemperature": {
         "name": "Light color temperature"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Helderheid binnenverlichting"
       },
       "refrigerator_max_temperature": {
         "name": "Koelkast max temperatuur"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -4836,6 +4836,9 @@
       "sabbath_mode_settingstart_timeminute": {
         "name": "Sabbatsmodus \u2013 start-minutt"
       },
+      "sabbath_mode_status": {
+        "name": "Status for sabbatsmodus"
+      },
       "sand_timer1_duration_in_seconds": {
         "name": "Eggur 1 \u2013 varighet"
       },
@@ -7837,6 +7840,9 @@
       "child_lock_status_status": {
         "name": "Barnesikringsstatus"
       },
+      "child_lock_switch_status": {
+        "name": "Barnesikring"
+      },
       "cleanairstatus": {
         "name": "Ren luft"
       },
@@ -7942,6 +7948,9 @@
       "proximitysensorstatus": {
         "name": "N\u00e6rhetssensor"
       },
+      "sabbath_mode_switch_status": {
+        "name": "Sabbatsmodus"
+      },
       "save_mode": {
         "name": "Sparemodus"
       },
@@ -7983,6 +7992,9 @@
       },
       "sr_mode": {
         "name": "SR-modus"
+      },
+      "standby_mode_status": {
+        "name": "Hvilemodus"
       },
       "steam": {
         "name": "Damp"
@@ -8067,6 +8079,9 @@
       },
       "welcome": {
         "name": "Velkommen"
+      },
+      "wine_light": {
+        "name": "Vinlys"
       }
     },
     "water_heater": {

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -696,6 +696,9 @@
       "fill_salt": {
         "name": "Fyll salt"
       },
+      "filter_state": {
+        "name": "Filterstatus"
+      },
       "float_switch": {
         "name": "Flott\u00f8rbryter"
       },
@@ -1686,6 +1689,9 @@
       "brightness_setting": {
         "name": "Lysstyrke"
       },
+      "charcoal_filter_surplus_time": {
+        "name": "Kullfiltertid"
+      },
       "delayendtime": {
         "name": "Utsatt sluttid"
       },
@@ -1715,6 +1721,9 @@
       },
       "lightcolortemperature": {
         "name": "Fargetemperatur for lys"
+      },
+      "lumin_value_of_interior_light": {
+        "name": "Innvendig lysstyrke"
       },
       "refrigerator_max_temperature": {
         "name": "Maks kj\u00f8leskapstemperatur"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1751,6 +1751,12 @@
       },
       "volume_setting": {
         "name": "Volum"
+      },
+      "wine_zone_lower_temperature": {
+        "name": "Nedre sone"
+      },
+      "wine_zone_upper_temperature": {
+        "name": "\u00d8vre sone"
       }
     },
     "select": {
@@ -7750,6 +7756,12 @@
       },
       "wine_light": {
         "name": "Vinlys"
+      },
+      "wine_zone_lower_real_temperature": {
+        "name": "Temperatur nedre sone"
+      },
+      "wine_zone_upper_real_temperature": {
+        "name": "Temperatur \u00f8vre sone"
       },
       "work_mode1": {
         "name": "Arbeidsmodus 1"


### PR DESCRIPTION
New device type **034** (wine cooler): base `034.yaml` plus a variant override for the dual-zone Hisense RW3N122GSLF (`034-1j0122z0035j`). Verified against the device owner's testing in #593.

## Entities (this model)
**Controls**
- Two writable zone setpoints, 5–20 °C: **Upper zone** (`variation_temperature`) and **Lower zone** (`refrigerator_temperature`)
- **Child lock** and **Sabbath mode** switches
- **Interior light brightness** (50–100 %)
- **Temperature unit** (°C/°F)
- **Charcoal filter** reminder (4–12 months)

**Sensors / diagnostics**
- Upper / Lower zone temperatures
- Door open + "door left open" alarm (single door), per-zone over-temperature alarms
- Charcoal filter expiration alarm
- Self-diagnostic fault flags (per-zone temp & evaporator sensors, ambient sensor, display board TX/RX, condensate fan, filter status)
- Upper-zone evaporator-coil temperature (optional, off by default)

## Naming
Zone entities use custom `translation_key`s (feature added in #595) so they read "Upper/Lower zone" instead of the fridge-shared "Variation/Refrigerator" names. Translated in all supported languages.

## Disabled
The device reuses the whole refrigerator property namespace; everything not listed above is disabled — generic noise (ice maker, humidity, water supply, RGB, reserved flags) in the base, and model-specific absences in the variant: zone C (`freeze_*`), `-40`-sentinel sensors (ambient, lower evaporator), the second (variation) door entities (single-door cabinet), standby, wine-light on/off, and redundant/unidentifiable sensors. Temperature readings use `-40` as the unknown sentinel.

Closes #593