### PR TITLE
Add per-device climate control overrides in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ This adds a `connectivity` binary sensor (a diagnostic entity) reporting whether
 the device's other entities from going unavailable while it is offline — they keep their last reported values
 until the device comes back online.
 
+## Swing mode control
+
+Some devices report more than one property that can drive the climate card's swing mode (for example, both a
+multi-position swing angle and a simple on/off swing). The integration normally picks one automatically, but a
+few devices advertise a control they don't actually honour — e.g. the swing angle options appear but only make
+the unit beep, while the on/off swing is what works.
+
+If the swing control on the climate card doesn't work, go to the
+[ConnectLife integration](https://my.home-assistant.io/redirect/integration/?domain=connectlife)
+and click "Configure" → "Configure a device", select the device, and set "Swing mode control" to the property
+your hardware actually responds to (leave it on "auto" to keep the automatic choice). This option only appears
+for devices that expose more than one swing property.
+
 ## Daily energy and water consumption sensors
 
 For supported device types, the integration exposes a **daily energy** sensor (kWh) and, for

--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -22,7 +22,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import climate_bound_properties, has_platform
+from .utils import climate_bound_properties, device_target_overrides, has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +37,8 @@ async def async_setup_entry(
     devices = config_entry.options.get(CONF_DEVICES, {})
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
-        climate_bound = climate_bound_properties(appliance, dictionary)
+        overrides = device_target_overrides(config_entry, appliance.device_id)
+        climate_bound = climate_bound_properties(appliance, dictionary, overrides)
         async_add_entities(
             ConnectLifeBinaryStatusSensor(
                 coordinator, appliance, s, dictionary.properties[s]

--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -31,7 +31,13 @@ from .const import (
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary
 from .entity import ConnectLifeEntity
-from .utils import climate_target_bindings, has_platform, to_temperature_map, normalize_temperature_unit
+from .utils import (
+    climate_target_bindings,
+    device_target_overrides,
+    has_platform,
+    to_temperature_map,
+    normalize_temperature_unit,
+)
 from connectlife.appliance import ConnectLifeAppliance
 
 _LOGGER = logging.getLogger(__name__)
@@ -146,8 +152,10 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
         self.unknown_values = {}
 
         # When several properties claim the same climate target, the lowest-
-        # priority candidate the device exposes wins (see climate_target_bindings).
-        self.target_map = climate_target_bindings(appliance, data_dictionary)
+        # priority candidate the device exposes wins (see climate_target_bindings),
+        # unless the user pinned a specific property via the options flow.
+        overrides = device_target_overrides(coordinator.config_entry, appliance.device_id)
+        self.target_map = climate_target_bindings(appliance, data_dictionary, overrides)
 
         hvac_modes: list[HVACMode] = []
         for target, status in self.target_map.items():

--- a/custom_components/connectlife/config_flow.py
+++ b/custom_components/connectlife/config_flow.py
@@ -25,10 +25,14 @@ from .const import (
     CONF_DEVELOPMENT_MODE,
     CONF_DISABLE_BEEP,
     CONF_EXPOSE_OFFLINE_STATE,
+    CONF_TARGET_OVERRIDES,
     CONF_TEST_SERVER_URL,
     CONF_TRIR,
     DOMAIN,
+    OVERRIDE_AUTO,
 )
+from .dictionaries import Dictionaries
+from .utils import contested_climate_targets
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -252,14 +256,34 @@ class OptionsFlowHandler(OptionsFlow):
 
     async def async_step_configure_device(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
 
+        # A device may expose more than one property for the same climate target
+        # (e.g. both t_swing_angle and t_up_down for swing_mode). Offer a select
+        # per contested target so the user can pin the one their hardware
+        # actually honours; "auto" keeps the priority-based binding.
+        coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
+        appliance = coordinator.data.get(self._device_id)
+        contested = (
+            contested_climate_targets(appliance, Dictionaries.get_dictionary(appliance))
+            if appliance
+            else {}
+        )
+
         # Configure the device
         if user_input is not None:
             data = self.config_entry.options.copy()
             data[CONF_DEVICES] = data[CONF_DEVICES].copy() if CONF_DEVICES in data else {}
-            data[CONF_DEVICES][self._device_id] = {
+            overrides = {
+                target: user_input[self._override_key(target)]
+                for target in contested
+                if user_input.get(self._override_key(target), OVERRIDE_AUTO) != OVERRIDE_AUTO
+            }
+            device_options: dict[str, Any] = {
                 CONF_DISABLE_BEEP: user_input[CONF_DISABLE_BEEP],
                 CONF_EXPOSE_OFFLINE_STATE: user_input[CONF_EXPOSE_OFFLINE_STATE],
             }
+            if overrides:
+                device_options[CONF_TARGET_OVERRIDES] = overrides
+            data[CONF_DEVICES][self._device_id] = device_options
             if not user_input[CONF_DISABLE_BEEP]:
                 ir.async_delete_issue(self.hass, DOMAIN, f"unsupported_beep.{self._device_id}")
             return self.async_create_entry(title="", data=data)
@@ -268,17 +292,26 @@ class OptionsFlowHandler(OptionsFlow):
         device = devices[self._device_id] if self._device_id in devices else {}
         disable_beep = device.get(CONF_DISABLE_BEEP, False)
         expose_offline_state = device.get(CONF_EXPOSE_OFFLINE_STATE, False)
-        schema = vol.Schema(
-            {
-                vol.Optional(CONF_DISABLE_BEEP, default=disable_beep): bool,
-                vol.Optional(CONF_EXPOSE_OFFLINE_STATE, default=expose_offline_state): bool,
-            }
-        )
-        coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
-        appliance = coordinator.data.get(self._device_id)
+        current_overrides = device.get(CONF_TARGET_OVERRIDES, {})
+        schema_dict: dict[Any, Any] = {
+            vol.Optional(CONF_DISABLE_BEEP, default=disable_beep): bool,
+            vol.Optional(CONF_EXPOSE_OFFLINE_STATE, default=expose_offline_state): bool,
+        }
+        for target, properties in contested.items():
+            default = current_overrides.get(target, OVERRIDE_AUTO)
+            if default not in properties:
+                default = OVERRIDE_AUTO
+            options = {OVERRIDE_AUTO: OVERRIDE_AUTO, **{p: p for p in properties}}
+            schema_dict[vol.Optional(self._override_key(target), default=default)] = vol.In(options)
+
         device_name = (appliance.device_nickname if appliance else self._device_id) or ""
         return self.async_show_form(
             step_id="configure_device",
-            data_schema=schema,
+            data_schema=vol.Schema(schema_dict),
             description_placeholders={"device_name": device_name},
         )
+
+    @staticmethod
+    def _override_key(target: str) -> str:
+        """Options-form field key for a climate target's property override."""
+        return f"{CONF_TARGET_OVERRIDES}_{target}"

--- a/custom_components/connectlife/const.py
+++ b/custom_components/connectlife/const.py
@@ -10,8 +10,13 @@ CONF_DEVICES = "devices"
 CONF_DEVELOPMENT_MODE = "development_mode"
 CONF_DISABLE_BEEP = "disable_beep"
 CONF_EXPOSE_OFFLINE_STATE = "expose_offline_state"
+CONF_TARGET_OVERRIDES = "target_overrides"
 CONF_TEST_SERVER_URL = "test_server_url"
 CONF_TRIR = "trir"
+
+# Sentinel option value meaning "use the automatic, priority-based binding"
+# for a contested climate target (see utils.climate_target_bindings).
+OVERRIDE_AUTO = "auto"
 
 OFFLINE_STATE = "offline_state"
 

--- a/custom_components/connectlife/data_dictionaries/README.md
+++ b/custom_components/connectlife/data_dictionaries/README.md
@@ -347,6 +347,14 @@ For example, vertical swing in `009.yaml`: `t_swing_angle` (multi-position) is t
 A device exposing both gets `t_swing_angle` as `swing_mode` and `t_up_down` as a switch; a device
 exposing only `t_up_down` gets it as `swing_mode`.
 
+When two variants share a `deviceTypeCode`/`deviceFeatureCode` **and** both advertise the
+higher-priority candidate, but only one actually honours it (e.g. `t_swing_angle` is present yet
+inert on some units), there's no data-dictionary signal to tell them apart. Rather than `disable`
+the candidate for the whole feature code (which would regress the variants where it works), the user
+pins the property their hardware honours per-device via the integration options (Settings → 
+Devices & Services → ConnectLife → Configure → pick device). Each climate target with more than one
+exposed candidate gets an "auto / property" select there; `auto` keeps this priority-based binding.
+
 Not yet supported target properties:
 
 - `target_temperature_high`

--- a/custom_components/connectlife/number.py
+++ b/custom_components/connectlife/number.py
@@ -12,7 +12,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import climate_bound_properties, has_platform, to_unit
+from .utils import climate_bound_properties, device_target_overrides, has_platform, to_unit
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +26,8 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
-        climate_bound = climate_bound_properties(appliance, dictionary)
+        overrides = device_target_overrides(config_entry, appliance.device_id)
+        climate_bound = climate_bound_properties(appliance, dictionary, overrides)
         async_add_entities(
             ConnectLifeNumberEntity(
                 coordinator,

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -13,7 +13,7 @@ from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
-from .utils import climate_bound_properties, has_platform
+from .utils import climate_bound_properties, device_target_overrides, has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,8 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
-        climate_bound = climate_bound_properties(appliance, dictionary)
+        overrides = device_target_overrides(config_entry, appliance.device_id)
+        climate_bound = climate_bound_properties(appliance, dictionary, overrides)
         async_add_entities(
             ConnectLifeSelect(
                 coordinator, appliance, s, dictionary.properties[s]

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -26,7 +26,7 @@ from .dictionaries import Dictionaries, Dictionary, Property
 from .entity import ConnectLifeEntity
 from .statistics_sources import StatisticsSensorDef, enabled_sensors
 from connectlife.appliance import ConnectLifeAppliance, MAX_DATETIME
-from .utils import climate_bound_properties, has_platform, to_unit
+from .utils import climate_bound_properties, device_target_overrides, has_platform, to_unit
 
 SERVICE_SET_VALUE = "set_value"
 
@@ -43,7 +43,8 @@ async def async_setup_entry(
     statistics_coordinator = hass.data[DOMAIN].get(f"{config_entry.entry_id}_statistics")
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
-        climate_bound = climate_bound_properties(appliance, dictionary)
+        overrides = device_target_overrides(config_entry, appliance.device_id)
+        climate_bound = climate_bound_properties(appliance, dictionary, overrides)
         async_add_entities(
             ConnectLifeStatusSensor(
                 coordinator, appliance, s, dictionary.properties[s], dictionary

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -8918,11 +8918,15 @@
       "configure_device": {
         "data": {
           "disable_beep": "Disable beep",
-          "expose_offline_state": "Expose offline state"
+          "expose_offline_state": "Expose offline state",
+          "target_overrides_swing_horizontal_mode": "Horizontal swing mode control",
+          "target_overrides_swing_mode": "Swing mode control"
         },
         "data_description": {
           "disable_beep": "Suppress the appliance beep on commands sent from Home Assistant.",
-          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable."
+          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable.",
+          "target_overrides_swing_horizontal_mode": "This device exposes more than one property that can drive horizontal swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them.",
+          "target_overrides_swing_mode": "This device exposes more than one property that can drive swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them (e.g. choose t_up_down if t_swing_angle is shown but does nothing)."
         },
         "description": "Configure {device_name}."
       },

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 from .coordinator import ConnectLifeCoordinator
 from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
-from .utils import climate_bound_properties, has_platform
+from .utils import climate_bound_properties, device_target_overrides, has_platform
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,8 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     for appliance in coordinator.data.values():
         dictionary = Dictionaries.get_dictionary(appliance)
-        climate_bound = climate_bound_properties(appliance, dictionary)
+        overrides = device_target_overrides(config_entry, appliance.device_id)
+        climate_bound = climate_bound_properties(appliance, dictionary, overrides)
         async_add_entities(
             ConnectLifeSwitch(
                 coordinator, appliance, s, dictionary.properties[s]

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -8918,11 +8918,15 @@
       "configure_device": {
         "data": {
           "disable_beep": "Disable beep",
-          "expose_offline_state": "Expose offline state"
+          "expose_offline_state": "Expose offline state",
+          "target_overrides_swing_horizontal_mode": "Horizontal swing mode control",
+          "target_overrides_swing_mode": "Swing mode control"
         },
         "data_description": {
           "disable_beep": "Suppress the appliance beep on commands sent from Home Assistant.",
-          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable."
+          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable.",
+          "target_overrides_swing_horizontal_mode": "This device exposes more than one property that can drive horizontal swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them.",
+          "target_overrides_swing_mode": "This device exposes more than one property that can drive swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them (e.g. choose t_up_down if t_swing_angle is shown but does nothing)."
         },
         "description": "Configure {device_name}."
       },

--- a/custom_components/connectlife/utils.py
+++ b/custom_components/connectlife/utils.py
@@ -1,8 +1,10 @@
+from collections.abc import Mapping
+
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import Platform, UnitOfTemperature
 
 from connectlife.appliance import ConnectLifeAppliance
-from .const import TEMPERATURE_UNIT
+from .const import CONF_DEVICES, CONF_TARGET_OVERRIDES, TEMPERATURE_UNIT
 from .dictionaries import Property, Dictionary
 
 
@@ -10,18 +12,15 @@ def has_platform(platform: Platform, property: Property):
     return hasattr(property, platform) and not property.disable
 
 
-def climate_target_bindings(
+def _climate_candidates(
     appliance: ConnectLifeAppliance, dictionary: Dictionary
-) -> dict[str, str]:
-    """Resolve which property serves each climate target for this appliance.
+) -> dict[str, list[tuple[int, str]]]:
+    """Group the climate-target candidates the appliance actually exposes.
 
-    Several properties may declare the same ``climate.target`` (e.g. both
-    ``t_swing_angle`` and ``t_up_down`` map to ``swing_mode``). Among the
-    candidates the device actually exposes (present in ``status_list`` and not
-    disabled), the one with the lowest ``priority`` wins the target; ties are
-    broken by dictionary order. Returns ``{target: property_name}``.
+    Returns ``{target: [(priority, property_name), ...]}`` in dictionary order,
+    including only properties present in ``status_list`` and not disabled.
     """
-    bindings: dict[str, tuple[int, str]] = {}
+    candidates: dict[str, list[tuple[int, str]]] = {}
     for name, prop in dictionary.properties.items():
         if name not in appliance.status_list:
             continue
@@ -30,14 +29,68 @@ def climate_target_bindings(
         target = prop.climate.target
         if target is None:
             continue
-        current = bindings.get(target)
-        if current is None or prop.climate.priority < current[0]:
-            bindings[target] = (prop.climate.priority, name)
-    return {target: name for target, (_, name) in bindings.items()}
+        candidates.setdefault(target, []).append((prop.climate.priority, name))
+    return candidates
+
+
+def climate_target_bindings(
+    appliance: ConnectLifeAppliance,
+    dictionary: Dictionary,
+    overrides: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve which property serves each climate target for this appliance.
+
+    Several properties may declare the same ``climate.target`` (e.g. both
+    ``t_swing_angle`` and ``t_up_down`` map to ``swing_mode``). Among the
+    candidates the device actually exposes (present in ``status_list`` and not
+    disabled), the one with the lowest ``priority`` wins the target; ties are
+    broken by dictionary order. Returns ``{target: property_name}``.
+
+    ``overrides`` (``{target: property_name}``) lets the user pin a specific
+    candidate for a target — used when a device advertises a control it doesn't
+    actually support (e.g. ``t_swing_angle`` present but inert). An override is
+    honoured only when the named property is itself a valid candidate for that
+    target on this device; otherwise the automatic winner is kept.
+    """
+    overrides = overrides or {}
+    bindings: dict[str, str] = {}
+    for target, candidates in _climate_candidates(appliance, dictionary).items():
+        names = [name for _, name in candidates]
+        override = overrides.get(target)
+        if override in names:
+            bindings[target] = override
+        else:
+            # Lowest priority wins; min() keeps the first on ties (dict order).
+            bindings[target] = min(candidates, key=lambda c: c[0])[1]
+    return bindings
+
+
+def contested_climate_targets(
+    appliance: ConnectLifeAppliance, dictionary: Dictionary
+) -> dict[str, list[str]]:
+    """Climate targets this appliance exposes more than one candidate for.
+
+    These are the targets where the automatic binding makes a choice the user
+    may want to override. Returns ``{target: [property_name, ...]}`` (dictionary
+    order), only for targets with two or more candidates.
+    """
+    return {
+        target: [name for _, name in candidates]
+        for target, candidates in _climate_candidates(appliance, dictionary).items()
+        if len(candidates) > 1
+    }
+
+
+def device_target_overrides(config_entry, device_id: str) -> dict[str, str]:
+    """Per-device climate target overrides configured via the options flow."""
+    device = config_entry.options.get(CONF_DEVICES, {}).get(device_id, {})
+    return device.get(CONF_TARGET_OVERRIDES, {})
 
 
 def climate_bound_properties(
-    appliance: ConnectLifeAppliance, dictionary: Dictionary
+    appliance: ConnectLifeAppliance,
+    dictionary: Dictionary,
+    overrides: Mapping[str, str] | None = None,
 ) -> set[str]:
     """Property names bound to a climate target for this appliance.
 
@@ -45,7 +98,7 @@ def climate_bound_properties(
     so its per-property platform (if any) must be suppressed to avoid a
     duplicate entity.
     """
-    return set(climate_target_bindings(appliance, dictionary).values())
+    return set(climate_target_bindings(appliance, dictionary, overrides).values())
 
 
 def to_unit(unit: str | None, appliance: ConnectLifeAppliance, dictionary: Dictionary):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -11,19 +11,32 @@ from custom_components.connectlife.climate import (
     _add_hvac_mode_mapping,
     is_climate,
 )
-from custom_components.connectlife.const import HVAC_MODE, IS_ON, SWING_MODE
+from custom_components.connectlife.const import (
+    CONF_DEVICES,
+    CONF_TARGET_OVERRIDES,
+    HVAC_MODE,
+    IS_ON,
+    SWING_MODE,
+)
 from custom_components.connectlife.dictionaries import Dictionary, Property
-from custom_components.connectlife.utils import climate_bound_properties
+from custom_components.connectlife.utils import (
+    climate_bound_properties,
+    contested_climate_targets,
+)
 
 
-def _coordinator(appliance: SimpleNamespace) -> SimpleNamespace:
+def _coordinator(appliance: SimpleNamespace, options: dict | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         data={appliance.device_id: appliance},
-        config_entry=SimpleNamespace(options={}, entry_id="e"),
+        config_entry=SimpleNamespace(options=options or {}, entry_id="e"),
         hass=None,
         last_update_success=True,
         add_entity=lambda *a, **k: None,
     )
+
+
+def _override_options(device_id: str, target: str, property_name: str) -> dict:
+    return {CONF_DEVICES: {device_id: {CONF_TARGET_OVERRIDES: {target: property_name}}}}
 
 
 def _swing_dictionary() -> Dictionary:
@@ -93,6 +106,46 @@ def test_swing_mode_falls_back_to_lower_priority_candidate() -> None:
 
     assert climate.target_map[SWING_MODE] == "t_up_down"
     assert "t_up_down" in climate_bound_properties(appliance, dictionary)
+
+
+def test_swing_mode_override_pins_configured_property() -> None:
+    """A per-device override pins t_up_down as swing_mode even when the
+    higher-priority t_swing_angle is also exposed (issue #607)."""
+    dictionary = _swing_dictionary()
+    appliance = _swing_appliance({"t_power": 1, "t_swing_angle": 0, "t_up_down": 0})
+    options = _override_options(appliance.device_id, SWING_MODE, "t_up_down")
+    climate = ConnectLifeClimate(_coordinator(appliance, options), appliance, dictionary)
+
+    assert climate.target_map[SWING_MODE] == "t_up_down"
+    # t_up_down now wins swing_mode, so it is no longer offered as a switch.
+    overrides = options[CONF_DEVICES][appliance.device_id][CONF_TARGET_OVERRIDES]
+    bound = climate_bound_properties(appliance, dictionary, overrides)
+    assert bound == {"t_up_down", "t_power"}
+
+
+def test_swing_mode_override_ignored_when_property_absent() -> None:
+    """An override naming a property the device doesn't expose is ignored,
+    falling back to the automatic priority-based winner."""
+    dictionary = _swing_dictionary()
+    appliance = _swing_appliance({"t_power": 1, "t_swing_angle": 0, "t_up_down": 0})
+    options = _override_options(appliance.device_id, SWING_MODE, "t_not_present")
+    climate = ConnectLifeClimate(_coordinator(appliance, options), appliance, dictionary)
+
+    assert climate.target_map[SWING_MODE] == "t_swing_angle"
+
+
+def test_contested_targets_reports_only_multi_candidate_targets() -> None:
+    """contested_climate_targets lists a target only when the device exposes
+    more than one candidate for it — that's what the options flow offers."""
+    dictionary = _swing_dictionary()
+
+    both = _swing_appliance({"t_power": 1, "t_swing_angle": 0, "t_up_down": 0})
+    assert contested_climate_targets(both, dictionary) == {
+        SWING_MODE: ["t_swing_angle", "t_up_down"]
+    }
+
+    single = _swing_appliance({"t_power": 1, "t_up_down": 0})
+    assert contested_climate_targets(single, dictionary) == {}
 
 
 def test_hvac_mode_alias_does_not_override_canonical_reverse_mapping() -> None:


### PR DESCRIPTION
## Summary

Some appliances expose more than one property for the same climate target (e.g. both `t_swing_angle` and `t_up_down` for `swing_mode`). The integration binds the lowest-priority candidate the device exposes, but a few devices **advertise a control they don't actually honour** — the swing angle options appear on the climate card yet only make the unit beep, while the simple on/off swing is what works.

Crucially, this can't be resolved in the data dictionaries: two variants can share the same `deviceTypeCode`/`deviceFeatureCode`, both report the property, both report the same `property_version`, and the static-data query returns nothing — yet one honours the control and the other doesn't. The only real discriminator is the physical model number, which the API doesn't expose. A blanket `disable` on the feature code would therefore regress the variants where the control genuinely works (confirmed in #590).

So this adds a **generic per-device, per-climate-target override** to the options flow. For every target with more than one exposed candidate, the user can pin the property their hardware responds to, or leave it on **auto** to keep today's priority-based binding.

## Changes

- **`utils.py`** — `_climate_candidates` groups the exposed candidates per target; `climate_target_bindings` / `climate_bound_properties` accept an `overrides` map (an override is honoured only when it names a valid candidate for that device, else auto wins); new `contested_climate_targets` and `device_target_overrides` helpers.
- **`climate.py`** and the five per-property platforms (sensor/number/switch/binary_sensor/select) thread the per-device overrides through, so the losing property still surfaces as its own entity.
- **`config_flow.py`** — adds an "auto / property" select per contested target in the per-device configure step (only appears when a device exposes more than one candidate).
- **`const.py`** — `CONF_TARGET_OVERRIDES`, `OVERRIDE_AUTO`.
- **Translations** — labels/descriptions for `swing_mode` / `swing_horizontal_mode` (regenerated via `gen_strings`).
- **Docs** — user-facing "Swing mode control" section in `README.md`; a note in the data-dictionary docs pointing authors to the override instead of a whole-feature-code `disable`.
- **Tests** — override pins the configured property, invalid override is ignored, and contested-target detection.

Default behaviour is unchanged (auto), so no existing device is affected; devices exposing a single swing candidate see no new option.

## Testing

- `uv run pytest` → 57 passed
- `uv run pyright custom_components/connectlife/` → 0 errors

Fixes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)