### PR TITLE
Add optional translation_key override for properties

### DIFF
--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -72,7 +72,7 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
             entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
-            translation_key=self.to_translation_key(status),
+            translation_key=self.to_translation_key(dd_entry.translation_key or status),
             device_class=dd_entry.binary_sensor.device_class,
             entity_category=dd_entry.entity_category,
         )

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -28,6 +28,7 @@ The following top-level fields always inherit, even across platform changes:
 - `disable`
 - `optional`
 - `entity_category`
+- `translation_key`
 - `unavailable`
 - `combine` — if you change the platform and want to drop the base's combine sources, clear it with
   `combine: null`.
@@ -167,6 +168,7 @@ Note that translation keys must be lowercase!
 | `icon`             | `mdi:eye`, etc.                    | Icon to use for the entity.                                                                                                                                                                                                                                                                         |
 | `unavailable`      | integer                            | If the property has this value on the device, no entity is created for it. Use for properties that the device reports as "not available" with a sentinel value.                                                                                                                                     |
 | `entity_category`  | `config`, `diagnostic`             | Whether the entity should be considered a diagnostics or config entity. Defaults to `None`. [More info in HA docs](https://developers.home-assistant.io/docs/core/entity/#registry-properties:~:text=automatic%20device%20registration.-,entity_category,-EntityCategory%20%7C%20None)              |
+| `translation_key`  | string                             | Custom translation key for the entity, used instead of the one derived from the property name. Lets a device-specific mapping name an entity (in `strings.json`/translations). Must be lowercase. Only applies to per-property platforms.                    |
 | `binary_sensor`    | [BinarySensor](#type-binarysensor) | Create a binary sensor of the property.                                                                                                                                                                                                                                                             |
 | `climate`          | [Climate](#type-climate)           | Map the property to a climate entity for the device.                                                                                                                                                                                                                                                |
 | `humidifier`       | [Humidifier](#type-humidifier)     | Map the property to a humidifier entity for the device.                                                                                                                                                                                                                                             |

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -145,6 +145,12 @@
             "config",
             "diagnostic"
           ]
+        },
+        "translation_key": {
+          "type": ["string", "null"],
+          "title": "Translation key",
+          "description": "Custom translation key for the entity, overriding the default derived from the property name. Use to give an entity a device-specific name without renaming the API property. Must be lowercase.",
+          "pattern": "^[a-z0-9_]+$"
         }
       },
       "required": [

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -57,6 +57,7 @@ SWITCH = "switch"
 COMBINE = "combine"
 UNAVAILABLE = "unavailable"
 ENTITY_CATEGORY = "entity_category"
+TRANSLATION_KEY = "translation_key"
 UNKNOWN_VALUE = "unknown_value"
 UNIT = "unit"
 WRITE = "write"
@@ -331,6 +332,7 @@ class Property:
     optional: bool
     unavailable: int | None
     entity_category: EntityCategory | None
+    translation_key: str | None
     combine: list[CombineSource] | None
     binary_sensor: BinarySensor
     climate: Climate
@@ -353,6 +355,7 @@ class Property:
             EntityCategory[entity_category.upper()] if entity_category is not None else None
         )
         self.combine = _val(entry, COMBINE)
+        self.translation_key = _val(entry, TRANSLATION_KEY)
 
         if Platform.BINARY_SENSOR in entry:
             self.binary_sensor = BinarySensor(self.name, entry[Platform.BINARY_SENSOR])

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -73,7 +73,7 @@ class ConnectLifeNumberEntity(ConnectLifeEntity, NumberEntity):
             native_unit_of_measurement=to_unit(
                 dd_entry.number.unit, appliance=appliance, dictionary=dictionary
             ),
-            translation_key=self.to_translation_key(status),
+            translation_key=self.to_translation_key(dd_entry.translation_key or status),
             entity_category=dd_entry.entity_category,
         )
         self._refresh_state()

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -68,7 +68,7 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
             entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
-            translation_key=self.to_translation_key(status),
+            translation_key=self.to_translation_key(dd_entry.translation_key or status),
             entity_category=dd_entry.entity_category,
         )
         self._refresh_state()

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -126,7 +126,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
                 dd_entry.sensor.unit, appliance=appliance, dictionary=dictionary
             ),
             state_class=state_class,
-            translation_key=self.to_translation_key(status),
+            translation_key=self.to_translation_key(dd_entry.translation_key or status),
             entity_category=dd_entry.entity_category,
         )
         self._refresh_state()

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -65,7 +65,7 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
             entity_registry_enabled_default=not dd_entry.optional,
             icon=dd_entry.icon,
             name=status.replace("_", " "),
-            translation_key=self.to_translation_key(status),
+            translation_key=self.to_translation_key(dd_entry.translation_key or status),
             device_class=dd_entry.switch.device_class,
             entity_category=dd_entry.entity_category,
         )

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -106,7 +106,7 @@ def main(basedir):
                     else:
                         if "disable" in property and property["disable"]:
                             continue
-                        key = to_key(property["property"])
+                        key = to_key(property.get("translation_key") or property["property"])
                         if not any(entity_type in property for entity_type in ["binary_sensor", "climate", "humidifier", "number", "select", "sensor", "switch", "water_heater"]):
                             valid_properties.setdefault("sensor", set()).add(key)
                             name = property["property"]
@@ -121,7 +121,7 @@ def main(basedir):
                                 if entity_type not in strings["entity"]:
                                     strings["entity"][entity_type] = {}
                                 name = property["property"]
-                                key = to_key(name)
+                                key = to_key(property.get("translation_key") or name)
                                 if key not in strings["entity"][entity_type]:
                                     strings["entity"][entity_type][key] = {"name": pretty(name)}
                                 elif "name" not in strings["entity"][entity_type][key]:

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -276,6 +276,37 @@ def test_optional_parsing():
     assert Property({"property": "p"}).optional is False
 
 
+def test_translation_key_parsing():
+    assert (
+        Property({"property": "p", "translation_key": "custom_key"}).translation_key
+        == "custom_key"
+    )
+    assert Property({"property": "p"}).translation_key is None
+    assert Property({"property": "p", "translation_key": None}).translation_key is None
+
+
+def test_translation_key_inherited_across_platform_change():
+    base = {
+        "property": "p",
+        "translation_key": "wine_zone_upper",
+        "sensor": {"device_class": "temperature", "unit": "°C"},
+    }
+    override = {"property": "p", "number": {"min_value": 5, "max_value": 20}}
+
+    merged = _merge_property(base, override)
+
+    assert merged["translation_key"] == "wine_zone_upper"
+
+
+def test_translation_key_overridden_by_feature():
+    base = {"property": "p", "translation_key": "base_key", "sensor": {}}
+    override = {"property": "p", "translation_key": "feature_key"}
+
+    merged = _merge_property(base, override)
+
+    assert merged["translation_key"] == "feature_key"
+
+
 def test_statistics_block_parsed(build_dictionary):
     # A statistics block is parsed into source + per-sensor flags.
     d = build_dictionary(


### PR DESCRIPTION
## Why

Entity names are derived from the property name (`to_translation_key(property_name)`), and that key is **global** — shared across every device type that maps the property. So a property reused across device types (e.g. `variation_temperature` on both refrigerators and wine coolers) can't be named differently per device without renaming the API property or clobbering the other device's entity name.

## What

Add an optional per-property `translation_key` field to the mapping files that overrides the derived key. A device-specific mapping can then name an entity (in `strings.json`/translations) independently of the shared property.

```yaml
- property: variation_temperature
  translation_key: wine_zone_upper
  number: { min_value: 5, max_value: 20 }
```

- **`dictionaries.py`** — parse `translation_key` on `Property`; inherits/overrides in feature files via the existing top-level merge (no `_merge_property` change needed).
- **Per-property entities** (`sensor`, `number`, `switch`, `select`, `binary_sensor`) — use the custom key when set, else fall back to the property name. Device-level entities (climate/humidifier/water_heater) and statistics sensors are unaffected.
- **`gen_strings.py`** — generates the matching `strings.json` key so names line up.
- **Schema** — new field with `pattern: ^[a-z0-9_]+$` (lowercase-only, required because the property object is `additionalProperties: false`).
- **README** — documented in the Property table and the inheritance list.

## Tests

3 new tests in `test_dictionaries.py` (parsing, inheritance across a platform change, feature override). Full suite: 50 passed. `gen_strings` is inert on existing mappings (no string churn until the field is used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)