### PR TITLE
Priority-based fallback for climate targets

### DIFF
--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -22,7 +22,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import has_platform
+from .utils import climate_bound_properties, has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,12 +37,14 @@ async def async_setup_entry(
     devices = config_entry.options.get(CONF_DEVICES, {})
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
+        climate_bound = climate_bound_properties(appliance, dictionary)
         async_add_entities(
             ConnectLifeBinaryStatusSensor(
                 coordinator, appliance, s, dictionary.properties[s]
             )
             for s in appliance.status_list
             if has_platform(Platform.BINARY_SENSOR, dictionary.properties[s])
+            and s not in climate_bound
         )
         if devices.get(appliance.device_id, {}).get(CONF_EXPOSE_OFFLINE_STATE, False):
             async_add_entities(

--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -31,7 +31,7 @@ from .const import (
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary
 from .entity import ConnectLifeEntity
-from .utils import has_platform, to_temperature_map, normalize_temperature_unit
+from .utils import climate_target_bindings, has_platform, to_temperature_map, normalize_temperature_unit
 from connectlife.appliance import ConnectLifeAppliance
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,7 +130,6 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
             translation_key=DOMAIN
         )
 
-        self.target_map = {}
         self.fan_mode_map = {}
         self.fan_mode_reverse_map = {}
         self.hvac_action_map = {}
@@ -146,16 +145,9 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
         self.max_temperature_map = {}
         self.unknown_values = {}
 
-        for dd_entry in data_dictionary.properties.values():
-            if has_platform(Platform.CLIMATE, dd_entry) and dd_entry.name in appliance.status_list and dd_entry.climate.target is not None:
-                target = dd_entry.climate.target
-                if target in self.target_map:
-                    _LOGGER.warning(
-                        "%s and %s both map to climate %s for %s; using %s. "
-                        "The device exposes more properties than its mapping expects — please report it.",
-                        self.target_map[target], dd_entry.name, target, self.nickname, dd_entry.name,
-                    )
-                self.target_map[target] = dd_entry.name
+        # When several properties claim the same climate target, the lowest-
+        # priority candidate the device exposes wins (see climate_target_bindings).
+        self.target_map = climate_target_bindings(appliance, data_dictionary)
 
         hvac_modes: list[HVACMode] = []
         for target, status in self.target_map.items():

--- a/custom_components/connectlife/data_dictionaries/006-201.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-201.yaml
@@ -1,10 +1,1 @@
 # Portable air conditioner — uses default mappings
-properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"

--- a/custom_components/connectlife/data_dictionaries/006-202.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-202.yaml
@@ -1,13 +1,5 @@
 # Portable air conditioner — cool-only (no heat mode)
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/006-203.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-203.yaml
@@ -1,10 +1,1 @@
 # Portable air conditioner — uses default mappings
-properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"

--- a/custom_components/connectlife/data_dictionaries/006-299.yaml
+++ b/custom_components/connectlife/data_dictionaries/006-299.yaml
@@ -1,13 +1,5 @@
 # Portable air conditioner — cool-only (no heat mode)
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/006.yaml
+++ b/custom_components/connectlife/data_dictionaries/006.yaml
@@ -285,6 +285,9 @@ properties:
   - property: t_swing_angle
     climate:
       target: swing_mode
+      # Preferred swing_mode control: this multi-position axis wins over the
+      # on/off t_up_down fallback on devices that expose both.
+      priority: 1
       options:
         # Ordered logically, not by key
         0: swing
@@ -357,8 +360,17 @@ properties:
     switch:
       device_class: switch
   - property: t_up_down
+    # On/off vertical swing. Used as the swing_mode control on devices that
+    # expose t_up_down but not the richer t_swing_angle (priority 1); when both
+    # are present, t_swing_angle wins and t_up_down falls back to this switch.
     switch:
       device_class: switch
+    climate:
+      target: swing_mode
+      priority: 2
+      options:
+        0: "off"
+        1: "on"
     icon: mdi:arrow-oscillating
   - property: t_work_mode
     climate:

--- a/custom_components/connectlife/data_dictionaries/009-100.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-100.yaml
@@ -70,12 +70,3 @@ climate:
       t_sleep: 4
       t_super: 0
       preset: eco_sleep_4
-properties:
-  # This device exposes only t_up_down (no t_swing_angle), so map it to the
-  # vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009-101.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-101.yaml
@@ -1,12 +1,4 @@
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-102.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-102.yaml
@@ -1,10 +1,1 @@
 # No overrides needed; all properties covered by default 009.yaml.
-properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009-103.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-103.yaml
@@ -1,12 +1,4 @@
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -77,11 +77,3 @@ properties:
       state_class: measurement
       unit: kW
       multiplier: 0.1
-  # This device exposes only t_up_down (no t_swing_angle), so map it to the
-  # vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009-105.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-105.yaml
@@ -72,14 +72,6 @@ climate:
       t_fan_mute: 0
       t_super: 0
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-107.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-107.yaml
@@ -1,12 +1,4 @@
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_work_mode
     climate:
       options:

--- a/custom_components/connectlife/data_dictionaries/009-120.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-120.yaml
@@ -1,12 +1,4 @@
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_temp
     climate:
       max_value:

--- a/custom_components/connectlife/data_dictionaries/009-121.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-121.yaml
@@ -1,13 +1,5 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-122.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-122.yaml
@@ -1,13 +1,5 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-125.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-125.yaml
@@ -1,13 +1,5 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-126.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-126.yaml
@@ -1,13 +1,5 @@
 # t_temp range extends to the 8° heat mode low setpoint (8 °C / 46 °F).
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_temp
     climate:
       min_value:

--- a/custom_components/connectlife/data_dictionaries/009-127.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-127.yaml
@@ -1,12 +1,4 @@
 properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"
   - property: t_temp
     climate:
       max_value:

--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -8,12 +8,3 @@ climate:
       t_fan_speed: 0 # auto
       t_power: 1
       preset: mute
-properties:
-  # This featureset's spec exposes only t_up_down (no t_swing_angle), so
-  # map it to the vertical swing_mode control instead of the default switch.
-  - property: t_up_down
-    climate:
-      target: swing_mode
-      options:
-        0: "off"
-        1: "on"

--- a/custom_components/connectlife/data_dictionaries/009.yaml
+++ b/custom_components/connectlife/data_dictionaries/009.yaml
@@ -401,6 +401,9 @@ properties:
   - property: t_swing_angle
     climate:
       target: swing_mode
+      # Preferred swing_mode control: this multi-position axis wins over the
+      # on/off t_up_down fallback on devices that expose both.
+      priority: 1
       options:
         # Ordered logically, not by key
         0: swing
@@ -422,8 +425,17 @@ properties:
         0: forward
         1: right
   - property: t_up_down
+    # On/off vertical swing. Used as the swing_mode control on devices that
+    # expose t_up_down but not the richer t_swing_angle (priority 1); when both
+    # are present, t_swing_angle wins and t_up_down falls back to this switch.
     switch:
       device_class: switch
+    climate:
+      target: swing_mode
+      priority: 2
+      options:
+        0: "off"
+        1: "on"
     icon: mdi:arrow-oscillating
   - property: t_temp
     climate:

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -18,8 +18,11 @@ will just be ignored for feature variants that don't expose that property.
 ### Property inheritance in feature overrides
 
 Any field in a property can be overridden in a feature file; unspecified fields are inherited from the
-base type file. If the override changes the platform type (e.g., from `sensor:` to `select:`), the
-override's platform block replaces the base's.
+base type file. Platforms are inherited in two independent groups: the **device-level** platform
+(`climate` / `humidifier` / `water_heater`) and the **per-property** platform (`binary_sensor` /
+`number` / `select` / `sensor` / `switch`). Changing the platform *within a group* (e.g. `sensor:` to
+`select:`) replaces the base's block for that group; an override that touches only one group leaves
+the other intact. A property may therefore hold one of each — see [Target fallback](#target-fallback).
 
 The following top-level fields always inherit, even across platform changes:
 
@@ -97,8 +100,9 @@ The file contains these top level items:
 To make a property visible by default, just add the property to the list. Note that properties you do not map are still
 mapped to [sensor](#type-sensor) entities, but registered as disabled by default.
 
-Each property is mapped to _one_ entity or _one_ target property. In addition, each `climate` preset is mapped to a
-set of properties and values.
+Each property is mapped to _one_ entity or _one_ target property (with one exception: a property may
+declare a climate `target` candidacy alongside a per-property platform as a [fallback](#target-fallback)).
+In addition, each `climate` preset is mapped to a set of properties and values.
 
 If you disable or change the type of mapping, old entities will be automatically removed from Home Assistant, while
 state attributes will change to unavailable.
@@ -278,6 +282,7 @@ type `climate`, a climate entity is created for the appliance.
 | Item            | Type                                               | Description                                                                                                                                                                                                                                                                                                                                |
 |-----------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `target`        | string                                             | Any  of these [climate entity](https://developers.home-assistant.io/docs/core/entity/climate#properties) attributes: `current_humidity`, `fan_mode`, `hvac_action`, `hvac_mode`, `swing_horizontal_mode`, `swing_mode`, `current_temperature`, `target_humidity`, `target_temperature`, `temperature_unit`, or the special target `is_on`. |
+| `priority`      | integer                                            | Tie-break when several properties map to the same `target`. Lower = preferred. Defaults to 100. See [Target fallback](#target-fallback).                                                                                                                                                                                                   |
 | `options`       | dictionary of integer to string                    | Required for `fan_mode`, `hvac_action`, `hvac_mode`, `swing_horizontal_mode`, `swing_mode`, and `temperature_unit`.                                                                                                                                                                                                                        |
 | `unknown_value` | integer                                            | The value used by the API to signal unknown value.                                                                                                                                                                                                                                                                                         |
 | `min_value`     | [IntegerOrTemperature](#type-integerortemperature) | Minimum allowed value. Supported for `target_humidity` (integer) and `target_temperature` (temperature).                                                                                                                                                                                                                                   |
@@ -305,6 +310,42 @@ If a value does not have a sensible mapping, leave it out to set `hvac_action` t
 mapping to a sensor `enum` instead.
 
 For `fan_mode`, `swing_horizontal_mode`, and `swing_mode`, remember to add [translation strings](#translation-strings) for the options.
+
+#### Target fallback
+
+Two appliances that share the same `deviceTypeCode`/`deviceFeatureCode` — and therefore the same
+data dictionary — can still expose different property sets. To handle this, **several properties may
+map to the same climate `target`**. For each target, the integration binds the candidate with the
+lowest `priority` *that the device actually exposes*; the others fall back to their own
+per-property platform (if they declare one).
+
+A property may carry both a `climate` candidacy **and** a per-property platform (`switch`,
+`select`, …). When it wins the target it is exposed through the climate entity; when it loses, it is
+exposed through its per-property platform instead. This lets the default mapping describe the full
+superset once, with each device resolving to the right control automatically.
+
+For example, vertical swing in `009.yaml`: `t_swing_angle` (multi-position) is the preferred
+`swing_mode` control, and `t_up_down` (on/off) is both a `switch` and a lower-priority fallback:
+
+```yaml
+- property: t_swing_angle
+  climate:
+    target: swing_mode
+    priority: 1            # preferred
+    options: { ... }
+- property: t_up_down
+  switch:                  # used when t_swing_angle is also present
+    device_class: switch
+  climate:
+    target: swing_mode
+    priority: 2            # fallback when t_swing_angle is absent
+    options:
+      0: "off"
+      1: "on"
+```
+
+A device exposing both gets `t_swing_angle` as `swing_mode` and `t_up_down` as a switch; a device
+exposing only `t_up_down` gets it as `swing_mode`.
 
 Not yet supported target properties:
 

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -236,6 +236,11 @@
         "target": {
           "$ref": "#/$defs/ClimateTarget"
         },
+        "priority": {
+          "type": "integer",
+          "description": "Tie-break when several properties map to the same climate target. The lowest-priority candidate the device actually exposes wins the target; the rest fall back to their per-property platform. Lower = preferred. Defaults to 100.",
+          "default": 100
+        },
         "unknown_value": {
           "$ref": "#/$defs/UnknownValue"
         },

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -50,6 +50,7 @@ MAX_VALUE = "max_value"
 MIN_VALUE = "min_value"
 MULTIPLIER = "multiplier"
 OPTIONAL = "optional"
+PRIORITY = "priority"
 TARGET = "target"
 READ_ONLY = "read_only"
 STATE_CLASS = "state_class"
@@ -103,6 +104,12 @@ class Climate:
     unknown_value: int | None
     min_value: int | dict[str, int] | None
     max_value: int | dict[str, int] | None
+    # Tie-break when several properties map to the same climate target. The
+    # lowest-priority candidate that the device actually exposes wins the
+    # target; the rest fall back to their per-property platform (if any). Lower
+    # number = preferred. Default is intentionally large so explicitly-ranked
+    # candidates win.
+    priority: int
 
     def __init__(self, name: str, climate: dict | None):
         if climate is None:
@@ -110,6 +117,7 @@ class Climate:
         self.target = _val(climate, TARGET)
         if self.target is None:
             _LOGGER.warning("Missing climate.target for for %s", name)
+        self.priority = _val(climate, PRIORITY, 100)
         self.options = _val(climate, OPTIONS, {})
         if not self.options and self.target in [
             FAN_MODE,
@@ -357,12 +365,20 @@ class Property:
         self.combine = _val(entry, COMBINE)
         self.translation_key = _val(entry, TRANSLATION_KEY)
 
-        if Platform.BINARY_SENSOR in entry:
-            self.binary_sensor = BinarySensor(self.name, entry[Platform.BINARY_SENSOR])
-        elif Platform.CLIMATE in entry:
+        # A property may carry one device-level platform (climate / humidifier /
+        # water_heater) AND one per-property platform (binary_sensor / number /
+        # select / sensor / switch). The device-level block acts as a target
+        # candidacy; when the device also exposes a higher-priority candidate for
+        # that target, this property falls back to its per-property platform.
+        if Platform.CLIMATE in entry:
             self.climate = Climate(self.name, entry[Platform.CLIMATE])
         elif Platform.HUMIDIFIER in entry:
             self.humidifier = Humidifier(self.name, entry[Platform.HUMIDIFIER])
+        elif Platform.WATER_HEATER in entry:
+            self.water_heater = WaterHeater(self.name, entry[Platform.WATER_HEATER])
+
+        if Platform.BINARY_SENSOR in entry:
+            self.binary_sensor = BinarySensor(self.name, entry[Platform.BINARY_SENSOR])
         elif Platform.NUMBER in entry:
             self.number = Number(self.name, entry[Platform.NUMBER])
         elif Platform.SENSOR in entry:
@@ -371,9 +387,7 @@ class Property:
             self.select = Select(self.name, entry[Platform.SELECT])
         elif Platform.SWITCH in entry:
             self.switch = Switch(self.name, entry[Platform.SWITCH])
-        elif Platform.WATER_HEATER in entry:
-            self.water_heater = WaterHeater(self.name, entry[Platform.WATER_HEATER])
-        else:
+        elif not any(p in entry for p in PLATFORM_KEYS):
             self.sensor = Sensor(self.name, {})
 
 
@@ -441,16 +455,22 @@ class Dictionary:
     statistics_sensors: dict[str, bool] = field(default_factory=dict)
 
 
-PLATFORM_KEYS = (
-    Platform.BINARY_SENSOR,
+# Device-level platforms own a `target` and may coexist with a per-property
+# platform on the same property (the per-property block is the fallback when
+# another property wins the target).
+DEVICE_PLATFORM_KEYS = (
     Platform.CLIMATE,
     Platform.HUMIDIFIER,
+    Platform.WATER_HEATER,
+)
+PER_PROPERTY_PLATFORM_KEYS = (
+    Platform.BINARY_SENSOR,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
-    Platform.WATER_HEATER,
 )
+PLATFORM_KEYS = DEVICE_PLATFORM_KEYS + PER_PROPERTY_PLATFORM_KEYS
 
 
 def _merge_property(base: dict | None, override: dict) -> dict:
@@ -466,33 +486,49 @@ def _merge_property(base: dict | None, override: dict) -> dict:
     A bare platform key in the override (``switch:`` with no value, parsed as
     ``None``) is YAML shorthand for ``{}``: it means "this property uses the
     given platform with no overrides", not "remove the platform from base".
-    To convert a property to a different platform, declare the new platform
-    key explicitly with the desired contents; to suppress an entity, use
-    ``disable: true``.
+
+    A property's platforms are merged in two independent groups — the
+    device-level platform (climate / humidifier / water_heater) and the
+    per-property platform (binary_sensor / number / select / sensor / switch).
+    Within a group, declaring a different platform key replaces the base's; an
+    override that touches only one group leaves the other intact (so a subtype
+    adding a ``climate`` candidacy keeps the base ``switch`` as the fallback,
+    and a subtype tweaking the ``switch`` keeps the inherited ``climate``).
+    To suppress an entity, use ``disable: true``.
     """
     if base is None:
         return dict(override)
 
     result = dict(base)
-    base_plat = next((p for p in PLATFORM_KEYS if p in base), None)
-    override_plat = next((p for p in PLATFORM_KEYS if p in override), None)
-
     for key, val in override.items():
         if key in PLATFORM_KEYS:
             continue
         result[key] = val
 
+    for group in (PER_PROPERTY_PLATFORM_KEYS, DEVICE_PLATFORM_KEYS):
+        _merge_platform_group(result, base, override, group)
+    return result
+
+
+def _merge_platform_group(result: dict, base: dict, override: dict, group: tuple) -> None:
+    """Merge the ``override`` platform within ``group`` onto ``result`` in place.
+
+    ``result`` already carries the base's platform for this group (it starts as
+    a copy of ``base``). If the override declares no platform in this group, the
+    base's platform is left untouched.
+    """
+    base_plat = next((p for p in group if p in base), None)
+    override_plat = next((p for p in group if p in override), None)
     if override_plat is None:
-        return result
+        return
     override_val = override[override_plat]
     if base_plat == override_plat:
         inner_override = {} if override_val is None else override_val
         result[override_plat] = _merge_platform_block(base[base_plat], inner_override)
-        return result
+        return
     if base_plat is not None:
         result.pop(base_plat, None)
     result[override_plat] = override_val
-    return result
 
 
 def _merge_platform_block(base, override):

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -12,7 +12,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import has_platform, to_unit
+from .utils import climate_bound_properties, has_platform, to_unit
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
+        climate_bound = climate_bound_properties(appliance, dictionary)
         async_add_entities(
             ConnectLifeNumberEntity(
                 coordinator,
@@ -36,6 +37,7 @@ async def async_setup_entry(
             )
             for s in appliance.status_list
             if has_platform(Platform.NUMBER, dictionary.properties[s])
+            and s not in climate_bound
         )
 
 

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -13,7 +13,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import has_platform
+from .utils import climate_bound_properties, has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,12 +27,14 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
+        climate_bound = climate_bound_properties(appliance, dictionary)
         async_add_entities(
             ConnectLifeSelect(
                 coordinator, appliance, s, dictionary.properties[s]
             )
             for s in appliance.status_list
             if has_platform(Platform.SELECT, dictionary.properties[s])
+            and s not in climate_bound
         )
 
 

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -26,7 +26,7 @@ from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from .statistics_sources import StatisticsSensorDef, enabled_sensors
 from connectlife.appliance import ConnectLifeAppliance, MAX_DATETIME
-from .utils import has_platform, to_unit
+from .utils import climate_bound_properties, has_platform, to_unit
 
 SERVICE_SET_VALUE = "set_value"
 
@@ -43,6 +43,7 @@ async def async_setup_entry(
     statistics_coordinator = hass.data[DOMAIN].get(f"{config_entry.entry_id}_statistics")
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
+        climate_bound = climate_bound_properties(appliance, dictionary)
         async_add_entities(
             ConnectLifeStatusSensor(
                 coordinator, appliance, s, dictionary.properties[s], dictionary
@@ -50,6 +51,7 @@ async def async_setup_entry(
             for s in appliance.status_list
             if s != SW_VERSION_PROPERTY
             and has_platform(Platform.SENSOR, dictionary.properties[s])
+            and s not in climate_bound
         )
         async_add_entities(
             ConnectLifeStatusSensor(

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
-from .utils import has_platform
+from .utils import climate_bound_properties, has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,12 +28,14 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
+        climate_bound = climate_bound_properties(appliance, dictionary)
         async_add_entities(
             ConnectLifeSwitch(
                 coordinator, appliance, s, dictionary.properties[s]
             )
             for s in appliance.status_list
             if has_platform(Platform.SWITCH, dictionary.properties[s])
+            and s not in climate_bound
         )
 
 

--- a/custom_components/connectlife/utils.py
+++ b/custom_components/connectlife/utils.py
@@ -10,6 +10,44 @@ def has_platform(platform: Platform, property: Property):
     return hasattr(property, platform) and not property.disable
 
 
+def climate_target_bindings(
+    appliance: ConnectLifeAppliance, dictionary: Dictionary
+) -> dict[str, str]:
+    """Resolve which property serves each climate target for this appliance.
+
+    Several properties may declare the same ``climate.target`` (e.g. both
+    ``t_swing_angle`` and ``t_up_down`` map to ``swing_mode``). Among the
+    candidates the device actually exposes (present in ``status_list`` and not
+    disabled), the one with the lowest ``priority`` wins the target; ties are
+    broken by dictionary order. Returns ``{target: property_name}``.
+    """
+    bindings: dict[str, tuple[int, str]] = {}
+    for name, prop in dictionary.properties.items():
+        if name not in appliance.status_list:
+            continue
+        if not has_platform(Platform.CLIMATE, prop):
+            continue
+        target = prop.climate.target
+        if target is None:
+            continue
+        current = bindings.get(target)
+        if current is None or prop.climate.priority < current[0]:
+            bindings[target] = (prop.climate.priority, name)
+    return {target: name for target, (_, name) in bindings.items()}
+
+
+def climate_bound_properties(
+    appliance: ConnectLifeAppliance, dictionary: Dictionary
+) -> set[str]:
+    """Property names bound to a climate target for this appliance.
+
+    A property that wins a climate target is exposed through the climate entity,
+    so its per-property platform (if any) must be suppressed to avoid a
+    duplicate entity.
+    """
+    return set(climate_target_bindings(appliance, dictionary).values())
+
+
 def to_unit(unit: str | None, appliance: ConnectLifeAppliance, dictionary: Dictionary):
     if unit is None:
         return None

--- a/scripts/gen_strings.py
+++ b/scripts/gen_strings.py
@@ -103,59 +103,62 @@ def main(basedir):
                             ):
                                 if include_option(option, filename):
                                     strings["entity"]["humidifier"]["connectlife"]["state_attributes"]["state"][option] = pretty(option)
-                    else:
-                        if "disable" in property and property["disable"]:
-                            continue
-                        key = to_key(property.get("translation_key") or property["property"])
-                        if not any(entity_type in property for entity_type in ["binary_sensor", "climate", "humidifier", "number", "select", "sensor", "switch", "water_heater"]):
-                            valid_properties.setdefault("sensor", set()).add(key)
+                    # A property may carry a per-property platform alongside a
+                    # climate/humidifier block (e.g. t_up_down is a switch that
+                    # also acts as the swing_mode fallback), so emit its name
+                    # independently of the climate/humidifier option states above.
+                    if "disable" in property and property["disable"]:
+                        continue
+                    key = to_key(property.get("translation_key") or property["property"])
+                    if not any(entity_type in property for entity_type in ["binary_sensor", "climate", "humidifier", "number", "select", "sensor", "switch", "water_heater"]):
+                        valid_properties.setdefault("sensor", set()).add(key)
+                        name = property["property"]
+                        if "sensor" not in strings["entity"]:
+                            strings["entity"]["sensor"] = {}
+                        if key not in strings["entity"]["sensor"]:
+                            strings["entity"]["sensor"][key] = {"name": pretty(name)}
+                        elif "name" not in strings["entity"]["sensor"][key]:
+                            strings["entity"]["sensor"][key]["name"] = pretty(name)
+                    for entity_type in ["binary_sensor", "switch", "number", "sensor", "select"]:
+                        if entity_type in property:
+                            if entity_type not in strings["entity"]:
+                                strings["entity"][entity_type] = {}
                             name = property["property"]
-                            if "sensor" not in strings["entity"]:
-                                strings["entity"]["sensor"] = {}
-                            if key not in strings["entity"]["sensor"]:
-                                strings["entity"]["sensor"][key] = {"name": pretty(name)}
-                            elif "name" not in strings["entity"]["sensor"][key]:
-                                strings["entity"]["sensor"][key]["name"] = pretty(name)
-                        for entity_type in ["binary_sensor", "switch", "number", "sensor", "select"]:
-                            if entity_type in property:
-                                if entity_type not in strings["entity"]:
-                                    strings["entity"][entity_type] = {}
-                                name = property["property"]
-                                key = to_key(property.get("translation_key") or name)
-                                if key not in strings["entity"][entity_type]:
-                                    strings["entity"][entity_type][key] = {"name": pretty(name)}
-                                elif "name" not in strings["entity"][entity_type][key]:
-                                    strings["entity"][entity_type][key]["name"] = pretty(name)
-                                valid_properties.setdefault(entity_type, set()).add(key)
-                                if (
-                                        property[entity_type] is not None
-                                        and "options" in property[entity_type]
-                                        and property[entity_type]["options"] is not None
-                                ):
-                                    for option in property[entity_type]["options"].values():
-                                        valid_options.setdefault((entity_type, key), set()).add(option)
-                                if (
-                                        (
-                                                (
-                                                        entity_type == "sensor"
-                                                        and entity_type in property
-                                                        and property[entity_type] is not None
-                                                        and "device_class" in property[entity_type]
-                                                        and property[entity_type]["device_class"] == "enum")
-                                                or entity_type == "select"
-                                        )
-                                        and "options" in property[entity_type]
-                                ):
-                                    for option in property[entity_type]["options"].values():
-                                        if option in ["off", "on"]:
-                                            continue
-                                        if not "state" in strings["entity"][entity_type][key]:
-                                            strings["entity"][entity_type][key]["state"] = {}
-                                        if not option in strings["entity"][entity_type][key]["state"]:
-                                            if include_option(option, filename):
-                                                strings["entity"][entity_type][key]["state"][option] = pretty(option)
-                                    if "state" in strings["entity"][entity_type][key] and not strings["entity"][entity_type][key]["state"]:
-                                        del(strings["entity"][entity_type][key]["state"])
+                            key = to_key(property.get("translation_key") or name)
+                            if key not in strings["entity"][entity_type]:
+                                strings["entity"][entity_type][key] = {"name": pretty(name)}
+                            elif "name" not in strings["entity"][entity_type][key]:
+                                strings["entity"][entity_type][key]["name"] = pretty(name)
+                            valid_properties.setdefault(entity_type, set()).add(key)
+                            if (
+                                    property[entity_type] is not None
+                                    and "options" in property[entity_type]
+                                    and property[entity_type]["options"] is not None
+                            ):
+                                for option in property[entity_type]["options"].values():
+                                    valid_options.setdefault((entity_type, key), set()).add(option)
+                            if (
+                                    (
+                                            (
+                                                    entity_type == "sensor"
+                                                    and entity_type in property
+                                                    and property[entity_type] is not None
+                                                    and "device_class" in property[entity_type]
+                                                    and property[entity_type]["device_class"] == "enum")
+                                            or entity_type == "select"
+                                    )
+                                    and "options" in property[entity_type]
+                            ):
+                                for option in property[entity_type]["options"].values():
+                                    if option in ["off", "on"]:
+                                        continue
+                                    if not "state" in strings["entity"][entity_type][key]:
+                                        strings["entity"][entity_type][key]["state"] = {}
+                                    if not option in strings["entity"][entity_type][key]["state"]:
+                                        if include_option(option, filename):
+                                            strings["entity"][entity_type][key]["state"][option] = pretty(option)
+                                if "state" in strings["entity"][entity_type][key] and not strings["entity"][entity_type][key]["state"]:
+                                    del(strings["entity"][entity_type][key]["state"])
 
             if "climate" in appliance:
                 if "presets" in appliance["climate"]:

--- a/scripts/validate_mappings.py
+++ b/scripts/validate_mappings.py
@@ -81,9 +81,36 @@ def _check_hvac_option_values(filename, merged_entry):
     )
 
 
+PER_PROPERTY_PLATFORMS = ('binary_sensor', 'number', 'select', 'sensor', 'switch')
+FALLBACK_UNSUPPORTED_DEVICE_PLATFORMS = ('humidifier', 'water_heater')
+
+
+def _check_device_platform_pairing(filename, merged_entry):
+    """A property may pair ``climate`` with a per-property platform — climate is
+    the only device-level platform with a per-appliance target-fallback skip
+    (``climate_bound_properties``), so the per-property entity is correctly
+    suppressed when climate wins the target (e.g. ``t_up_down``: switch +
+    ``climate`` swing_mode). ``humidifier``/``water_heater`` have no such skip,
+    so pairing one with a per-property platform would create a duplicate entity.
+    Reject it until those platforms grow the same fallback mechanism."""
+    device = next((p for p in FALLBACK_UNSUPPORTED_DEVICE_PLATFORMS if p in merged_entry), None)
+    if device is None:
+        return None
+    per_property = next((p for p in PER_PROPERTY_PLATFORMS if p in merged_entry), None)
+    if per_property is None:
+        return None
+    return (
+        f"{filename}: property '{merged_entry['property']}' pairs {device} with "
+        f"{per_property}. Only climate supports a per-property fallback; "
+        f"{device} paired with a per-property platform would create a duplicate "
+        f"entity."
+    )
+
+
 CHECKS = (
     _check_entity_category_config_on_sensor,
     _check_hvac_option_values,
+    _check_device_platform_pairing,
 )
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -11,8 +11,88 @@ from custom_components.connectlife.climate import (
     _add_hvac_mode_mapping,
     is_climate,
 )
-from custom_components.connectlife.const import HVAC_MODE, IS_ON
+from custom_components.connectlife.const import HVAC_MODE, IS_ON, SWING_MODE
 from custom_components.connectlife.dictionaries import Dictionary, Property
+from custom_components.connectlife.utils import climate_bound_properties
+
+
+def _coordinator(appliance: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        data={appliance.device_id: appliance},
+        config_entry=SimpleNamespace(options={}, entry_id="e"),
+        hass=None,
+        last_update_success=True,
+        add_entity=lambda *a, **k: None,
+    )
+
+
+def _swing_dictionary() -> Dictionary:
+    """t_swing_angle (priority 1) and t_up_down (switch + priority 2) both
+    claim swing_mode, mirroring the hoisted 009.yaml mapping."""
+    return Dictionary(
+        climate=None,
+        properties={
+            "t_power": Property(
+                {"property": "t_power", "climate": {"target": "is_on"}}
+            ),
+            "t_swing_angle": Property(
+                {
+                    "property": "t_swing_angle",
+                    "climate": {
+                        "target": "swing_mode",
+                        "priority": 1,
+                        "options": {0: "swing", 1: "auto"},
+                    },
+                }
+            ),
+            "t_up_down": Property(
+                {
+                    "property": "t_up_down",
+                    "switch": {"device_class": "switch"},
+                    "climate": {
+                        "target": "swing_mode",
+                        "priority": 2,
+                        "options": {0: "off", 1: "on"},
+                    },
+                }
+            ),
+        },
+        buttons=[],
+    )
+
+
+def _swing_appliance(status_list: dict[str, int]) -> SimpleNamespace:
+    return SimpleNamespace(
+        device_id="dev1",
+        device_nickname="AC",
+        device_feature_name="104",
+        device_type_code="009",
+        device_feature_code="104",
+        room_name="Kitchen",
+        status_list=status_list,
+    )
+
+
+def test_swing_mode_prefers_higher_priority_candidate() -> None:
+    """When both axes are exposed, the lower-priority number (t_swing_angle)
+    wins swing_mode and t_up_down falls back to its switch (issue #590)."""
+    dictionary = _swing_dictionary()
+    appliance = _swing_appliance({"t_power": 1, "t_swing_angle": 0, "t_up_down": 0})
+    climate = ConnectLifeClimate(_coordinator(appliance), appliance, dictionary)
+
+    assert climate.target_map[SWING_MODE] == "t_swing_angle"
+    # t_up_down lost swing_mode, so it must remain available to the switch platform.
+    assert climate_bound_properties(appliance, dictionary) == {"t_swing_angle", "t_power"}
+
+
+def test_swing_mode_falls_back_to_lower_priority_candidate() -> None:
+    """A device exposing only t_up_down promotes it to swing_mode."""
+    dictionary = _swing_dictionary()
+    appliance = _swing_appliance({"t_power": 1, "t_up_down": 0})
+    climate = ConnectLifeClimate(_coordinator(appliance), appliance, dictionary)
+
+    assert climate.target_map[SWING_MODE] == "t_up_down"
+    assert "t_up_down" in climate_bound_properties(appliance, dictionary)
 
 
 def test_hvac_mode_alias_does_not_override_canonical_reverse_mapping() -> None:

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -134,6 +134,50 @@ def test_different_platform_replaces_block_but_top_level_inherits():
     assert merged["select"] == {"options": {0: "a", 1: "b"}}
 
 
+def test_climate_candidacy_is_additive_with_per_property_platform():
+    """A subtype adding a climate candidacy keeps the inherited per-property
+    platform (the device-level and per-property groups merge independently),
+    so the property can fall back to its switch when it loses the target."""
+    base = {
+        "property": "t_up_down",
+        "switch": {"device_class": "switch"},
+        "icon": "mdi:arrow-oscillating",
+    }
+    override = {
+        "property": "t_up_down",
+        "climate": {"target": "swing_mode", "options": {0: "off", 1: "on"}},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["switch"] == {"device_class": "switch"}
+    assert merged["climate"]["target"] == "swing_mode"
+    assert merged["icon"] == "mdi:arrow-oscillating"
+
+    prop = Property(merged)
+    assert hasattr(prop, "switch")
+    assert hasattr(prop, "climate")
+
+
+def test_per_property_override_keeps_inherited_climate_candidacy():
+    """Tweaking only the per-property block leaves the inherited climate block."""
+    base = {
+        "property": "t_up_down",
+        "switch": {"device_class": "switch"},
+        "climate": {"target": "swing_mode", "priority": 2, "options": {0: "off"}},
+    }
+    override = {
+        "property": "t_up_down",
+        "switch": {"device_class": "outlet"},
+    }
+
+    merged = _merge_property(base, override)
+
+    assert merged["switch"] == {"device_class": "outlet"}
+    assert merged["climate"]["target"] == "swing_mode"
+    assert merged["climate"]["priority"] == 2
+
+
 def test_explicit_null_in_platform_unsets_base_field():
     base = {
         "property": "t_setpoint",


### PR DESCRIPTION
## Problem

Two appliances that share a `deviceTypeCode`/`deviceFeatureCode` resolve to the **same** data dictionary, but the cloud can report **different property sets** for them. In #590 two Hisense ACs both report `009-104`: one (CF35MR04G) exposes only `t_up_down` for vertical swing, the other (CF20YR04G) exposes both `t_up_down` and the richer multi-position `t_swing_angle`.

Both mapped to climate `swing_mode`, so the device exposing both logged:
```
t_swing_angle and t_up_down both map to climate swing_mode … using t_up_down. …
```
and the **worse** control (on/off) won, discarding the multi-position one.

## Fix: priority-based target fallback

Let several properties claim the same climate target; per appliance, bind the lowest-`priority` candidate the device **actually exposes**, and let the rest fall back to their own per-property platform.

- Climate blocks gain an optional `priority` (lower = preferred; default 100).
- A property may carry a device-level platform (`climate`/`humidifier`/`water_heater`) **and** a per-property platform together. `_merge_property` now merges those two groups independently, so adding a `climate` candidacy no longer evicts the base `switch`.
- `climate_target_bindings` / `climate_bound_properties` (utils) resolve the winner per appliance; the per-property platforms skip a property that wins a climate target (no duplicate entity).
- Hoisted the swing fallback into `006.yaml` and `009.yaml` — `t_swing_angle` `priority: 1`, `t_up_down` `switch` + `priority: 2` — and removed the duplicated `t_up_down → swing_mode` overrides from the affected subtypes.
- `gen_strings`: emit a property's per-property name independently of its climate/humidifier block, so a dual-platform property (`t_up_down`) keeps its switch name.
- `validate_mappings` guard: the per-property fallback skip only covers `climate`, so `humidifier`/`water_heater` paired with a per-property platform would create a duplicate entity. Reject that pairing at validation time until those platforms grow the same mechanism (`climate` + per-property stays allowed).

## Result

- Device exposing **only** `t_up_down` → `swing_mode` = on/off (best the API offers).
- Device exposing **both** → `swing_mode` = `t_swing_angle` (multi-angle, confirmed functional by the reporter); `t_up_down` falls back to a switch.
- No more duplicate-mapping warning.

Backward compatible — `priority` only breaks ties, so single-candidate targets are unaffected.

## Testing

- `pytest` (incl. new tests for the fallback and the additive platform merge), `validate_mappings`, `pyright` — all green; `gen_strings` produces no drift.
- Verified against the test server with the #590 dumps (`009-104.json` vs `009-104_2.json`): the two devices render the expected, different swing controls; `009-19901` (swing disabled) shows no swing controls.
- Reviewed via sub-agent: no correctness issues; the one flagged latent trap (humidifier/water_heater + per-property) is closed by the validate_mappings guard above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)