### PR TITLE
Add light on/off buttons for 009-104 AC

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009-104.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-104.yaml
@@ -1,3 +1,14 @@
+buttons:
+# t_dimmer is write-only on this model (not reported in statusList), so it is
+# exposed as two buttons rather than a switch. Confirmed: 1 = LED on, 0 = LED off.
+- key: light_on
+  icon: mdi:lightbulb-on
+  write:
+    t_dimmer: 1
+- key: light_off
+  icon: mdi:lightbulb-off
+  write:
+    t_dimmer: 0
 climate:
   presets:
     - t_eco: 1

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -1885,6 +1885,12 @@
       "cancel": {
         "name": "Cancel"
       },
+      "light_off": {
+        "name": "Light off"
+      },
+      "light_on": {
+        "name": "Light on"
+      },
       "pause": {
         "name": "Pause"
       },

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1164,6 +1164,12 @@
       "cancel": {
         "name": "Abbrechen"
       },
+      "light_off": {
+        "name": "Licht aus"
+      },
+      "light_on": {
+        "name": "Licht an"
+      },
       "pause": {
         "name": "Pause"
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -1885,6 +1885,12 @@
       "cancel": {
         "name": "Cancel"
       },
+      "light_off": {
+        "name": "Light off"
+      },
+      "light_on": {
+        "name": "Light on"
+      },
       "pause": {
         "name": "Pause"
       },

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -612,6 +612,12 @@
       "cancel": {
         "name": "Cancelar"
       },
+      "light_off": {
+        "name": "Luz apagada"
+      },
+      "light_on": {
+        "name": "Luz encendida"
+      },
       "pause": {
         "name": "Pausa"
       },

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -330,6 +330,12 @@
       "cancel": {
         "name": "Annuler"
       },
+      "light_off": {
+        "name": "Lumi\u00e8re \u00e9teinte"
+      },
+      "light_on": {
+        "name": "Lumi\u00e8re allum\u00e9e"
+      },
       "pause": {
         "name": "Pause"
       },

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -219,6 +219,12 @@
       "cancel": {
         "name": "Annulla"
       },
+      "light_off": {
+        "name": "Luce spenta"
+      },
+      "light_on": {
+        "name": "Luce accesa"
+      },
       "pause": {
         "name": "Pausa"
       },

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -1577,6 +1577,12 @@
       "cancel": {
         "name": "Annuleren"
       },
+      "light_off": {
+        "name": "Licht uit"
+      },
+      "light_on": {
+        "name": "Licht aan"
+      },
       "pause": {
         "name": "Pauze"
       },

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -1577,6 +1577,12 @@
       "cancel": {
         "name": "Avbryt"
       },
+      "light_off": {
+        "name": "Lys av"
+      },
+      "light_on": {
+        "name": "Lys p\u00e5"
+      },
       "pause": {
         "name": "Pause"
       },


### PR DESCRIPTION
Fixes #340.

`t_dimmer` controls the temperature LED on the 009-104 AC but is **write-only** — the device never reports it in `statusList`, so the inherited `t_dimmer` switch entity is never created and there's no way to control the light from HA.

Expose it via two write-only buttons on the `009-104` subtype instead:

- **Light on** → `t_dimmer: 1`
- **Light off** → `t_dimmer: 0`

Values confirmed on-device by a 009-104 owner (audible beep + immediate LED response). State isn't tracked since the property isn't reported back.

Translations added for all seven languages (de, en, es, fr, it, nl, no).