### PR TITLE
Add wine cooler (034) to DEVICES.md and README

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -123,3 +123,4 @@
 | DH5S102BB                | Tumble dryer             | 030              | 1wk100266v0f                |
 | DHSE80-BEW001            | Tumble dryer             | 030              | 1wk080027e0w                |
 | DPNA83W                  | Tumble dryer             | 032              | 000                         |
+| Hisense RW3N122GSLF      | Wine cooler              | 034              | 1j0122z0035j                |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Default mapping files are provided for the following device types:
 | Washing machine          | [027](custom_components/connectlife/data_dictionaries/027.yaml) |
 | Tumble dryer             | [030](custom_components/connectlife/data_dictionaries/030.yaml) |
 | Tumble dryer             | [032](custom_components/connectlife/data_dictionaries/032.yaml) |
+| Wine cooler              | [034](custom_components/connectlife/data_dictionaries/034.yaml) |
 
 Any devices of these types will use the default mapping file, but it may not be fully functional until a
 feature-specific mapping file is provided.


### PR DESCRIPTION
Device type `034` (wine cooler) was added in 0.43.0 (#594) but wasn't listed in the supported-devices docs.

## Changes

- **DEVICES.md** — add `Hisense RW3N122GSLF | Wine cooler | 034 | 1j0122z0035j`
- **README.md** — add the `Wine cooler` → `034` row to the *Default device types* table

Both files are hand-maintained (no generator), which is why the new mapping slipped through.