### PR TITLE
Add missing config and options flow translations

### DIFF
--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -8924,7 +8924,7 @@
         },
         "data_description": {
           "disable_beep": "Suppress the appliance beep on commands sent from Home Assistant.",
-          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable.",
+          "expose_offline_state": "Adds a connectivity sensor for this device and keeps its other entities available with their last known values even when the API reports it offline, instead of marking them unavailable.",
           "target_overrides_swing_horizontal_mode": "This device exposes more than one property that can drive horizontal swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them.",
           "target_overrides_swing_mode": "This device exposes more than one property that can drive swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them (e.g. choose t_up_down if t_swing_angle is shown but does nothing)."
         },

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Ger\u00e4t ist bereits konfiguriert"
+      "already_configured": "Ger\u00e4t ist bereits konfiguriert",
+      "reauth_successful": "Erneute Authentifizierung war erfolgreich"
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
@@ -15,13 +16,28 @@
         "data": {
           "test_server_url": "Test-Server-URL"
         },
+        "data_description": {
+          "test_server_url": "URL des Testservers, gegen den anstelle der ConnectLife-API authentifiziert werden soll."
+        },
         "description": "Aktiviere den Entwicklungsmodus, um eine Verbindung zum Testserver anstelle der ConnectLife-API herzustellen."
+      },
+      "reauth_confirm": {
+        "data": {
+          "password": "Passwort",
+          "username": "Benutzername"
+        },
+        "description": "Bitte gib deine ConnectLife-Anmeldedaten erneut ein."
       },
       "user": {
         "data": {
           "development_mode": "Entwicklungsmodus",
           "password": "Passwort",
+          "trir": "ConnectLife.TRIR (Russland/GUS) \u2014 experimentell",
           "username": "Benutzername"
+        },
+        "data_description": {
+          "development_mode": "Mit einem lokalen Testserver anstelle der ConnectLife-API verbinden. Nur f\u00fcr die Entwicklung.",
+          "trir": "Nur aktivieren, wenn du dich mit der ConnectLife.TRIR-App anmeldest, die in Russland/GUS verwendet wird. Experimentell."
         }
       }
     }
@@ -3951,7 +3967,16 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Signalton deaktivieren"
+          "disable_beep": "Signalton deaktivieren",
+          "expose_offline_state": "Offline-Status anzeigen",
+          "target_overrides_swing_horizontal_mode": "Steuerung des horizontalen Schwenkmodus",
+          "target_overrides_swing_mode": "Steuerung des Schwenkmodus"
+        },
+        "data_description": {
+          "disable_beep": "Unterdr\u00fcckt den Signalton des Ger\u00e4ts bei Befehlen, die von Home Assistant gesendet werden.",
+          "expose_offline_state": "F\u00fcgt einen Konnektivit\u00e4tssensor f\u00fcr dieses Ger\u00e4t hinzu und h\u00e4lt seine anderen Entit\u00e4ten mit ihren zuletzt bekannten Werten verf\u00fcgbar, selbst wenn die API das Ger\u00e4t als offline meldet, anstatt sie als nicht verf\u00fcgbar zu markieren.",
+          "target_overrides_swing_horizontal_mode": "Dieses Ger\u00e4t stellt mehr als eine Eigenschaft bereit, die den horizontalen Schwenkmodus steuern kann. Belasse die Einstellung auf \u201eauto\u201c, damit die Integration w\u00e4hlt, oder lege eine bestimmte Eigenschaft fest, wenn deine Hardware nur eine davon unterst\u00fctzt.",
+          "target_overrides_swing_mode": "Dieses Ger\u00e4t stellt mehr als eine Eigenschaft bereit, die den Schwenkmodus steuern kann. Belasse die Einstellung auf \u201eauto\u201c, damit die Integration w\u00e4hlt, oder lege eine bestimmte Eigenschaft fest, wenn deine Hardware nur eine davon unterst\u00fctzt (z. B. t_up_down w\u00e4hlen, wenn t_swing_angle angezeigt wird, aber nichts bewirkt)."
         },
         "description": "{device_name} konfigurieren."
       },

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -8924,7 +8924,7 @@
         },
         "data_description": {
           "disable_beep": "Suppress the appliance beep on commands sent from Home Assistant.",
-          "expose_offline_state": "Add a connectivity sensor for this device and keep its other entities available with their last known values while it is offline, instead of marking them unavailable.",
+          "expose_offline_state": "Adds a connectivity sensor for this device and keeps its other entities available with their last known values even when the API reports it offline, instead of marking them unavailable.",
           "target_overrides_swing_horizontal_mode": "This device exposes more than one property that can drive horizontal swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them.",
           "target_overrides_swing_mode": "This device exposes more than one property that can drive swing mode. Leave on \"auto\" to let the integration choose, or pin a specific property if your hardware only honours one of them (e.g. choose t_up_down if t_swing_angle is shown but does nothing)."
         },

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "El dispositivo ya est\u00e1 configurado"
+      "already_configured": "El dispositivo ya est\u00e1 configurado",
+      "reauth_successful": "La reautenticaci\u00f3n se realiz\u00f3 correctamente"
     },
     "error": {
       "cannot_connect": "Fallo al establecer la conexi\u00f3n",
@@ -15,13 +16,28 @@
         "data": {
           "test_server_url": "Test server URL"
         },
+        "data_description": {
+          "test_server_url": "URL del servidor de prueba contra el que autenticarse en lugar de la API de ConnectLife."
+        },
         "description": "Habilitar modo desarrollo para conectar al test server en vez de a ConnectLife API."
+      },
+      "reauth_confirm": {
+        "data": {
+          "password": "Contrase\u00f1a",
+          "username": "Nombre de usuario"
+        },
+        "description": "Vuelve a introducir tus credenciales de ConnectLife."
       },
       "user": {
         "data": {
           "development_mode": "Modo desarrollo",
           "password": "Contrase\u00f1a",
+          "trir": "ConnectLife.TRIR (Rusia/CEI) \u2014 experimental",
           "username": "Nombre de usuario"
+        },
+        "data_description": {
+          "development_mode": "Conectar a un servidor de prueba local en lugar de a la API de ConnectLife. Solo para desarrollo.",
+          "trir": "Habil\u00edtalo solo si inicias sesi\u00f3n con la app ConnectLife.TRIR utilizada en Rusia/CEI. Experimental."
         }
       }
     }
@@ -1770,7 +1786,16 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Deshabilitar beep"
+          "disable_beep": "Deshabilitar beep",
+          "expose_offline_state": "Exponer estado sin conexi\u00f3n",
+          "target_overrides_swing_horizontal_mode": "Control del modo de oscilaci\u00f3n horizontal",
+          "target_overrides_swing_mode": "Control del modo de oscilaci\u00f3n"
+        },
+        "data_description": {
+          "disable_beep": "Suprime el pitido del electrodom\u00e9stico en los comandos enviados desde Home Assistant.",
+          "expose_offline_state": "A\u00f1ade un sensor de conectividad para este dispositivo y mantiene sus dem\u00e1s entidades disponibles con sus \u00faltimos valores conocidos incluso cuando la API lo notifica como sin conexi\u00f3n, en lugar de marcarlas como no disponibles.",
+          "target_overrides_swing_horizontal_mode": "Este dispositivo expone m\u00e1s de una propiedad que puede controlar el modo de oscilaci\u00f3n horizontal. D\u00e9jalo en \u00abauto\u00bb para que la integraci\u00f3n elija, o fija una propiedad concreta si tu hardware solo admite una de ellas.",
+          "target_overrides_swing_mode": "Este dispositivo expone m\u00e1s de una propiedad que puede controlar el modo de oscilaci\u00f3n. D\u00e9jalo en \u00abauto\u00bb para que la integraci\u00f3n elija, o fija una propiedad concreta si tu hardware solo admite una de ellas (por ejemplo, elige t_up_down si se muestra t_swing_angle pero no hace nada)."
         },
         "description": "Configurar {device_name}."
       },

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "L\u2019appareil est d\u00e9j\u00e0 configur\u00e9"
+      "already_configured": "L\u2019appareil est d\u00e9j\u00e0 configur\u00e9",
+      "reauth_successful": "La r\u00e9-authentification a r\u00e9ussi"
     },
     "error": {
       "cannot_connect": "\u00c9chec de l\u2019\u00e9tablissement de la connexion",
@@ -15,13 +16,28 @@
         "data": {
           "test_server_url": "URL du serveur de test"
         },
+        "data_description": {
+          "test_server_url": "URL du serveur de test sur lequel s\u2019authentifier au lieu de l\u2019API ConnectLife."
+        },
         "description": "Activer le mode d\u00e9veloppement pour se connecter au serveur de test au lieu de l\u2019API ConnectLife."
+      },
+      "reauth_confirm": {
+        "data": {
+          "password": "Mot de passe",
+          "username": "Nom d\u2019utilisateur"
+        },
+        "description": "Veuillez saisir \u00e0 nouveau vos identifiants ConnectLife."
       },
       "user": {
         "data": {
           "development_mode": "Mode d\u00e9veloppement",
           "password": "Mot de passe",
+          "trir": "ConnectLife.TRIR (Russie/CEI) \u2014 exp\u00e9rimental",
           "username": "Nom d\u2019utilisateur"
+        },
+        "data_description": {
+          "development_mode": "Se connecter \u00e0 un serveur de test local au lieu de l\u2019API ConnectLife. Pour le d\u00e9veloppement uniquement.",
+          "trir": "\u00c0 activer uniquement si vous vous connectez avec l\u2019application ConnectLife.TRIR utilis\u00e9e en Russie/CEI. Exp\u00e9rimental."
         }
       }
     }
@@ -1342,7 +1358,16 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "D\u00e9sactiver le bip"
+          "disable_beep": "D\u00e9sactiver le bip",
+          "expose_offline_state": "Exposer l'\u00e9tat hors ligne",
+          "target_overrides_swing_horizontal_mode": "Contr\u00f4le du mode d'oscillation horizontale",
+          "target_overrides_swing_mode": "Contr\u00f4le du mode d'oscillation"
+        },
+        "data_description": {
+          "disable_beep": "Supprime le bip de l'appareil lors des commandes envoy\u00e9es depuis Home Assistant.",
+          "expose_offline_state": "Ajoute un capteur de connectivit\u00e9 pour cet appareil et conserve ses autres entit\u00e9s disponibles avec leurs derni\u00e8res valeurs connues m\u00eame lorsque l\u2019API le signale hors ligne, au lieu de les marquer comme indisponibles.",
+          "target_overrides_swing_horizontal_mode": "Cet appareil expose plusieurs propri\u00e9t\u00e9s pouvant piloter le mode d'oscillation horizontale. Laissez sur \u00ab auto \u00bb pour laisser l'int\u00e9gration choisir, ou fixez une propri\u00e9t\u00e9 pr\u00e9cise si votre mat\u00e9riel n'en prend en charge qu'une seule.",
+          "target_overrides_swing_mode": "Cet appareil expose plusieurs propri\u00e9t\u00e9s pouvant piloter le mode d'oscillation. Laissez sur \u00ab auto \u00bb pour laisser l'int\u00e9gration choisir, ou fixez une propri\u00e9t\u00e9 pr\u00e9cise si votre mat\u00e9riel n'en prend en charge qu'une seule (par exemple, choisissez t_up_down si t_swing_angle est affich\u00e9 mais n'a aucun effet)."
         },
         "description": "Configurer {device_name}."
       },

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Il dispositivo \u00e8 gi\u00e0 configurato"
+      "already_configured": "Il dispositivo \u00e8 gi\u00e0 configurato",
+      "reauth_successful": "La riautenticazione \u00e8 riuscita"
     },
     "error": {
       "cannot_connect": "Impossibile connettersi",
@@ -15,13 +16,28 @@
         "data": {
           "test_server_url": "Test server URL"
         },
+        "data_description": {
+          "test_server_url": "URL del server di prova con cui autenticarsi anzich\u00e9 con l'API ConnectLife."
+        },
         "description": "Abilita la modalit\u00e0 di sviluppo per connettersi al server di test anzich\u00e9 all'API ConnectLife."
+      },
+      "reauth_confirm": {
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        },
+        "description": "Reinserisci le tue credenziali ConnectLife."
       },
       "user": {
         "data": {
           "development_mode": "Modalit\u00e0 di sviluppo",
           "password": "Password",
+          "trir": "ConnectLife.TRIR (Russia/CSI) \u2014 sperimentale",
           "username": "Username"
+        },
+        "data_description": {
+          "development_mode": "Connettersi a un server di prova locale anzich\u00e9 all'API ConnectLife. Solo per lo sviluppo.",
+          "trir": "Abilita solo se accedi con l'app ConnectLife.TRIR utilizzata in Russia/CSI. Sperimentale."
         }
       }
     }
@@ -741,7 +757,16 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Disattiva beep"
+          "disable_beep": "Disattiva beep",
+          "expose_offline_state": "Esponi stato offline",
+          "target_overrides_swing_horizontal_mode": "Controllo della modalit\u00e0 di oscillazione orizzontale",
+          "target_overrides_swing_mode": "Controllo della modalit\u00e0 di oscillazione"
+        },
+        "data_description": {
+          "disable_beep": "Disattiva il segnale acustico dell'elettrodomestico per i comandi inviati da Home Assistant.",
+          "expose_offline_state": "Aggiunge un sensore di connettivit\u00e0 per questo dispositivo e mantiene le altre entit\u00e0 disponibili con i loro ultimi valori noti anche quando l'API lo segnala offline, invece di contrassegnarle come non disponibili.",
+          "target_overrides_swing_horizontal_mode": "Questo dispositivo espone pi\u00f9 di una propriet\u00e0 in grado di controllare la modalit\u00e0 di oscillazione orizzontale. Lascia su \u00abauto\u00bb per far scegliere all'integrazione, oppure fissa una propriet\u00e0 specifica se il tuo hardware ne supporta solo una.",
+          "target_overrides_swing_mode": "Questo dispositivo espone pi\u00f9 di una propriet\u00e0 in grado di controllare la modalit\u00e0 di oscillazione. Lascia su \u00abauto\u00bb per far scegliere all'integrazione, oppure fissa una propriet\u00e0 specifica se il tuo hardware ne supporta solo una (ad esempio scegli t_up_down se viene mostrato t_swing_angle ma non ha alcun effetto)."
         },
         "description": "Configura {device_name}."
       },

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -16,6 +16,9 @@
         "data": {
           "test_server_url": "Test server URL"
         },
+        "data_description": {
+          "test_server_url": "URL van de testserver om tegen te authenticeren in plaats van de ConnectLife API."
+        },
         "description": "Schakel ontwikkelingsmodus in om verbinding te maken met de testserver in plaats van de ConnectLife API."
       },
       "reauth_confirm": {
@@ -29,7 +32,12 @@
         "data": {
           "development_mode": "Ontwikkelingsmodus",
           "password": "Wachtwoord",
+          "trir": "ConnectLife.TRIR (Rusland/GOS) \u2014 experimenteel",
           "username": "Gebruikersnaam"
+        },
+        "data_description": {
+          "development_mode": "Verbinden met een lokale testserver in plaats van de ConnectLife API. Alleen voor ontwikkeling.",
+          "trir": "Alleen inschakelen als je inlogt met de ConnectLife.TRIR-app die in Rusland/GOS wordt gebruikt. Experimenteel."
         }
       }
     }
@@ -8188,7 +8196,16 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Pieptoon uitschakelen"
+          "disable_beep": "Pieptoon uitschakelen",
+          "expose_offline_state": "Offline-status tonen",
+          "target_overrides_swing_horizontal_mode": "Bediening horizontale zwenkmodus",
+          "target_overrides_swing_mode": "Bediening zwenkmodus"
+        },
+        "data_description": {
+          "disable_beep": "Onderdrukt de pieptoon van het apparaat bij opdrachten die vanuit Home Assistant worden verzonden.",
+          "expose_offline_state": "Voegt een connectiviteitssensor voor dit apparaat toe en houdt de andere entiteiten beschikbaar met hun laatst bekende waarden, zelfs wanneer de API het als offline meldt, in plaats van ze als niet beschikbaar te markeren.",
+          "target_overrides_swing_horizontal_mode": "Dit apparaat biedt meer dan \u00e9\u00e9n eigenschap die de horizontale zwenkmodus kan aansturen. Laat op \u2018auto\u2019 staan om de integratie te laten kiezen, of leg een specifieke eigenschap vast als je hardware er maar \u00e9\u00e9n ondersteunt.",
+          "target_overrides_swing_mode": "Dit apparaat biedt meer dan \u00e9\u00e9n eigenschap die de zwenkmodus kan aansturen. Laat op \u2018auto\u2019 staan om de integratie te laten kiezen, of leg een specifieke eigenschap vast als je hardware er maar \u00e9\u00e9n ondersteunt (kies bijvoorbeeld t_up_down als t_swing_angle wordt getoond maar niets doet)."
         },
         "description": "{device_name} configureren."
       },

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -16,6 +16,9 @@
         "data": {
           "test_server_url": "URL for testserver"
         },
+        "data_description": {
+          "test_server_url": "URL-en til testserveren som det skal autentiseres mot i stedet for ConnectLife-API-et."
+        },
         "description": "Aktiver utviklingsmodus for \u00e5 koble til testserveren i stedet for ConnectLife-API-et."
       },
       "reauth_confirm": {
@@ -29,7 +32,12 @@
         "data": {
           "development_mode": "Utviklingsmodus",
           "password": "Passord",
+          "trir": "ConnectLife.TRIR (Russland/SUS) \u2014 eksperimentell",
           "username": "Brukernavn"
+        },
+        "data_description": {
+          "development_mode": "Koble til en lokal testserver i stedet for ConnectLife-API-et. Kun for utvikling.",
+          "trir": "Aktiver kun hvis du logger inn med ConnectLife.TRIR-appen som brukes i Russland/SUS. Eksperimentell."
         }
       }
     }
@@ -8188,7 +8196,16 @@
     "step": {
       "configure_device": {
         "data": {
-          "disable_beep": "Deaktiver pip"
+          "disable_beep": "Deaktiver pip",
+          "expose_offline_state": "Vis frakoblet tilstand",
+          "target_overrides_swing_horizontal_mode": "Styring av horisontal svingemodus",
+          "target_overrides_swing_mode": "Styring av svingemodus"
+        },
+        "data_description": {
+          "disable_beep": "Undertrykker pipetonen p\u00e5 apparatet ved kommandoer sendt fra Home Assistant.",
+          "expose_offline_state": "Legger til en tilkoblingssensor for denne enheten og holder de \u00f8vrige entitetene tilgjengelige med sine sist kjente verdier selv n\u00e5r API-et rapporterer enheten som frakoblet, i stedet for \u00e5 markere dem som utilgjengelige.",
+          "target_overrides_swing_horizontal_mode": "Denne enheten eksponerer mer enn \u00e9n egenskap som kan styre horisontal svingemodus. La den st\u00e5 p\u00e5 \u00abauto\u00bb for \u00e5 la integrasjonen velge, eller l\u00e5s en bestemt egenskap hvis maskinvaren din bare st\u00f8tter \u00e9n av dem.",
+          "target_overrides_swing_mode": "Denne enheten eksponerer mer enn \u00e9n egenskap som kan styre svingemodus. La den st\u00e5 p\u00e5 \u00abauto\u00bb for \u00e5 la integrasjonen velge, eller l\u00e5s en bestemt egenskap hvis maskinvaren din bare st\u00f8tter \u00e9n av dem (velg for eksempel t_up_down hvis t_swing_angle vises, men ikke gj\u00f8r noe)."
         },
         "description": "Konfigurer {device_name}."
       },


### PR DESCRIPTION
## Summary

The options flow recently gained per-device climate-target override selects and an offline-state toggle, and the config flow gained the development-mode / ConnectLife.TRIR fields — but only English carried strings for the new fields. This fills in the **config** and **options** flow translations across all six languages (`de`, `es`, `fr`, `it`, `nl`, `no`).

Newly translated options-flow keys (all languages):
- `expose_offline_state` (label + description)
- `target_overrides_swing_mode` / `target_overrides_swing_horizontal_mode` (labels + descriptions)
- `disable_beep` (description)

Newly translated config-flow keys:
- All languages: `development.data_description.test_server_url`, `user.data.trir`, `user.data_description.development_mode`, `user.data_description.trir`
- `de`/`es`/`fr`/`it` also: `abort.reauth_successful` and the `reauth_confirm` step (`nl`/`no` already had these)

Also rewords the `expose_offline_state` description in the **English source** (`strings.json` + `en.json`) and every translation so it names both effects: it adds the connectivity sensor **and** keeps the device's other entities available with their last known values even when the API reports it offline.

## Notes
- Per-language conventions preserved (curly apostrophes in French, `Username`/`Password` left as-is in Italian to match that file's existing user step, localized CIS abbreviations).
- `check_translations` reports no missing `config.*` or `options.*` keys in any language; `sort_translations` is a no-op (formatting already canonical).
- These are machine-authored translations — a native-speaker pass wouldn't hurt.