### PR TITLE
Add 026-1b0628z0049j to DEVICES.md

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -108,6 +108,7 @@
 | RQ5P470SEIE              | Refrigerator             | 026              | 1b0470z0026j                |
 | RF793N4SAFE              | Refrigerator             | 026              | 1b0610z0043j                |
 |                          | Refrigerator             | 026              | 1b0610z0049j                |
+| RS818N4TFE               | Refrigerator             | 026              | 1b0628z0049j                |
 |                          | Refrigerator             | 026              | 1b0628z0075j                |
 | RS818N4TIE1              | Refrigerator             | 026              | 1b0628z0146j                |
 | Hisense BCD-668WP1BWF1R1 | Refrigerator             | 026              | 1b0668z0100j                |


### PR DESCRIPTION
The `026`-`1b0628z0049j` refrigerator mapping (Hisense RS818N4TFE) was added in #603 but missed in the hand-maintained DEVICES.md, same gap as #599 for the wine cooler.