### PR TITLE
Add missing Spanish translations

### DIFF
--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -44,6 +44,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "add_moist_now": {
+        "name": "A\u00f1adir humedad ahora"
+      },
       "ado_allowed": {
         "name": "ADO permitido"
       },
@@ -86,8 +89,14 @@
       "alarm_alarm_time_reached": {
         "name": "Tiempo de alarma finalizado."
       },
+      "alarm_aquaclean_finished": {
+        "name": "AquaClean finalizado"
+      },
       "alarm_auto_dose_refill": {
         "name": "Alarma en el auto relleno del dosificador"
+      },
+      "alarm_auto_program_ended": {
+        "name": "Programa autom\u00e1tico finalizado"
       },
       "alarm_auto_program_notification": {
         "name": "Auto program notification"
@@ -104,17 +113,41 @@
       "alarm_baking_finished": {
         "name": "Alarma de horneado finalizada"
       },
+      "alarm_baking_stoped": {
+        "name": "Alarma de cocci\u00f3n detenida"
+      },
+      "alarm_child_lock_deactivated_on_the_oven": {
+        "name": "Alarma de bloqueo infantil desactivada en el horno"
+      },
       "alarm_clean_the_filters": {
         "name": "Limpiar filtros"
+      },
+      "alarm_cleaning_suggestion_after_baking_finished": {
+        "name": "Alarma de sugerencia de limpieza tras finalizar el horneado"
+      },
+      "alarm_defrost_finished": {
+        "name": "Alarma de descongelaci\u00f3n finalizada"
       },
       "alarm_descale_now": {
         "name": "Alarma, descalcifique ahora"
       },
+      "alarm_descaling_needed": {
+        "name": "Alarma de descalcificaci\u00f3n necesaria"
+      },
       "alarm_door_closed": {
         "name": "Puerta cerrada"
       },
+      "alarm_door_locked": {
+        "name": "Alarma de puerta bloqueada"
+      },
       "alarm_door_opened": {
         "name": "Puerta abierta"
+      },
+      "alarm_ean_scan_info": {
+        "name": "Alarma de escaneo EAN"
+      },
+      "alarm_empty_and_clean_water_tank": {
+        "name": "Alarma para vaciar y limpiar el dep\u00f3sito de agua"
       },
       "alarm_external_autodose_level15": {
         "name": "Autodosificador externo nivel 15"
@@ -122,8 +155,23 @@
       "alarm_external_autodose_level30": {
         "name": "Autodosificador externo nivel 30"
       },
+      "alarm_fast_preheat_active": {
+        "name": "Alarma de precalentamiento r\u00e1pido activo"
+      },
+      "alarm_fast_preheating_finished": {
+        "name": "Alarma de precalentamiento r\u00e1pido finalizado"
+      },
+      "alarm_grease_filter": {
+        "name": "Alarma de filtro de grasa"
+      },
       "alarm_hob_hood_started": {
         "name": "Campana encendida"
+      },
+      "alarm_keepwarm_ended": {
+        "name": "Mantenimiento de calor finalizado"
+      },
+      "alarm_mw_active": {
+        "name": "Microondas activo"
       },
       "alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina NTC"
@@ -134,17 +182,38 @@
       "alarm_ntc_tc": {
         "name": "NTC TC"
       },
+      "alarm_oven_temperature_too_high": {
+        "name": "Alarma de temperatura del horno demasiado alta"
+      },
+      "alarm_oven_usage_reached_set_limit_auto_cleaning_suggested": {
+        "name": "Alarma: el uso del horno alcanz\u00f3 el l\u00edmite establecido, se sugiere limpieza autom\u00e1tica"
+      },
+      "alarm_platewarm_ended": {
+        "name": "Calentamiento de platos finalizado"
+      },
       "alarm_preheat_reached": {
         "name": "Alarma, precalentamiento alcanzado"
       },
       "alarm_preheating_ready": {
         "name": "Precalentado"
       },
+      "alarm_probe_inserted": {
+        "name": "Alarma de sonda insertada"
+      },
+      "alarm_probe_temp_reached": {
+        "name": "Alarma de temperatura de sonda alcanzada"
+      },
       "alarm_program_done": {
         "name": "Programa terminado"
       },
       "alarm_program_pause": {
         "name": "Programa pausado"
+      },
+      "alarm_pyrolytic_finished": {
+        "name": "Alarma de pir\u00f3lisis finalizada"
+      },
+      "alarm_recirculation_filter_1": {
+        "name": "Alarma del filtro de recirculaci\u00f3n 1"
       },
       "alarm_remote_start_canceled": {
         "name": "Inicio remoto cancelado"
@@ -158,14 +227,38 @@
       "alarm_run_selfcleaning": {
         "name": "Ejecutar autolimpieza"
       },
+      "alarm_running_time_over_10_or_24_hour_limit_error": {
+        "name": "Error de alarma por tiempo de funcionamiento superior al l\u00edmite de 10 o 24 horas"
+      },
+      "alarm_sabbath_reminder": {
+        "name": "Recordatorio de modo sab\u00e1tico"
+      },
       "alarm_salt_refill": {
         "name": "Recargar sal"
+      },
+      "alarm_sand_timer_1_elapsed": {
+        "name": "Alarma de temporizador de arena 1 transcurrido"
+      },
+      "alarm_sand_timer_2_elapsed": {
+        "name": "Alarma de temporizador de arena 2 transcurrido"
+      },
+      "alarm_sand_timer_3_elapsed": {
+        "name": "Alarma de temporizador de arena 3 transcurrido"
       },
       "alarm_sani_program_finished": {
         "name": "Programa Sani terminado"
       },
+      "alarm_set_temperature_reached": {
+        "name": "Alarma de temperatura ajustada alcanzada"
+      },
       "alarm_steam_empty": {
         "name": "Vapor vac\u00edo"
+      },
+      "alarm_steam_fill_alarm": {
+        "name": "Alarma de llenado de vapor"
+      },
+      "alarm_steam_function_active": {
+        "name": "Alarma de funci\u00f3n de vapor activa"
       },
       "alarm_temperature_reached": {
         "name": "Temperatura alcanzada"
@@ -175,6 +268,9 @@
       },
       "alarm_turn_food": {
         "name": "Girar comida"
+      },
+      "alarm_user_interaction_on_appliance_detected": {
+        "name": "Alarma de interacci\u00f3n del usuario detectada en el aparato"
       },
       "alarm_voltage": {
         "name": "Voltage"
@@ -191,23 +287,221 @@
       "alarm_water_tank_empty": {
         "name": "Tanque de agua vacio"
       },
+      "alarm_water_tank_is_empty": {
+        "name": "Alarma de dep\u00f3sito de agua vac\u00edo"
+      },
+      "alarm_water_tank_is_missing": {
+        "name": "Alarma de dep\u00f3sito de agua ausente"
+      },
       "alarm_water_tank_missing": {
         "name": "Tanque de agua no encontrado"
       },
       "alarm_zone_turned_off": {
         "name": "Zona apagada"
       },
+      "alarmalmost_finished": {
+        "name": "Alarma casi finalizada"
+      },
+      "alarmchild_lockoff": {
+        "name": "Alarma de bloqueo infantil desactivado"
+      },
+      "alarmchild_lockon": {
+        "name": "Alarma de bloqueo infantil activado"
+      },
+      "alarmcleanairended": {
+        "name": "Alarma de aire limpio finalizada"
+      },
+      "alarmcleancondense": {
+        "name": "Limpiar condensador"
+      },
+      "alarmcleancondenserfilter": {
+        "name": "Limpiar el filtro del condensador"
+      },
+      "alarmcleandoorfilter": {
+        "name": "Limpiar filtro de la puerta"
+      },
+      "alarmcleanfilterwarning": {
+        "name": "Limpiar filtro"
+      },
+      "alarmcleantank": {
+        "name": "Alarma de limpieza del dep\u00f3sito"
+      },
+      "alarmclosethedoorwarning": {
+        "name": "Puerta no cerrada"
+      },
+      "alarmdehydrate_ended": {
+        "name": "Alarma de deshidrataci\u00f3n finalizada"
+      },
+      "alarmdescalestep1": {
+        "name": "Alarma de descalcificaci\u00f3n paso 1"
+      },
+      "alarmdescalestep2": {
+        "name": "Alarma de descalcificaci\u00f3n paso 2"
+      },
+      "alarmdescalestep3": {
+        "name": "Alarma de descalcificaci\u00f3n paso 3"
+      },
+      "alarmdescaling_interrupted": {
+        "name": "Alarma de descalcificaci\u00f3n interrumpida"
+      },
+      "alarmemptytankpause": {
+        "name": "Alarma de pausa por dep\u00f3sito vac\u00edo"
+      },
+      "alarmfilladcontainer1warning": {
+        "name": "Contenedor de dosificaci\u00f3n autom\u00e1tica 1 vac\u00edo"
+      },
+      "alarmfilladcontainer2warning": {
+        "name": "Contenedor de dosificaci\u00f3n autom\u00e1tica 2 vac\u00edo"
+      },
+      "alarmfilltank": {
+        "name": "Alarma llenar dep\u00f3sito"
+      },
+      "alarmfoamdetection": {
+        "name": "Espuma detectada"
+      },
+      "alarmfulltank": {
+        "name": "Dep\u00f3sito de agua lleno"
+      },
+      "alarmgreasefilter": {
+        "name": "Alarma de filtro de grasa"
+      },
+      "alarmincreased_power_consumption": {
+        "name": "Alarma de aumento del consumo de energ\u00eda"
+      },
+      "alarmkey_lock_on": {
+        "name": "Alarma de bloqueo de teclas activado"
+      },
+      "alarmmicrowave_system_finished": {
+        "name": "Alarma de sistema de microondas finalizado"
+      },
+      "alarmoptionnotavailable": {
+        "name": "Opci\u00f3n no disponible"
+      },
+      "alarmoven_system_finished": {
+        "name": "Alarma de sistema del horno finalizado"
+      },
+      "alarmpoptankopened": {
+        "name": "Alarma de dep\u00f3sito abierto"
+      },
+      "alarmpower_failure_running": {
+        "name": "Alarma de corte de corriente durante el funcionamiento"
+      },
+      "alarmpowerfail": {
+        "name": "Corte de corriente"
+      },
+      "alarmpowerfailalert": {
+        "name": "Corte de corriente"
+      },
+      "alarmprobe_lost_connection": {
+        "name": "Alarma de p\u00e9rdida de conexi\u00f3n de la sonda"
+      },
+      "alarmprogramfinished": {
+        "name": "Programa finalizado"
+      },
+      "alarmrecirculationfilter1": {
+        "name": "Alarma del filtro de recirculaci\u00f3n 1"
+      },
+      "alarmrecirculationfilter2": {
+        "name": "Alarma del filtro de recirculaci\u00f3n 2"
+      },
+      "alarmremotestartpowerfailure": {
+        "name": "Alarma de fallo de alimentaci\u00f3n en inicio remoto"
+      },
+      "alarmremove_probe": {
+        "name": "Alarma de retirada de la sonda"
+      },
+      "alarmsabbathabouttostart": {
+        "name": "Alarma de modo sab\u00e1tico a punto de empezar"
+      },
+      "alarmsabbathended": {
+        "name": "Alarma de fin de modo Sabbath"
+      },
+      "alarmsabbathpostpone": {
+        "name": "Alarma de aplazamiento de modo sab\u00e1tico"
+      },
+      "alarmsteam_interrupted": {
+        "name": "Alarma de vapor interrumpido"
+      },
+      "alarmsteam_system_finished": {
+        "name": "Alarma de sistema de vapor finalizado"
+      },
+      "alarmsteamclean_finished": {
+        "name": "Alarma de limpieza a vapor finalizada"
+      },
+      "alarmsteriltubrunwarning": {
+        "name": "Esterilizaci\u00f3n del tambor pendiente"
+      },
+      "alarmtanklevel1": {
+        "name": "Alarma de nivel del dep\u00f3sito 1"
+      },
+      "alarmtimerended": {
+        "name": "Alarma de temporizador finalizado"
+      },
+      "alarmwashfinished": {
+        "name": "Lavado finalizado"
+      },
+      "ali_wifi_fault_flag": {
+        "name": "Fallo de WiFi"
+      },
+      "alramemptywatertank": {
+        "name": "Vaciar el dep\u00f3sito de agua"
+      },
+      "auto_boost": {
+        "name": "Refuerzo autom\u00e1tico"
+      },
+      "auto_bridge": {
+        "name": "Puente autom\u00e1tico"
+      },
       "auto_dose_refill": {
         "name": "Recargar autodosificador"
+      },
+      "auto_timer": {
+        "name": "Temporizador autom\u00e1tico"
+      },
+      "automatic_ice_making": {
+        "name": "Fabricaci\u00f3n autom\u00e1tica de hielo"
       },
       "charcoal_filter_expiration_alarm": {
         "name": "Alarma de caducidad del filtro de carb\u00f3n"
       },
+      "charcoal_filter_surplus_time": {
+        "name": "Tiempo restante del filtro de carb\u00f3n"
+      },
+      "charcoal_filter_time_reset": {
+        "name": "Restablecimiento del tiempo del filtro de carb\u00f3n"
+      },
+      "chef_mode": {
+        "name": "Modo chef"
+      },
       "child_lock": {
         "name": "Bloqueo ni\u00f1os"
       },
+      "child_lock_open_alarm": {
+        "name": "Alarma de bloqueo infantil abierto"
+      },
+      "child_lock_open_door_sound_alarm": {
+        "name": "Alarma sonora de puerta abierta con bloqueo infantil"
+      },
+      "child_lock_switch_exist": {
+        "name": "Existencia del interruptor de bloqueo infantil"
+      },
+      "child_lock_switch_status": {
+        "name": "Estado del interruptor de bloqueo infantil"
+      },
+      "childlockactive": {
+        "name": "Estado del bloqueo infantil"
+      },
       "clean_filter": {
         "name": "Limpiar filtro"
+      },
+      "condensation_fan_failure_status": {
+        "name": "Estado de fallo del ventilador de condensaci\u00f3n"
+      },
+      "control_failure_status": {
+        "name": "Estado de fallo del control"
+      },
+      "delay_start": {
+        "name": "Estado de inicio retrasado"
       },
       "delay_start_status": {
         "name": "Estado de inicio retrasado"
@@ -221,11 +515,197 @@
       "detergent_display": {
         "name": "Display Detergente"
       },
+      "detergent_state": {
+        "name": "Estado del detergente"
+      },
       "door": {
+        "name": "Puerta"
+      },
+      "door_lock": {
+        "name": "Bloqueo de la puerta"
+      },
+      "door_status": {
+        "name": "Puerta"
+      },
+      "doorstatus": {
         "name": "Puerta"
       },
       "eco_mode": {
         "name": "Modo ECO"
+      },
+      "envi_temp_sens_head_failure": {
+        "name": "Fallo del cabezal del sensor de temperatura ambiente"
+      },
+      "error0": {
+        "name": "Error 0"
+      },
+      "error1": {
+        "name": "Error 1"
+      },
+      "error10": {
+        "name": "Error 10"
+      },
+      "error11": {
+        "name": "Error 11"
+      },
+      "error12": {
+        "name": "Error 12"
+      },
+      "error12_1": {
+        "name": "Error 12 1"
+      },
+      "error12_10": {
+        "name": "Error 12 10"
+      },
+      "error12_12": {
+        "name": "Error 12 12"
+      },
+      "error12_2": {
+        "name": "Error 12 2"
+      },
+      "error12_3": {
+        "name": "Error 12 3"
+      },
+      "error12_4": {
+        "name": "Error 12 4"
+      },
+      "error12_5": {
+        "name": "Error 12 5"
+      },
+      "error12_6": {
+        "name": "Error 12 6"
+      },
+      "error12_7": {
+        "name": "Error 12 7"
+      },
+      "error12_8": {
+        "name": "Error 12 8"
+      },
+      "error12_9": {
+        "name": "Error 12 9"
+      },
+      "error13": {
+        "name": "Error 13"
+      },
+      "error13_1": {
+        "name": "Error 13 1"
+      },
+      "error13_2": {
+        "name": "Error 13 2"
+      },
+      "error13_3": {
+        "name": "Error 13 3"
+      },
+      "error14": {
+        "name": "Error 14"
+      },
+      "error15": {
+        "name": "Error 15"
+      },
+      "error2": {
+        "name": "Error 2"
+      },
+      "error22": {
+        "name": "Error 22"
+      },
+      "error23": {
+        "name": "Error 23"
+      },
+      "error24": {
+        "name": "Error 24"
+      },
+      "error25": {
+        "name": "Error 25"
+      },
+      "error26": {
+        "name": "Error 26"
+      },
+      "error27": {
+        "name": "Error 27"
+      },
+      "error28": {
+        "name": "Error 28"
+      },
+      "error29": {
+        "name": "Error 29"
+      },
+      "error3": {
+        "name": "Error 3"
+      },
+      "error30": {
+        "name": "Error 30"
+      },
+      "error31": {
+        "name": "Error 31"
+      },
+      "error32": {
+        "name": "Error 32"
+      },
+      "error33": {
+        "name": "Error 33"
+      },
+      "error34": {
+        "name": "Error 34"
+      },
+      "error35": {
+        "name": "Error 35"
+      },
+      "error36": {
+        "name": "Error 36"
+      },
+      "error37": {
+        "name": "Error 37"
+      },
+      "error38": {
+        "name": "Error 38"
+      },
+      "error39": {
+        "name": "Error 39"
+      },
+      "error4": {
+        "name": "Error 4"
+      },
+      "error40": {
+        "name": "Error 40"
+      },
+      "error41": {
+        "name": "Error 41"
+      },
+      "error42": {
+        "name": "Error 42"
+      },
+      "error43": {
+        "name": "Error 43"
+      },
+      "error44": {
+        "name": "Error 44"
+      },
+      "error45": {
+        "name": "Error 45"
+      },
+      "error46": {
+        "name": "Error 46"
+      },
+      "error47": {
+        "name": "Error 47"
+      },
+      "error5": {
+        "name": "Error 5"
+      },
+      "error6": {
+        "name": "Error 6"
+      },
+      "error7": {
+        "name": "Error 7"
+      },
+      "error7_1": {
+        "name": "Error 7 1"
+      },
+      "error8": {
+        "name": "Error 8"
+      },
+      "error9": {
+        "name": "Error 9"
       },
       "error_0": {
         "name": "Error 0"
@@ -254,14 +734,86 @@
       "error_16": {
         "name": "Error 16"
       },
+      "error_17": {
+        "name": "Error 17"
+      },
+      "error_18": {
+        "name": "Error 18"
+      },
+      "error_19": {
+        "name": "Error 19"
+      },
       "error_2": {
         "name": "Error 2"
+      },
+      "error_20": {
+        "name": "Error 20"
+      },
+      "error_21": {
+        "name": "Error 21"
+      },
+      "error_22": {
+        "name": "Error 22"
+      },
+      "error_23": {
+        "name": "Error 23"
+      },
+      "error_24": {
+        "name": "Error 24"
+      },
+      "error_25": {
+        "name": "Error 25"
+      },
+      "error_26": {
+        "name": "Error 26"
+      },
+      "error_27": {
+        "name": "Error 27"
+      },
+      "error_28": {
+        "name": "Error 28"
+      },
+      "error_29": {
+        "name": "Error 29"
       },
       "error_3": {
         "name": "Error 3"
       },
+      "error_30": {
+        "name": "Error 30"
+      },
+      "error_31": {
+        "name": "Error 31"
+      },
+      "error_32": {
+        "name": "Error 32"
+      },
+      "error_33": {
+        "name": "Error 33"
+      },
+      "error_34": {
+        "name": "Error 34"
+      },
+      "error_35": {
+        "name": "Error 35"
+      },
+      "error_36": {
+        "name": "Error 36"
+      },
+      "error_37": {
+        "name": "Error 37"
+      },
+      "error_38": {
+        "name": "Error 38"
+      },
+      "error_39": {
+        "name": "Error 39"
+      },
       "error_4": {
         "name": "Error 4"
+      },
+      "error_40": {
+        "name": "Error 40"
       },
       "error_5": {
         "name": "Error 5"
@@ -278,14 +830,86 @@
       "error_9": {
         "name": "Error 9"
       },
+      "existing_fuzzy_mode": {
+        "name": "Modo difuso existente"
+      },
+      "existing_holiday_mode": {
+        "name": "Modo vacaciones activo"
+      },
+      "existing_lock_fresh_mode": {
+        "name": "Bloqueo existente del modo frescura"
+      },
+      "existing_save_mode": {
+        "name": "Modo de ahorro disponible"
+      },
+      "existing_sf_mode": {
+        "name": "Modo SF activo"
+      },
+      "existing_sr_mode": {
+        "name": "Modo SR activo"
+      },
       "f-filter": {
         "name": "Filtro"
+      },
+      "f_e_arkgrille": {
+        "name": "Alarma de protecci\u00f3n de la rejilla del mueble"
+      },
+      "f_e_drive": {
+        "name": "Accionamiento"
       },
       "f_e_dwmachine": {
         "name": "Fallo de la unidad inferior"
       },
+      "f_e_eeprom": {
+        "name": "EEPROM"
+      },
       "f_e_filterclean": {
         "name": "Limpiar filtro"
+      },
+      "f_e_incoiltemp": {
+        "name": "Fallo del sensor de temperatura de la bater\u00eda interior"
+      },
+      "f_e_incom": {
+        "name": "Fallo de comunicaci\u00f3n interior/exterior"
+      },
+      "f_e_indisplay": {
+        "name": "Fallo de comunicaci\u00f3n entre el panel de control interior y el panel indicador"
+      },
+      "f_e_ineeprom": {
+        "name": "Error de EEPROM de la placa de control interior"
+      },
+      "f_e_inele": {
+        "name": "Fallo de comunicaci\u00f3n entre el panel de control interior y el panel de alimentaci\u00f3n interior"
+      },
+      "f_e_infanmotor": {
+        "name": "Fallo de funcionamiento an\u00f3malo del motor del ventilador interior"
+      },
+      "f_e_inhumidity": {
+        "name": "Fallo del sensor de humedad interior"
+      },
+      "f_e_inkeys": {
+        "name": "Fallo de comunicaci\u00f3n entre el panel de control interior y el teclado"
+      },
+      "f_e_intemp": {
+        "name": "Fallo del sensor de temperatura interior"
+      },
+      "f_e_invzero": {
+        "name": "Fallo de detecci\u00f3n de cruce por cero de la tensi\u00f3n interior"
+      },
+      "f_e_inwifi": {
+        "name": "Fallo de comunicaci\u00f3n entre el panel de control WiFi y el panel de control interior"
+      },
+      "f_e_outcoiltemp": {
+        "name": "Fallo del sensor de temperatura de la bater\u00eda exterior"
+      },
+      "f_e_outeeprom": {
+        "name": "Error de EEPROM de la unidad exterior"
+      },
+      "f_e_outgastemp": {
+        "name": "Fallo del sensor de temperatura de escape"
+      },
+      "f_e_outtemp": {
+        "name": "Fallo del sensor de temperatura ambiente exterior"
       },
       "f_e_over_cold": {
         "name": "Protecci\u00f3n contra sobreenfriamiento"
@@ -320,6 +944,12 @@
       "float_switch": {
         "name": "Interruptor de flotador"
       },
+      "fota_set": {
+        "name": "FOTA activado"
+      },
+      "fota_status": {
+        "name": "Estado de FOTA"
+      },
       "free_defrosting_failure": {
         "name": "Fallo en descongelaci\u00f3n del congelador"
       },
@@ -329,17 +959,62 @@
       "free_fan_failure": {
         "name": "Fallo del ventilador del congelador"
       },
+      "free_room_open": {
+        "name": "Compartimento libre abierto"
+      },
       "free_room_over_temp_alarm_failure": {
         "name": "Fallo de alarma de exceso de temperatura en la sala del congelador"
       },
       "free_temp_sens_head_failure": {
         "name": "Falla en el cabezal sensor de temperatura del congelador"
       },
+      "freeze_poweroff_ad": {
+        "name": "Anuncio de apagado por congelaci\u00f3n"
+      },
+      "freeze_poweron_ad": {
+        "name": "Anuncio de encendido por congelaci\u00f3n"
+      },
+      "frize_temp_2_degree_above_starting_point": {
+        "name": "Temperatura del congelador 2\u00b0 por encima del inicio"
+      },
       "frost_state": {
         "name": "Estado de escarcha"
       },
+      "fuzzy_mode": {
+        "name": "Modo fuzzy"
+      },
+      "gold_water_supply_mode": {
+        "name": "Modo de suministro de agua Gold"
+      },
+      "gratin_available": {
+        "name": "Gratinado disponible"
+      },
+      "gratin_from_below_function_allowed": {
+        "name": "Funci\u00f3n de gratinado inferior permitida"
+      },
+      "gratin_from_below_function_status": {
+        "name": "Estado de la funci\u00f3n de gratinado desde abajo"
+      },
+      "gratin_status": {
+        "name": "Estado del gratinado"
+      },
+      "grill_plate_status": {
+        "name": "Estado de la placa del grill"
+      },
       "hard_pairing_status": {
         "name": "Estado de emparejamiento dif\u00edcil"
+      },
+      "hardpairingstatus": {
+        "name": "Estado de emparejamiento dif\u00edcil"
+      },
+      "hardpairingunpairall": {
+        "name": "Desemparejar todo en emparejamiento forzado"
+      },
+      "hob_status": {
+        "name": "Estado de la placa"
+      },
+      "hob_warming_zone_status": {
+        "name": "Estado de la zona de mantenimiento de calor"
       },
       "humidity_sensor": {
         "name": "Sensor humedad"
@@ -347,11 +1022,38 @@
       "humidity_sensor_failure": {
         "name": "Fallo en el sensor de humedad"
       },
+      "ice_make_room_alarm": {
+        "name": "Alarma del compartimento del fabricador de hielo"
+      },
       "ice_making_machine_failure": {
         "name": "Fallo en maquina de hielo"
       },
+      "ice_making_normal_status": {
+        "name": "Estado normal de fabricaci\u00f3n de hielo"
+      },
+      "ice_making_state": {
+        "name": "Estado de fabricaci\u00f3n de hielo"
+      },
+      "ice_making_stop_status": {
+        "name": "Estado de parada de fabricaci\u00f3n de hielo"
+      },
+      "ice_sensor_failure_flag": {
+        "name": "Indicador de fallo del sensor de hielo"
+      },
+      "ice_temperature_sensor_header_failure_flag": {
+        "name": "Indicador de fallo del cabezal del sensor de temperatura del hielo"
+      },
+      "inlet_pipe_temp_sens_head_failure": {
+        "name": "Fallo del cabezal del sensor de temperatura del tubo de entrada"
+      },
+      "interior_light_control_available": {
+        "name": "Control de luz interior disponible"
+      },
       "light": {
         "name": "Luz"
+      },
+      "lock_fresh_mode": {
+        "name": "Bloqueo del modo frescor"
       },
       "low_wine_area_c_evaporator_fault": {
         "name": "Fallo del evaporador del \u00e1rea baja c de vino"
@@ -377,6 +1079,54 @@
       "mid_wine_area_b_temp_fault": {
         "name": "Fallo en la temperatura del \u00e1rea media b de vino"
       },
+      "motorspeed1000rpmavailable": {
+        "name": "Velocidad del motor 1000 rpm disponible"
+      },
+      "motorspeed100rpmavailable": {
+        "name": "Velocidad del motor 100 rpm disponible"
+      },
+      "motorspeed1100rpmavailable": {
+        "name": "Velocidad del motor 1100 rpm disponible"
+      },
+      "motorspeed1200rpmavailable": {
+        "name": "Velocidad del motor 1200 rpm disponible"
+      },
+      "motorspeed1300rpmavailable": {
+        "name": "Velocidad del motor 1300 rpm disponible"
+      },
+      "motorspeed1400rpmavailable": {
+        "name": "Velocidad del motor 1400 rpm disponible"
+      },
+      "motorspeed1500rpmavailable": {
+        "name": "Velocidad del motor 1500 rpm disponible"
+      },
+      "motorspeed1600rpmavailable": {
+        "name": "Velocidad del motor 1600 rpm disponible"
+      },
+      "motorspeed400rpmavailable": {
+        "name": "Velocidad del motor 400 rpm disponible"
+      },
+      "motorspeed500rpmavailable": {
+        "name": "Velocidad del motor 500 rpm disponible"
+      },
+      "motorspeed600rpmavailable": {
+        "name": "Velocidad del motor 600 rpm disponible"
+      },
+      "motorspeed800rpmavailable": {
+        "name": "Velocidad del motor 800 rpm disponible"
+      },
+      "motorspeed900rpmavailable": {
+        "name": "Velocidad del motor 900 rpm disponible"
+      },
+      "motorspeednodrainavailable": {
+        "name": "Velocidad del motor sin desag\u00fce disponible"
+      },
+      "motorspeednospinavailable": {
+        "name": "Velocidad del motor sin centrifugado disponible"
+      },
+      "offline_state": {
+        "name": "Conectividad"
+      },
       "open_freeze_door_alarm": {
         "name": "Alarma, puerta abierta del frigor\u00edfico"
       },
@@ -389,14 +1139,23 @@
       "open_variation_door_alarm": {
         "name": "Alarma, puerta abierta"
       },
+      "permanent_pot_detection": {
+        "name": "Detecci\u00f3n permanente de recipiente"
+      },
       "preheat": {
         "name": "Precalentar"
       },
       "quiet_mode_status": {
         "name": "Modo silencioso"
       },
+      "recovery": {
+        "name": "Recuperaci\u00f3n"
+      },
       "reed_switch": {
         "name": "Interruptor ca\u00f1a"
+      },
+      "refi_temp_2_degree_above_starting_point": {
+        "name": "Temperatura del frigor\u00edfico 2\u00b0 por encima del inicio"
       },
       "refr_defrosting_failure": {
         "name": "Fallo en el descongelamiento del refrigerador"
@@ -422,8 +1181,50 @@
       "refr_var_room_sens_failure": {
         "name": "Refrigerator var room sens failure"
       },
+      "refrigerator_defrosting_failure": {
+        "name": "Fallo en el descongelamiento del refrigerador"
+      },
+      "refrigerator_dry_wet_room_sens_failure": {
+        "name": "Fallo en sensor de compartimento seco-h\u00famedo del refrigerador"
+      },
+      "refrigerator_evap_temp_sens_head_failure": {
+        "name": "Fallo en el cabezal del sensor de temperatura"
+      },
+      "refrigerator_fan_failure": {
+        "name": "Fallo en el ventilador del refrigerador"
+      },
+      "refrigerator_room_open": {
+        "name": "Puerta abierta refrigerador"
+      },
+      "refrigerator_room_over_temp_alarm": {
+        "name": "Alarma de temperatura en el refigerador"
+      },
+      "refrigerator_temp_sens_head_failure": {
+        "name": "Fallo en el cabezal del sensor de temperatura"
+      },
+      "refrigerator_var_room_sens_failure": {
+        "name": "Refrigerator var room sens failure"
+      },
       "remote_control_mode_monitoring": {
         "name": "Monitoreo del modo de control remoto"
+      },
+      "remote_control_monitoring": {
+        "name": "Supervisi\u00f3n por control remoto"
+      },
+      "remote_control_monitoring_set_commands": {
+        "name": "Comandos configurados de supervisi\u00f3n del control remoto"
+      },
+      "remote_control_monitoring_set_commands_actions": {
+        "name": "Control remoto"
+      },
+      "remote_controlmode": {
+        "name": "Modo de control remoto"
+      },
+      "right_free_sensor_failure": {
+        "name": "Fallo del sensor libre derecho"
+      },
+      "rinse_aid_refill": {
+        "name": "Recargar abrillantador"
       },
       "rx_failure": {
         "name": "Fallo RX"
@@ -437,6 +1238,12 @@
       "selected_program_anticrease_status": {
         "name": "Antiarrgas "
       },
+      "selected_program_auto_door_open_function": {
+        "name": "Apertura autom\u00e1tica de puerta del programa seleccionado"
+      },
+      "selected_program_disinfection": {
+        "name": "Desinfecci\u00f3n"
+      },
       "selected_program_extradry_status": {
         "name": "Secado extra"
       },
@@ -446,11 +1253,17 @@
       "session_pairing_active": {
         "name": "Emparejamiento de sesiones activo"
       },
+      "session_pairing_setting": {
+        "name": "Ajuste de emparejamiento de sesi\u00f3n"
+      },
       "sl1_alarm_auto_program_notification": {
         "name": "Notificaci\u00f3n de programa autom\u00e1tico de zona 1"
       },
       "sl1_alarm_automatic_switch_off_zone": {
         "name": "La zona 1 se apaga autom\u00e1ticamente"
+      },
+      "sl1_alarm_ntc_coil": {
+        "name": "Alarma NTC de la resistencia de la zona 1"
       },
       "sl1_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 1"
@@ -464,8 +1277,65 @@
       "sl1_bridge_function_active": {
         "name": "Zone 1 puente activo"
       },
+      "sl1_error_1": {
+        "name": "Zona 1 error 1"
+      },
+      "sl1_error_10": {
+        "name": "Zona 1 error 10"
+      },
+      "sl1_error_11": {
+        "name": "Zona 1 error 11"
+      },
+      "sl1_error_12": {
+        "name": "Zona 1 error 12"
+      },
+      "sl1_error_13": {
+        "name": "Zona 1 error 13"
+      },
+      "sl1_error_14": {
+        "name": "Zona 1 error 14"
+      },
+      "sl1_error_15": {
+        "name": "Zona 1 error 15"
+      },
+      "sl1_error_16": {
+        "name": "Zona 1 error 16"
+      },
+      "sl1_error_17": {
+        "name": "Zona 1 error 17"
+      },
+      "sl1_error_2": {
+        "name": "Zona 1 error 2"
+      },
+      "sl1_error_3": {
+        "name": "Zona 1 error 3"
+      },
+      "sl1_error_4": {
+        "name": "Zona 1 error 4"
+      },
+      "sl1_error_5": {
+        "name": "Zona 1 error 5"
+      },
+      "sl1_error_6": {
+        "name": "Zona 1 error 6"
+      },
+      "sl1_error_7": {
+        "name": "Zona 1 error 7"
+      },
+      "sl1_error_8": {
+        "name": "Zona 1 error 8"
+      },
+      "sl1_error_9": {
+        "name": "Zona 1 error 9"
+      },
       "sl1_pot_detected": {
         "name": "Zone 1 olla detectada"
+      },
+      "sl1_present": {
+        "name": "Zona 1 presente"
+      },
+      "sl1_residual_heat_signal": {
+        "name": "Calor residual de zona 1"
       },
       "sl1_status": {
         "name": "Estado Zone 1"
@@ -475,6 +1345,9 @@
       },
       "sl2_alarm_automatic_switch_off_zone": {
         "name": "La zona 2 se apaga autom\u00e1ticamente"
+      },
+      "sl2_alarm_ntc_coil": {
+        "name": "Alarma NTC de la resistencia de la zona 2"
       },
       "sl2_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 2"
@@ -488,8 +1361,65 @@
       "sl2_bridge_function_active": {
         "name": "Zone 2 puente activo"
       },
+      "sl2_error_1": {
+        "name": "Zona 2 error 1"
+      },
+      "sl2_error_10": {
+        "name": "Zona 2 error 10"
+      },
+      "sl2_error_11": {
+        "name": "Zona 2 error 11"
+      },
+      "sl2_error_12": {
+        "name": "Zona 2 error 12"
+      },
+      "sl2_error_13": {
+        "name": "Zona 2 error 13"
+      },
+      "sl2_error_14": {
+        "name": "Zona 2 error 14"
+      },
+      "sl2_error_15": {
+        "name": "Zona 2 error 15"
+      },
+      "sl2_error_16": {
+        "name": "Zona 2 error 16"
+      },
+      "sl2_error_17": {
+        "name": "Zona 2 error 17"
+      },
+      "sl2_error_2": {
+        "name": "Zona 2 error 2"
+      },
+      "sl2_error_3": {
+        "name": "Zona 2 error 3"
+      },
+      "sl2_error_4": {
+        "name": "Zona 2 error 4"
+      },
+      "sl2_error_5": {
+        "name": "Zona 2 error 5"
+      },
+      "sl2_error_6": {
+        "name": "Zona 2 error 6"
+      },
+      "sl2_error_7": {
+        "name": "Zona 2 error 7"
+      },
+      "sl2_error_8": {
+        "name": "Zona 2 error 8"
+      },
+      "sl2_error_9": {
+        "name": "Zona 2 error 9"
+      },
       "sl2_pot_detected": {
         "name": "Zone 2 olla detectada"
+      },
+      "sl2_present": {
+        "name": "Zona 2 presente"
+      },
+      "sl2_residual_heat_signal": {
+        "name": "Calor residual de zona 2"
       },
       "sl2_status": {
         "name": "Estado Zone 2"
@@ -499,6 +1429,9 @@
       },
       "sl3_alarm_automatic_switch_off_zone": {
         "name": "La zona 3 se apaga autom\u00e1ticamente"
+      },
+      "sl3_alarm_ntc_coil": {
+        "name": "Alarma NTC de la resistencia de la zona 3"
       },
       "sl3_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 3"
@@ -512,8 +1445,65 @@
       "sl3_bridge_function_active": {
         "name": "Zone 3 puente activo"
       },
+      "sl3_error_1": {
+        "name": "Zona 3 error 1"
+      },
+      "sl3_error_10": {
+        "name": "Zona 3 error 10"
+      },
+      "sl3_error_11": {
+        "name": "Zona 3 error 11"
+      },
+      "sl3_error_12": {
+        "name": "Zona 3 error 12"
+      },
+      "sl3_error_13": {
+        "name": "Zona 3 error 13"
+      },
+      "sl3_error_14": {
+        "name": "Zona 3 error 14"
+      },
+      "sl3_error_15": {
+        "name": "Zona 3 error 15"
+      },
+      "sl3_error_16": {
+        "name": "Zona 3 error 16"
+      },
+      "sl3_error_17": {
+        "name": "Zona 3 error 17"
+      },
+      "sl3_error_2": {
+        "name": "Zona 3 error 2"
+      },
+      "sl3_error_3": {
+        "name": "Zona 3 error 3"
+      },
+      "sl3_error_4": {
+        "name": "Zona 3 error 4"
+      },
+      "sl3_error_5": {
+        "name": "Zona 3 error 5"
+      },
+      "sl3_error_6": {
+        "name": "Zona 3 error 6"
+      },
+      "sl3_error_7": {
+        "name": "Zona 3 error 7"
+      },
+      "sl3_error_8": {
+        "name": "Zona 3 error 8"
+      },
+      "sl3_error_9": {
+        "name": "Zona 3 error 9"
+      },
       "sl3_pot_detected": {
         "name": "Zone 3 olla detectada"
+      },
+      "sl3_present": {
+        "name": "Zona 3 presente"
+      },
+      "sl3_residual_heat_signal": {
+        "name": "Calor residual de zona 3"
       },
       "sl3_status": {
         "name": "Estado Zone 3"
@@ -524,6 +1514,12 @@
       "sl4_alarm_automatic_switch_off_zone": {
         "name": "La zona 4 se apaga autom\u00e1ticamente"
       },
+      "sl4_alarm_ntc_coil": {
+        "name": "Alarma NTC de la resistencia de la zona 4"
+      },
+      "sl4_alarm_ntc_coil_overheating": {
+        "name": "Sobrecalentamiento de la bobina de la zona 4"
+      },
       "sl4_alarm_timer_ended": {
         "name": "El temporizador de la zona 4 finaliz\u00f3"
       },
@@ -533,8 +1529,65 @@
       "sl4_bridge_function_active": {
         "name": "Zone 4 puente activo"
       },
+      "sl4_error_1": {
+        "name": "Zona 4 error 1"
+      },
+      "sl4_error_10": {
+        "name": "Zona 4 error 10"
+      },
+      "sl4_error_11": {
+        "name": "Zona 4 error 11"
+      },
+      "sl4_error_12": {
+        "name": "Zona 4 error 12"
+      },
+      "sl4_error_13": {
+        "name": "Zona 4 error 13"
+      },
+      "sl4_error_14": {
+        "name": "Zona 4 error 14"
+      },
+      "sl4_error_15": {
+        "name": "Zona 4 error 15"
+      },
+      "sl4_error_16": {
+        "name": "Zona 4 error 16"
+      },
+      "sl4_error_17": {
+        "name": "Zona 4 error 17"
+      },
+      "sl4_error_2": {
+        "name": "Zona 4 error 2"
+      },
+      "sl4_error_3": {
+        "name": "Zona 4 error 3"
+      },
+      "sl4_error_4": {
+        "name": "Zona 4 error 4"
+      },
+      "sl4_error_5": {
+        "name": "Zona 4 error 5"
+      },
+      "sl4_error_6": {
+        "name": "Zona 4 error 6"
+      },
+      "sl4_error_7": {
+        "name": "Zona 4 error 7"
+      },
+      "sl4_error_8": {
+        "name": "Zona 4 error 8"
+      },
+      "sl4_error_9": {
+        "name": "Zona 4 error 9"
+      },
       "sl4_pot_detected": {
         "name": "Zone 4 olla detectada"
+      },
+      "sl4_present": {
+        "name": "Zona 4 presente"
+      },
+      "sl4_residual_heat_signal": {
+        "name": "Calor residual de zona 4"
       },
       "sl4_status": {
         "name": "Estado Zone 4"
@@ -544,6 +1597,9 @@
       },
       "sl5_alarm_automatic_switch_off_zone": {
         "name": "La zona 5 se apaga autom\u00e1ticamente"
+      },
+      "sl5_alarm_ntc_coil": {
+        "name": "Alarma NTC de la resistencia de la zona 5"
       },
       "sl5_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 5"
@@ -557,8 +1613,65 @@
       "sl5_bridge_function_active": {
         "name": "Zone 5 puente activo"
       },
+      "sl5_error_1": {
+        "name": "Zona 5 error 1"
+      },
+      "sl5_error_10": {
+        "name": "Zona 5 error 10"
+      },
+      "sl5_error_11": {
+        "name": "Zona 5 error 11"
+      },
+      "sl5_error_12": {
+        "name": "Zona 5 error 12"
+      },
+      "sl5_error_13": {
+        "name": "Zona 5 error 13"
+      },
+      "sl5_error_14": {
+        "name": "Zona 5 error 14"
+      },
+      "sl5_error_15": {
+        "name": "Zona 5 error 15"
+      },
+      "sl5_error_16": {
+        "name": "Zona 5 error 16"
+      },
+      "sl5_error_17": {
+        "name": "Zona 5 error 17"
+      },
+      "sl5_error_2": {
+        "name": "Zona 5 error 2"
+      },
+      "sl5_error_3": {
+        "name": "Zona 5 error 3"
+      },
+      "sl5_error_4": {
+        "name": "Zona 5 error 4"
+      },
+      "sl5_error_5": {
+        "name": "Zona 5 error 5"
+      },
+      "sl5_error_6": {
+        "name": "Zona 5 error 6"
+      },
+      "sl5_error_7": {
+        "name": "Zona 5 error 7"
+      },
+      "sl5_error_8": {
+        "name": "Zona 5 error 8"
+      },
+      "sl5_error_9": {
+        "name": "Zona 5 error 9"
+      },
       "sl5_pot_detected": {
         "name": "Zone 5 olla detectada"
+      },
+      "sl5_present": {
+        "name": "Zona 5 presente"
+      },
+      "sl5_residual_heat_signal": {
+        "name": "Calor residual de zona 5"
       },
       "sl5_status": {
         "name": "Estado Zone 5"
@@ -568,6 +1681,9 @@
       },
       "sl6_alarm_automatic_switch_off_zone": {
         "name": "La zona 6 se apaga autom\u00e1ticamente"
+      },
+      "sl6_alarm_ntc_coil": {
+        "name": "Alarma NTC de la resistencia de la zona 6"
       },
       "sl6_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 6"
@@ -581,35 +1697,170 @@
       "sl6_bridge_function_active": {
         "name": "Zone 6 puente activo"
       },
+      "sl6_error_1": {
+        "name": "Zona 6 error 1"
+      },
+      "sl6_error_10": {
+        "name": "Zona 6 error 10"
+      },
+      "sl6_error_11": {
+        "name": "Zona 6 error 11"
+      },
+      "sl6_error_12": {
+        "name": "Zona 6 error 12"
+      },
+      "sl6_error_13": {
+        "name": "Zona 6 error 13"
+      },
+      "sl6_error_14": {
+        "name": "Zona 6 error 14"
+      },
+      "sl6_error_15": {
+        "name": "Zona 6 error 15"
+      },
+      "sl6_error_16": {
+        "name": "Zona 6 error 16"
+      },
+      "sl6_error_17": {
+        "name": "Zona 6 error 17"
+      },
+      "sl6_error_2": {
+        "name": "Zona 6 error 2"
+      },
+      "sl6_error_3": {
+        "name": "Zona 6 error 3"
+      },
+      "sl6_error_4": {
+        "name": "Zona 6 error 4"
+      },
+      "sl6_error_5": {
+        "name": "Zona 6 error 5"
+      },
+      "sl6_error_6": {
+        "name": "Zona 6 error 6"
+      },
+      "sl6_error_7": {
+        "name": "Zona 6 error 7"
+      },
+      "sl6_error_8": {
+        "name": "Zona 6 error 8"
+      },
+      "sl6_error_9": {
+        "name": "Zona 6 error 9"
+      },
       "sl6_pot_detected": {
         "name": "Zone 6 olla detectada"
+      },
+      "sl6_present": {
+        "name": "Zona 6 presente"
+      },
+      "sl6_residual_heat_signal": {
+        "name": "Calor residual de zona 6"
       },
       "sl6_status": {
         "name": "Estado Zone 6"
       },
+      "soft_pairing_setting": {
+        "name": "Ajuste de emparejamiento suave"
+      },
+      "softener_state": {
+        "name": "Estado del suavizante"
+      },
       "softer_display": {
         "name": "Display Suavizante"
+      },
+      "steam123_0_available": {
+        "name": "Steam123 0 disponible"
+      },
+      "steam123_1_available": {
+        "name": "Steam123 1 disponible"
+      },
+      "steam123_2_available": {
+        "name": "Steam123 2 disponible"
+      },
+      "steam123_3_available": {
+        "name": "Steam123 3 disponible"
+      },
+      "steam_shot": {
+        "name": "Golpe de vapor"
       },
       "step1_status": {
         "name": "Estado paso 1"
       },
+      "step1_steam_assist": {
+        "name": "Asistencia de vapor paso 1"
+      },
+      "step2_status": {
+        "name": "Estado del paso 2"
+      },
+      "step2_steam_assist": {
+        "name": "Asistencia de vapor paso 2"
+      },
       "step3_status": {
         "name": "Estado paso 3"
+      },
+      "step3_steam_assist": {
+        "name": "Asistencia de vapor paso 3"
+      },
+      "step_1_status": {
+        "name": "Estado paso 1"
+      },
+      "step_2_status": {
+        "name": "Estado del paso 2"
+      },
+      "stopaddgo_status": {
+        "name": "Stop & Go"
+      },
+      "stopaddgoallowed": {
+        "name": "Stop & Go permitido"
       },
       "t_beep": {
         "name": "Beep"
       },
+      "t_pump": {
+        "name": "Bomba"
+      },
+      "test_mode": {
+        "name": "Modo de prueba"
+      },
       "tx_failure": {
         "name": "Fallo TX"
+      },
+      "up_wine_area_a_evaporator_fault": {
+        "name": "Fallo del evaporador de la zona A de vinos superior"
+      },
+      "up_wine_area_a_fan_fault": {
+        "name": "Fallo del ventilador de la zona de vino superior A"
+      },
+      "up_wine_area_a_humdy_fault": {
+        "name": "Fallo de humedad de la zona de vino A superior"
+      },
+      "up_wine_area_a_temp_fault": {
+        "name": "Fallo de temperatura de la zona A de vinos superior"
       },
       "vacuum_on_off_status": {
         "name": "Estado aspiradora"
       },
+      "var_room_over_temp_alarm": {
+        "name": "Alarma de sobretemperatura de la sala variable"
+      },
       "vari_evap_temp_sens_head_failure": {
         "name": "Fallo del cabezal sensor de temperatura de evaporaci\u00f3n variable"
       },
+      "vari_room_open": {
+        "name": "Compartimento variable abierto"
+      },
+      "vari_temp_2_degree_above_starting_point": {
+        "name": "Temperatura variable 2\u00b0 por encima del inicio"
+      },
       "vari_temp_sens_head_failure": {
         "name": "Fallo del cabezal sensor de temperatura variable"
+      },
+      "variable_fan_failure_status": {
+        "name": "Fallo del ventilador de velocidad variable"
+      },
+      "variable_heater_failure_status": {
+        "name": "Fallo del calentador variable"
       },
       "vibration_alarm": {
         "name": "Alarma de vibraci\u00f3n"
@@ -617,11 +1868,17 @@
       "vibration_sensor_fault": {
         "name": "Fallo en sensor de vibraci\u00f3n"
       },
+      "warming_drawer_status": {
+        "name": "Estado del caj\u00f3n calientaplatos"
+      },
       "water_level_switch": {
         "name": "Interruptor nivel de agua"
       },
       "waterbox_full": {
         "name": "Compartimento de agua lleno"
+      },
+      "wine_sensor_failure_flag": {
+        "name": "Fallo del sensor de vino"
       }
     },
     "button": {
@@ -662,6 +1919,7 @@
           "preset_mode": {
             "state": {
               "ai": "AI",
+              "bedtime": "Noche",
               "eco_mute": "Silencioso Eco",
               "eco_sleep_1": "Sue\u00f1o Eco 1",
               "eco_sleep_2": "Sue\u00f1o Eco 2",
@@ -674,6 +1932,15 @@
               "sleep_3": "Sue\u00f1o 3",
               "sleep_4": "Sue\u00f1o 4",
               "super": "Super"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "both_sides": "Ambos lados",
+              "forward": "Adelante",
+              "left": "Izquierda",
+              "right": "Derecha",
+              "swing": "balanceo"
             }
           },
           "swing_mode": {
@@ -706,8 +1973,44 @@
       }
     },
     "number": {
+      "airing_program_set_time": {
+        "name": "Tiempo de ventilaci\u00f3n"
+      },
+      "aus_zone1_opencontrol": {
+        "name": "Apertura de la zona 1"
+      },
+      "aus_zone2_opencontrol": {
+        "name": "Apertura zona 2"
+      },
+      "aus_zone3_opencontrol": {
+        "name": "Apertura zona 3"
+      },
+      "aus_zone4_opencontrol": {
+        "name": "Apertura zona 4"
+      },
+      "aus_zone5_opencontrol": {
+        "name": "Apertura zona 5"
+      },
+      "aus_zone6_opencontrol": {
+        "name": "Apertura zona 6"
+      },
+      "aus_zone7_opencontrol": {
+        "name": "Apertura zona 7"
+      },
+      "aus_zone8_opencontrol": {
+        "name": "Apertura zona 8"
+      },
+      "brightness_setting": {
+        "name": "Brillo"
+      },
       "charcoal_filter_surplus_time": {
         "name": "Tiempo del filtro de carb\u00f3n"
+      },
+      "delayendtime": {
+        "name": "Hora de finalizaci\u00f3n diferida"
+      },
+      "delayendtime_hour": {
+        "name": "Hora de finalizaci\u00f3n diferida"
       },
       "freeze_max_temperature": {
         "name": "Congelador temperatura m\u00e1xima"
@@ -718,8 +2021,29 @@
       "freeze_temperature": {
         "name": "Temperatura Congelador"
       },
+      "gratin_from_below_functionset_time_in_seconds": {
+        "name": "Tiempo ajustado de la funci\u00f3n de gratinado inferior"
+      },
+      "gratin_function_set_time_in_seconds": {
+        "name": "Tiempo ajustado de la funci\u00f3n gratinar"
+      },
+      "greasefiltersetlifetimeinhours": {
+        "name": "Vida \u00fatil del filtro de grasa"
+      },
+      "lightbrightness": {
+        "name": "Brillo de la luz"
+      },
+      "lightcolortemperature": {
+        "name": "Temperatura de color de la luz"
+      },
       "lumin_value_of_interior_light": {
         "name": "Brillo de la luz interior"
+      },
+      "programoptiontimestartdelayhour": {
+        "name": "Horas de inicio diferido"
+      },
+      "programtimesstartdelayhours": {
+        "name": "Horas de inicio diferido"
       },
       "refrigerator_max_temperature": {
         "name": "Frigorifico temperatura m\u00e1xima"
@@ -730,6 +2054,12 @@
       "refrigerator_temperature": {
         "name": "Temperatura frigor\u00edfico"
       },
+      "selected_program_timedry_set_duration": {
+        "name": "Duraci\u00f3n del secado por tiempo"
+      },
+      "t_fanspeedcv": {
+        "name": "Velocidad de ventilador variable"
+      },
       "variation_max_temperature": {
         "name": "Variaci\u00f3n temperatura m\u00e1xima"
       },
@@ -739,6 +2069,9 @@
       "variation_temperature": {
         "name": "Temperatura variaci\u00f3n"
       },
+      "volume_setting": {
+        "name": "Volumen"
+      },
       "wine_zone_lower_temperature": {
         "name": "Zona inferior"
       },
@@ -747,6 +2080,25 @@
       }
     },
     "select": {
+      "actions": {
+        "name": "Acciones",
+        "state": {
+          "add_duration": "A\u00f1adir duraci\u00f3n",
+          "add_gratin": "A\u00f1adir gratinado",
+          "cancel": "Cancelar",
+          "direct_steam": "Vapor directo",
+          "none": "No centrifugar",
+          "pause": "Pausa",
+          "production_test": "Prueba de producci\u00f3n",
+          "program_continue": "Continuar programa",
+          "reset_programs_to_default": "Restablecer programas a los valores predeterminados",
+          "start": "Iniciar",
+          "steam_shot": "Golpe de vapor",
+          "steamer_water_tank_door_open": "Abrir la puerta del dep\u00f3sito de agua del vaporizador",
+          "stop": "Detener",
+          "stop_finish": "Detener y finalizar"
+        }
+      },
       "ads_dirtiness_setting_status": {
         "name": "Suciedad",
         "state": {
@@ -756,44 +2108,278 @@
         }
       },
       "anticrease_setting": {
-        "name": "Duraci\u00f3n anti arrugas"
+        "name": "Duraci\u00f3n anti arrugas",
+        "state": {
+          "1_hour": "1 hora",
+          "2_hours": "2 horas",
+          "3_hours": "3 horas",
+          "4_hours": "4 horas",
+          "off": "Apagado"
+        }
       },
       "auto_dose_quantity_setting_status": {
         "name": "Configuraci\u00f3n autom\u00e1tica de la cantidad de dosificador"
       },
-      "delaystart_delayend_mode_status": {
+      "baking_steps_intensity_levels": {
+        "name": "Niveles de intensidad de los pasos de horneado",
         "state": {
+          "none": "No centrifugar"
+        }
+      },
+      "baking_steps_intensity_levels_type": {
+        "name": "Tipo de niveles de intensidad de los pasos de horneado",
+        "state": {
+          "low_mid_high": "Bajo medio alto",
+          "none": "No centrifugar",
+          "not_used": "No utilizado",
+          "rare_medium_well_done": "Poco hecho, al punto, muy hecho"
+        }
+      },
+      "brightness": {
+        "name": "Brillo",
+        "state": {
+          "level_1": "Nivel 1",
+          "level_2": "Nivel 2",
+          "level_3": "Nivel 3",
+          "level_4": "Nivel 4",
+          "level_5": "Nivel 5"
+        }
+      },
+      "circulationmodestatus": {
+        "name": "Modo de circulaci\u00f3n",
+        "state": {
+          "exhaust": "Extracci\u00f3n",
+          "recirculation": "Recirculaci\u00f3n"
+        }
+      },
+      "compartment1_type_setting_status": {
+        "name": "Tipo de compartimento 1",
+        "state": {
+          "black_detergent": "Detergente para prendas negras",
+          "color_detergent": "Detergente para color",
+          "detergent": "Detergente",
+          "sensitive_detergent": "Detergente para prendas delicadas",
+          "softener": "Suavizante",
+          "white_detergent": "Detergente para blancos"
+        }
+      },
+      "compartment2_type_setting_status": {
+        "name": "Tipo de compartimento 2",
+        "state": {
+          "black_detergent": "Detergente para prendas negras",
+          "color_detergent": "Detergente para color",
+          "detergent": "Detergente",
+          "other_rinse_agent": "Otro agente de aclarado",
+          "sensitive_detergent": "Detergente para prendas delicadas",
+          "softener": "Suavizante",
+          "white_detergent": "Detergente para blancos"
+        }
+      },
+      "condensewatermode": {
+        "name": "Modo de condensaci\u00f3n de agua",
+        "state": {
+          "drain": "Desag\u00fce",
+          "tank": "Dep\u00f3sito"
+        }
+      },
+      "cooking_intensity": {
+        "name": "Intensidad de cocci\u00f3n"
+      },
+      "delayendtime": {
+        "name": "Hora de finalizaci\u00f3n diferida",
+        "state": {
+          "10_hours": "10 horas",
+          "11_hours": "11 horas",
+          "12_hours": "12 horas",
+          "13_hours": "13 horas",
+          "14_hours": "14 horas",
+          "15_hours": "15 horas",
+          "16_hours": "16 horas",
+          "17_hours": "17 horas",
+          "18_hours": "18 horas",
+          "19_hours": "19 horas",
+          "1_hour": "1 hora",
+          "20_hours": "20 horas",
+          "21_hours": "21 horas",
+          "22_hours": "22 horas",
+          "23_hours": "23 horas",
+          "24_hours": "24 horas",
+          "2_hours": "2 horas",
+          "3_hours": "3 horas",
+          "4_hours": "4 horas",
+          "5_hours": "5 horas",
+          "6_hours": "6 horas",
+          "7_hours": "7 horas",
+          "8_hours": "8 horas",
+          "9_hours": "9 horas",
+          "none": "No centrifugar"
+        }
+      },
+      "delaystart_delayend_mode_status": {
+        "name": "Inicio retrasado",
+        "state": {
+          "delay_end": "Fin diferido",
+          "delay_start": "Estado de inicio retrasado",
+          "not_active": "No activo",
           "off": "Apagado",
           "on": "Encendido"
         }
       },
+      "detergent": {
+        "name": "Detergente",
+        "state": {
+          "auto": "Auto",
+          "less": "Menos",
+          "more": "M\u00e1s",
+          "off": "Apagado",
+          "standard": "Est\u00e1ndar"
+        }
+      },
+      "detergent_amount_status": {
+        "name": "Cantidad de detergente",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Apagado"
+        }
+      },
+      "displaybrightness": {
+        "name": "Configuracion brillo display",
+        "state": {
+          "level_1": "Nivel 1",
+          "level_2": "Nivel 2",
+          "level_3": "Nivel 3",
+          "level_4": "Nivel 4",
+          "level_5": "Nivel 5"
+        }
+      },
+      "drain": {
+        "name": "Desag\u00fce",
+        "state": {
+          "pump": "Bomba",
+          "valve": "V\u00e1lvula"
+        }
+      },
       "dry_level": {
         "name": "Nivel Secado",
-        "state": {}
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Media"
+        }
       },
       "dry_time": {
         "name": "Secado",
         "state": {
+          "10_min": "10 min",
+          "120_min": "120 min",
+          "15_min": "15 min",
+          "180_min": "180 min",
+          "240_min": "240 min",
+          "30_min": "30 min",
+          "5_min": "5 min",
+          "60_min": "60 min",
+          "90_min": "90 min",
+          "cupboard": "Armario",
           "extra_dry": "Exstra seco",
+          "iron": "Plancha",
+          "none": "No centrifugar",
+          "off": "Apagado",
           "pre-ironing": "Plancha",
           "wardrobe": "Armario"
         }
       },
       "extradry_setting": {
-        "name": "Configuraci\u00f3n extra-seco"
+        "name": "Configuraci\u00f3n extra-seco",
+        "state": {
+          "10_min": "10 min",
+          "15_min": "15 min",
+          "5_min": "5 min",
+          "off": "Apagado"
+        }
+      },
+      "extrarinsenum": {
+        "name": "Aclarado extra",
+        "state": {
+          "none": "No centrifugar"
+        }
       },
       "feedback_volumen_setting_status": {
+        "name": "Volumen de sonido",
         "state": {
           "high": "Alto",
           "low": "Bajo",
           "mid": "Medio",
           "mute": "Silenciar"
+        }
+      },
+      "greasefilterresetcounter": {
+        "name": "Restablecer contador del filtro de grasa",
+        "state": {
+          "not_active": "No activo",
+          "reset": "Restablecer"
+        }
+      },
+      "language_setting": {
+        "name": "Idioma",
+        "state": {
+          "au_english": "Ingl\u00e9s (AU)",
+          "gb_english": "Ingl\u00e9s (GB)",
+          "norwegian": "Noruego",
+          "swedish_asko": "Sueco (ASKO)",
+          "swedish_cylinda": "Sueco (Cylinda)",
+          "us_english": "Ingl\u00e9s (US)"
+        }
+      },
+      "language_status": {
+        "name": "Idioma",
+        "state": {
+          "english": "Ingl\u00e9s",
+          "simplified_chinese": "Chino simplificado"
+        }
+      },
+      "liquid_unit_setting_status": {
+        "name": "Unidad de l\u00edquido",
+        "state": {
+          "ml": "ml",
+          "tbs": "cda"
+        }
+      },
+      "load": {
+        "name": "Carga",
+        "state": {
+          "100_percent": "100 por ciento",
+          "25_percent": "25 por ciento",
+          "50_percent": "50 por ciento"
         }
       },
       "max_rpm_allowed_stat": {
-        "name": "Velocidad m\u00e1xima de centrifugado"
+        "name": "Velocidad m\u00e1xima de centrifugado",
+        "state": {
+          "0_rpm": "0 rpm",
+          "1000_rpm": "1000 rpm",
+          "1100_rpm": "1100 rpm",
+          "1200_rpm": "1200 rpm",
+          "1300_rpm": "1300 rpm",
+          "1400_rpm": "1400 rpm",
+          "1500_rpm": "1500 rpm",
+          "1600_rpm": "1600 rpm",
+          "1700_rpm": "1700 rpm",
+          "1800_rpm": "1800 rpm",
+          "400_rpm": "400 rpm",
+          "600_rpm": "600 rpm",
+          "700_rpm": "700 rpm",
+          "800_rpm": "800 rpm",
+          "900_rpm": "900 rpm"
+        }
+      },
+      "motorlevel": {
+        "name": "Nivel del motor"
       },
       "notification_volumen_setting_status": {
+        "name": "Volumen de notificaciones",
         "state": {
           "high": "Alto",
           "low": "Bajo",
@@ -801,9 +2387,52 @@
           "mute": "Silenciar"
         }
       },
+      "oven_temperature_unit": {
+        "name": "Unidad de temperatura del horno",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "quickermode": {
+        "name": "Modo m\u00e1s r\u00e1pido",
+        "state": {
+          "level_1": "Nivel 1",
+          "level_2": "Nivel 2",
+          "none": "No centrifugar"
+        }
+      },
       "rinse_aid_setting_status": {
+        "name": "Abrillantador",
         "state": {
           "tab": "TAB"
+        }
+      },
+      "sand_timer_1_status_cmd": {
+        "name": "Control del temporizador de arena 1",
+        "state": {
+          "cancel": "Cancelar",
+          "pause": "Pausa",
+          "start": "Iniciar",
+          "stop": "Detener"
+        }
+      },
+      "sand_timer_2_status_cmd": {
+        "name": "Control del temporizador de arena 2",
+        "state": {
+          "cancel": "Cancelar",
+          "pause": "Pausa",
+          "start": "Iniciar",
+          "stop": "Detener"
+        }
+      },
+      "sand_timer_3_status_cmd": {
+        "name": "Control del temporizador de arena 3",
+        "state": {
+          "cancel": "Cancelar",
+          "pause": "Pausa",
+          "start": "Iniciar",
+          "stop": "Detener"
         }
       },
       "selected_program_id": {
@@ -819,10 +2448,20 @@
           "delicates": "Delicados",
           "down": "Bajar",
           "drum_clean": "Limpieza Tambor",
+          "duvet": "Edred\u00f3n",
+          "eco": "Eco",
           "eco_40_60": "Eco 40-60",
+          "full_load_49": "Carga completa 49",
+          "hand_wash": "Lavado a mano",
+          "ion_refresh": "Refresco por iones",
+          "jeans": "Jeans",
+          "mix": "Mix",
+          "pets": "Mascotas",
+          "power_30": "Potencia 30",
           "power_49": "Power 49",
           "quick_15": "Rapido 15\u00b4",
           "quick_30": "Rapido 30\u00b4",
+          "rack_dry": "Secado en rejilla",
           "refresh": "Refrescar",
           "rinse_spin": "Aclarado y Centrifugado",
           "shirts": "Camisas",
@@ -832,7 +2471,9 @@
           "synthetic": "Sint\u00e9ticos",
           "synthetic_dry": "Secado Sinteticos",
           "time": "Secado por tiempo",
+          "time_dry": "Tiempo de secado",
           "towels": "Toalas",
+          "wash_and_dry_49": "Lavado y secado 49",
           "wool": "Lana"
         }
       },
@@ -840,17 +2481,43 @@
         "name": "Programa seleccionado",
         "state": {
           "auto": "Auto",
+          "baby_care": "Ropa beb\u00e9",
           "clean": "Limpieza",
+          "color": "Color",
+          "down_feathers": "Plum\u00f3n",
+          "draining": "Desag\u00fce",
+          "drum_clean": "Limpieza Tambor",
           "eco": "Eco",
+          "eco_40_60": "Eco 40-60",
+          "extra_hygiene": "Higiene extra",
           "glass": "Cristal",
           "hygiene": "Higiene",
           "intensive": "Intensivo",
+          "intensive_59_32": "Intensivo 59'/32'",
+          "mix_synthetic": "Mixto/Sint\u00e9ticos",
           "night": "Noche",
+          "no_program_selected": "Ning\u00fan programa seleccionado",
           "one_hour": "1 hora",
+          "pet_hair_removal": "Eliminaci\u00f3n de pelo de mascotas",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Aclarar y esperar",
+          "rinsing_softening": "Aclarado y suavizado",
           "self_cleaning": "Autolimpieza",
-          "time_program": "Programa temporizado"
+          "shirts": "Camisas",
+          "speed_20": "Speed 20",
+          "spinning_draining": "Centrifugado y desag\u00fce",
+          "sportswear": "Ropa deporte",
+          "time_program": "Programa temporizado",
+          "white_cotton": "Algod\u00f3n blanco",
+          "wool_manual": "Lana y manual"
+        }
+      },
+      "selected_program_load": {
+        "name": "Carga",
+        "state": {
+          "heavy": "Intensa",
+          "light": "Luz",
+          "medium": "Media"
         }
       },
       "selected_program_mode": {
@@ -859,7 +2526,15 @@
           "fast": "R\u00e1pido",
           "night": "Noche",
           "normal": "Normal",
+          "not_available": "No disponible",
           "speed": "R\u00e1pido"
+        }
+      },
+      "selected_program_mode2": {
+        "name": "Modo especial",
+        "state": {
+          "delicate": "Delicados",
+          "disinfection": "Desinfecci\u00f3n"
         }
       },
       "selected_program_mode2_status": {
@@ -868,6 +2543,86 @@
           "green_mode": "Verde",
           "night_mode": "Noche",
           "speed_mode": "Velocidad"
+        }
+      },
+      "selected_program_mode_status": {
+        "name": "Modo de programa",
+        "state": {
+          "intensive": "Intensivo",
+          "nature_dry": "NatureDry",
+          "normal": "Normal",
+          "steam_tech": "SteamTech",
+          "time_care_1": "Time Care 1",
+          "time_care_2": "Time Care 2"
+        }
+      },
+      "selected_program_set_temperature_status": {
+        "name": "Temperatura",
+        "state": {
+          "20_c": "20 \u00b0C",
+          "30_c": "30 \u00b0C",
+          "40_c": "40 \u00b0C",
+          "60_c": "60 \u00b0C",
+          "90_c": "90 \u00b0C",
+          "95_c": "95 \u00b0C",
+          "cold": "Frio"
+        }
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Centrifugado",
+        "state": {
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "1600_rpm": "1600",
+          "400_rpm": "400",
+          "600_rpm": "600",
+          "700_rpm": "700",
+          "800_rpm": "800"
+        }
+      },
+      "setmaxmotorspeed": {
+        "name": "Velocidad m\u00e1xima de centrifugado",
+        "state": {
+          "1000_rpm": "1000 rpm",
+          "100_rpm": "100 rpm",
+          "1100_rpm": "1100 rpm",
+          "1200_rpm": "1200 rpm",
+          "1300_rpm": "1300 rpm",
+          "1400_rpm": "1400 rpm",
+          "1500_rpm": "1500 rpm",
+          "1600_rpm": "1600 rpm",
+          "400_rpm": "400 rpm",
+          "500_rpm": "500 rpm",
+          "600_rpm": "600 rpm",
+          "800_rpm": "800 rpm",
+          "900_rpm": "900 rpm",
+          "no_drain": "Sin desag\u00fce",
+          "no_spin": "Sin centrifugado",
+          "not_available": "No disponible",
+          "reserved_0": "Reservado 0",
+          "reserved_7": "Reservado 7"
+        }
+      },
+      "softener": {
+        "name": "Suavizante",
+        "state": {
+          "auto": "Auto",
+          "less": "Menos",
+          "more": "M\u00e1s",
+          "off": "Apagado",
+          "standard": "Est\u00e1ndar"
+        }
+      },
+      "softener_amount_status": {
+        "name": "Cantidad de suavizante",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "auto": "Auto",
+          "off": "Apagado"
         }
       },
       "sound_setting_status": {
@@ -879,10 +2634,151 @@
           "3": "3"
         }
       },
+      "sound_settings": {
+        "name": "Nivel de sonido",
+        "state": {
+          "0": "0",
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "4": "4",
+          "5": "5"
+        }
+      },
       "spin_speed_rpm": {
         "name": "Centrifugado",
         "state": {
+          "1000": "1000 rpm",
+          "1200": "1200 rpm",
+          "1400": "1400 rpm",
+          "600": "600 rpm",
+          "800": "800 rpm",
+          "none": "No centrifugar",
+          "off": "Apagado"
+        }
+      },
+      "steam_123": {
+        "name": "Vapor 123",
+        "state": {
+          "steam123_0": "Vapor123 0",
+          "steam123_1": "Vapor123 1",
+          "steam123_2": "Vapor123 2",
+          "steam123_3": "Vapor123 3"
+        }
+      },
+      "step_1_bake_mode": {
+        "name": "Modo de cocci\u00f3n del paso 1",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "extrabake_cleaning": "ExtraBake - Limpieza",
+          "extrabake_fastpreheat": "ExtraBake - Precalentamiento r\u00e1pido",
+          "extrabake_warming": "ExtraBake - Mantenimiento en caliente",
+          "meatprobebake": "Horneado con sonda de carne",
+          "probake": "ProBake",
+          "recipe": "Receta",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Sin definir"
+        }
+      },
+      "step_1_set_microwave_wattage": {
+        "name": "Ajustar potencia del microondas del paso 1",
+        "state": {
           "none": "No centrifugar"
+        }
+      },
+      "step_1_time_unit": {
+        "name": "Unidad de tiempo del paso 1",
+        "state": {
+          "hours": "Horas",
+          "minutes": "Minutos",
+          "seconds": "Segundos"
+        }
+      },
+      "step_2_bake_mode": {
+        "name": "Modo de cocci\u00f3n del paso 2",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Receta",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Sin definir"
+        }
+      },
+      "step_2_set_microwave_wattage": {
+        "name": "Ajustar potencia del microondas del paso 2",
+        "state": {
+          "none": "No centrifugar"
+        }
+      },
+      "step_2_time_unit": {
+        "name": "Unidad de tiempo del paso 2",
+        "state": {
+          "hours": "Horas",
+          "minutes": "Minutos",
+          "seconds": "Segundos"
+        }
+      },
+      "step_3_bake_mode": {
+        "name": "Modo de cocci\u00f3n del paso 3",
+        "state": {
+          "autobake": "AutoBake",
+          "extrabake": "ExtraBake",
+          "probake": "ProBake",
+          "recipe": "Receta",
+          "steambake": "SteamBake",
+          "steamcombibake": "SteamCombiBake",
+          "stepbake": "StepBake",
+          "undefined": "Sin definir"
+        }
+      },
+      "step_3_set_microwave_wattage": {
+        "name": "Ajustar potencia del microondas del paso 3",
+        "state": {
+          "none": "No centrifugar"
+        }
+      },
+      "step_3_time_unit": {
+        "name": "Unidad de tiempo del paso 3",
+        "state": {
+          "hours": "Horas",
+          "minutes": "Minutos",
+          "seconds": "Segundos"
+        }
+      },
+      "step_after_bake_mode": {
+        "name": "Modo posterior al horneado",
+        "state": {
+          "gratine": "Gratinar"
+        }
+      },
+      "step_after_bake_time_unit": {
+        "name": "Unidad de tiempo tras la cocci\u00f3n del paso",
+        "state": {
+          "hours": "Horas",
+          "minutes": "Minutos",
+          "seconds": "Segundos"
+        }
+      },
+      "step_pre_bake_mode": {
+        "name": "Modo de precalentamiento por paso",
+        "state": {
+          "delay_start_waiting": "Esperando inicio pospuesto",
+          "not_active": "No activo",
+          "preheat": "Precalentar"
+        }
+      },
+      "step_pre_bake_time_unit": {
+        "name": "Unidad de tiempo de precocci\u00f3n del paso",
+        "state": {
+          "hours": "Horas",
+          "minutes": "Minutos",
+          "seconds": "Segundos"
         }
       },
       "t_fan_speed": {
@@ -890,7 +2786,8 @@
         "state": {
           "auto": "Auto",
           "high": "Alto",
-          "low": "Bajo"
+          "low": "Bajo",
+          "medium": "Media"
         }
       },
       "t_sleep": {
@@ -911,37 +2808,559 @@
           "off": "Apagado"
         }
       },
+      "t_temp_compensate": {
+        "name": "Compensaci\u00f3n de temperatura",
+        "state": {
+          "offset_0": "0 \u00b0C",
+          "offset_minus_1": "-1 \u00b0C",
+          "offset_minus_2": "-2 \u00b0C",
+          "offset_minus_3": "-3 \u00b0C",
+          "offset_minus_4": "-4 \u00b0C",
+          "offset_minus_5": "-5 \u00b0C",
+          "offset_minus_6": "-6 \u00b0C",
+          "offset_minus_7": "-7 \u00b0C",
+          "offset_plus_1": "+1 \u00b0C",
+          "offset_plus_2": "+2 \u00b0C",
+          "offset_plus_3": "+3 \u00b0C",
+          "offset_plus_4": "+4 \u00b0C",
+          "offset_plus_5": "+5 \u00b0C",
+          "offset_plus_6": "+6 \u00b0C",
+          "offset_plus_7": "+7 \u00b0C"
+        }
+      },
       "temperature": {
         "name": "Temperatura",
         "state": {
           "cold": "Frio"
         }
       },
+      "temperature_unit": {
+        "name": "Unidad de temperatura",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "temperature_unit_setting_status": {
+        "name": "Unidad de temperatura",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "time_format": {
+        "name": "Formato de hora",
+        "state": {
+          "12h": "12h",
+          "24h": "24h"
+        }
+      },
       "time_program_set_duration_status": {
         "name": "Duraci\u00f3n del programa temporizado",
         "state": {
+          "15_min": "00:15",
+          "1_h": "01:00",
+          "1_h_30_min": "01:30",
+          "2_h": "02:00",
+          "2_h_30_min": "02:30",
+          "30_min": "00:30",
+          "45_min": "00:45",
+          "not_available": "No disponible",
           "not_set": "Sin definir"
+        }
+      },
+      "timeiconsetting": {
+        "name": "Ajuste del icono de hora",
+        "state": {
+          "icon": "Icono",
+          "time": "Secado por tiempo"
+        }
+      },
+      "timersetting": {
+        "name": "Acci\u00f3n del temporizador",
+        "state": {
+          "not_active": "No activo",
+          "pause": "Pausa",
+          "start": "Iniciar",
+          "stop": "Detener"
+        }
+      },
+      "units_setting_status": {
+        "name": "Unidades",
+        "state": {
+          "imperial": "Imperial",
+          "metric": "M\u00e9trico"
+        }
+      },
+      "view_size_setting": {
+        "name": "Tama\u00f1o de visualizaci\u00f3n",
+        "state": {
+          "big_text": "Texto grande",
+          "normal_text": "Texto normal"
+        }
+      },
+      "view_size_setting_status": {
+        "name": "Tama\u00f1o de visualizaci\u00f3n",
+        "state": {
+          "big_text": "Texto grande",
+          "normal_text": "Texto normal"
+        }
+      },
+      "volume": {
+        "name": "Volumen",
+        "state": {
+          "level_1": "Nivel 1",
+          "level_2": "Nivel 2",
+          "level_3": "Nivel 3",
+          "level_4": "Nivel 4",
+          "level_5": "Nivel 5"
+        }
+      },
+      "warming_drawer_power_level": {
+        "name": "Nivel de potencia del caj\u00f3n calientaplatos",
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Media"
+        }
+      },
+      "water_hardness": {
+        "name": "Dureza del agua"
+      },
+      "water_hardness_setting_status": {
+        "name": "Dureza del agua",
+        "state": {
+          "1": "1",
+          "2": "2",
+          "3": "3",
+          "not_set": "Sin definir"
+        }
+      },
+      "weight_unit_setting_status": {
+        "name": "Unidad de peso",
+        "state": {
+          "kg": "kg",
+          "lbs": "lbs"
         }
       }
     },
     "sensor": {
+      "actions": {
+        "name": "Acciones"
+      },
+      "activemodelightbrightness": {
+        "name": "Brillo de la luz en modo activo"
+      },
+      "activemodelightcolortemperature": {
+        "name": "Temperatura de color de la luz en modo activo"
+      },
+      "activemodemotorlevel": {
+        "name": "Nivel del motor en modo activo"
+      },
+      "adapttech_setting": {
+        "name": "Ajuste AdaptTech"
+      },
+      "add_clothes_check": {
+        "name": "Comprobaci\u00f3n de a\u00f1adir ropa"
+      },
+      "add_on_program_download_id": {
+        "name": "ID de descarga del programa adicional"
+      },
+      "add_on_program_download_status": {
+        "name": "Estado de descarga del programa adicional"
+      },
+      "add_program_to_device": {
+        "name": "A\u00f1adir programa al dispositivo"
+      },
+      "add_water_flag": {
+        "name": "Indicador de a\u00f1adir agua"
+      },
+      "ads_settings_current_program_detergent_setting_status": {
+        "name": "Ajustes ADS: estado del ajuste de detergente del programa actual"
+      },
+      "ads_settings_current_program_softener_setting_status": {
+        "name": "Ajustes ADS: estado del ajuste de suavizante del programa actual"
+      },
+      "ai_energy_mode_switch": {
+        "name": "Interruptor de modo de energ\u00eda IA"
+      },
+      "air_dry_function": {
+        "name": "Funci\u00f3n de secado al aire"
+      },
+      "air_dry_function_status": {
+        "name": "Estado de la funci\u00f3n de secado al aire"
+      },
+      "air_freshness": {
+        "name": "Frescura del aire"
+      },
+      "airdryflag": {
+        "name": "Indicador de secado al aire"
+      },
+      "airwashtime": {
+        "name": "Tiempo de lavado con aire"
+      },
+      "alarm_1": {
+        "name": "Alarma 1"
+      },
+      "alarm_10": {
+        "name": "Alarma 10"
+      },
+      "alarm_11": {
+        "name": "Alarma 11"
+      },
+      "alarm_12": {
+        "name": "Alarm 12"
+      },
+      "alarm_13": {
+        "name": "Alarma 13"
+      },
+      "alarm_14": {
+        "name": "Alarma 14"
+      },
+      "alarm_15": {
+        "name": "Alarma 15"
+      },
+      "alarm_16": {
+        "name": "Alarma 16"
+      },
+      "alarm_17": {
+        "name": "Alarma 17"
+      },
+      "alarm_18": {
+        "name": "Alarma 18"
+      },
+      "alarm_19": {
+        "name": "Alarma 19"
+      },
+      "alarm_2": {
+        "name": "Alarma 2"
+      },
+      "alarm_20": {
+        "name": "Alarma 20"
+      },
+      "alarm_21": {
+        "name": "Alarma 21"
+      },
+      "alarm_22": {
+        "name": "Alarma 22"
+      },
+      "alarm_3": {
+        "name": "Alarma 3"
+      },
+      "alarm_4": {
+        "name": "Alarma 4"
+      },
+      "alarm_5": {
+        "name": "Alarma 5"
+      },
+      "alarm_6": {
+        "name": "Alarma 6"
+      },
+      "alarm_7": {
+        "name": "Alarma 7"
+      },
+      "alarm_8": {
+        "name": "Alarma 8"
+      },
+      "alarm_9": {
+        "name": "Alarma 9"
+      },
+      "alarm_key": {
+        "name": "Tecla de alarma"
+      },
+      "alarm_sound_volume": {
+        "name": "Volumen del sonido de alarma"
+      },
+      "almost_finished_notification_setting": {
+        "name": "Ajuste de notificaci\u00f3n de casi finalizado"
+      },
+      "almost_finished_notification_settingtimer_in_minutes": {
+        "name": "Ajuste de notificaci\u00f3n de casi finalizado: temporizador en minutos"
+      },
+      "ambient_sound_setting": {
+        "name": "Ajuste de sonido ambiente"
+      },
+      "ambientlightbrightness": {
+        "name": "Brillo de la luz ambiental"
+      },
+      "ambientlightcolortemperature": {
+        "name": "Temperatura de color de la luz ambiental"
+      },
+      "ancreae_mux": {
+        "name": "An creae mux"
+      },
+      "anticrease_flag": {
+        "name": "Indicador antiarrugas"
+      },
+      "appcontrol_flag": {
+        "name": "Indicador de control por app"
+      },
       "appliance_status": {
+        "name": "Estado del electrodom\u00e9stico",
         "state": {
           "idle": "Inactivo",
           "running": "En funcionamiento"
         }
       },
+      "applicationpermissions": {
+        "name": "Permisos de la aplicaci\u00f3n",
+        "state": {
+          "disabled": "Desactivado",
+          "enabled": "Habilitado",
+          "granted": "Concedido",
+          "not_granted": "No concedido"
+        }
+      },
+      "aquapreserve": {
+        "name": "Conservaci\u00f3n de agua"
+      },
+      "aquapreserve_flag": {
+        "name": "Indicador de conservaci\u00f3n de agua"
+      },
+      "aquapreserve_runing_flag": {
+        "name": "Indicador de Aqua Preserve en funcionamiento"
+      },
+      "aromatherapy": {
+        "name": "Aromaterapia"
+      },
+      "auto_dose_compartment1_amount_setting": {
+        "name": "Ajuste de cantidad de dosis autom\u00e1tica compartimento 1"
+      },
+      "auto_dose_compartment1_status_102": {
+        "name": "Estado 102 del compartimento 1 de dosis autom\u00e1tica"
+      },
+      "auto_dose_compartment1_tank_amount": {
+        "name": "Cantidad del dep\u00f3sito del compartimento 1 de dosis autom\u00e1tica"
+      },
+      "auto_dose_compartment2_amount_setting": {
+        "name": "Ajuste de cantidad de dosis autom\u00e1tica compartimento 2"
+      },
+      "auto_dose_compartment2_status_102": {
+        "name": "Estado 102 del compartimento 2 de dosis autom\u00e1tica"
+      },
+      "auto_dose_compartment2_tank_amount": {
+        "name": "Cantidad del dep\u00f3sito del compartimento 2 de dosis autom\u00e1tica"
+      },
+      "auto_dose_drawer_status": {
+        "name": "Estado del caj\u00f3n de dosificaci\u00f3n autom\u00e1tica"
+      },
       "auto_dose_duration": {
         "name": "Duraci\u00f3n de la dosis autom\u00e1tica"
+      },
+      "auto_grease_filter_indication": {
+        "name": "Filtro de grasa autom\u00e1tico"
+      },
+      "auto_tower_up": {
+        "name": "Elevaci\u00f3n autom\u00e1tica de la torre"
+      },
+      "autodose_flag": {
+        "name": "Indicador de dosis autom\u00e1tica",
+        "state": {
+          "available": "Disponible",
+          "unavailable": "No disponible"
+        }
+      },
+      "autodosetype": {
+        "name": "Tipo de dosis autom\u00e1tica"
+      },
+      "automatic_display_brightness_setting": {
+        "name": "Ajuste autom\u00e1tico del brillo de la pantalla"
+      },
+      "automatic_door_closing_at_program_start_setting": {
+        "name": "Ajuste de cierre autom\u00e1tico de la puerta al iniciar el programa"
+      },
+      "automatic_door_open_at_program_end_after_time_setting": {
+        "name": "Ajuste de apertura autom\u00e1tica de la puerta al finalizar el programa tras un tiempo"
+      },
+      "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
+        "name": "Ajuste de apertura autom\u00e1tica de la puerta al finalizar el programa tras un tiempo: temporizador en minutos"
+      },
+      "automatic_door_open_at_program_end_setting": {
+        "name": "Ajuste de apertura autom\u00e1tica de la puerta al final del programa"
+      },
+      "automatic_water_tank_opening_setting": {
+        "name": "Ajuste de apertura autom\u00e1tica del dep\u00f3sito de agua"
+      },
+      "automaticchild_lock_setting": {
+        "name": "Ajuste autom\u00e1tico de bloqueo infantil"
+      },
+      "automaticdoor_lock_setting": {
+        "name": "Ajuste de bloqueo autom\u00e1tico de la puerta"
+      },
+      "automaticdoor_lock_setting_allowed": {
+        "name": "Ajuste de bloqueo autom\u00e1tico de la puerta permitido"
+      },
+      "auxiliary_heat": {
+        "name": "Calor auxiliar"
+      },
+      "bake_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC de fecha/hora UTC de inicio de horneado"
+      },
+      "bathingwaterpump_flag": {
+        "name": "Indicador de la bomba de agua de ba\u00f1o"
+      },
+      "bathingwaterpump_rinse": {
+        "name": "Aclarado de la bomba de agua de ba\u00f1o"
+      },
+      "bathingwaterpump_wash": {
+        "name": "Lavado de la bomba de agua de ba\u00f1o"
+      },
+      "bathingwaterpumpstate": {
+        "name": "Estado de la bomba de agua de ba\u00f1o"
+      },
+      "blockdetailedprogramview": {
+        "name": "Bloquear vista detallada del programa"
+      },
+      "bookavailabletime": {
+        "name": "Tiempo disponible para reserva"
+      },
+      "booking": {
+        "name": "Reserva"
+      },
+      "bookreservedtime": {
+        "name": "Hora reservada"
+      },
+      "booktimetoendreservation": {
+        "name": "Tiempo restante de la reserva"
+      },
+      "brand_splash_setting": {
+        "name": "Ajuste de pantalla de bienvenida"
+      },
+      "brightness_setting": {
+        "name": "Ajuste de brillo"
+      },
+      "builtin_hood_status": {
+        "name": "Estado de la campana integrada"
       },
       "bundling_humidity": {
         "name": "Humedad acumulado"
       },
+      "bundling_sensor_setting_status": {
+        "name": "Estado de configuraci\u00f3n del sensor de agrupaci\u00f3n"
+      },
       "bundling_temperature": {
         "name": "Temperatura acumulado"
       },
+      "camera_enable_setting": {
+        "name": "Ajuste de activaci\u00f3n de c\u00e1mara"
+      },
+      "camera_state": {
+        "name": "Estado de la c\u00e1mara"
+      },
+      "camera_status": {
+        "name": "Estado de la c\u00e1mara"
+      },
+      "cameralive_feed_current_phase": {
+        "name": "Fase actual de la transmisi\u00f3n en directo de la c\u00e1mara"
+      },
+      "cameralive_feed_status": {
+        "name": "Estado de la transmisi\u00f3n en directo de la c\u00e1mara"
+      },
+      "camerapicture_current_phase": {
+        "name": "Fase actual de la imagen de la c\u00e1mara"
+      },
+      "camerapicture_request": {
+        "name": "Solicitud de imagen de la c\u00e1mara"
+      },
+      "cameratime_lapse_current_phase": {
+        "name": "Fase actual del time-lapse de la c\u00e1mara"
+      },
+      "cameratime_lapse_request": {
+        "name": "Solicitud de time-lapse de la c\u00e1mara"
+      },
+      "can_upload_wifi_program": {
+        "name": "Puede cargar programa Wi-Fi"
+      },
+      "cancel_delayend_flag": {
+        "name": "Indicador de cancelaci\u00f3n de fin diferido"
+      },
+      "cancle_delayend": {
+        "name": "Cancelar fin diferido"
+      },
       "child_lock_setting_status": {
         "name": "Configuracion bloqueo ni\u00f1os"
+      },
+      "childlock_flag": {
+        "name": "Indicador de bloqueo infantil"
+      },
+      "childlock_newfuntion": {
+        "name": "Nueva funci\u00f3n de bloqueo infantil"
+      },
+      "childlock_pause": {
+        "name": "Pausa del bloqueo infantil"
+      },
+      "circulation_mode": {
+        "name": "Modo de circulaci\u00f3n"
+      },
+      "clean_mode_switch_status": {
+        "name": "Estado del interruptor de modo de limpieza"
+      },
+      "cleanairactivepassedhours": {
+        "name": "Horas transcurridas de aire limpio activo"
+      },
+      "cleanairactivetotalhours": {
+        "name": "Horas totales de aire limpio activo"
+      },
+      "cleanairdurationofcycleinminutes": {
+        "name": "Duraci\u00f3n del ciclo de aire limpio en minutos"
+      },
+      "cleanairmotorlevel": {
+        "name": "Nivel del motor de aire limpio"
+      },
+      "cleanairruncycleeverynumberofminutes": {
+        "name": "Ejecutar ciclo de aire limpio cada cierto n\u00famero de minutos"
+      },
+      "cleanairstarttime": {
+        "name": "Hora de inicio de aire limpio"
+      },
+      "cleancondensefilter": {
+        "name": "Limpiar el filtro del condensador"
+      },
+      "cleandoorfilter": {
+        "name": "Limpiar filtro de la puerta"
+      },
+      "coldwash": {
+        "name": "Lavado en fr\u00edo"
+      },
+      "commodity_inspection": {
+        "name": "Inspecci\u00f3n del producto"
+      },
+      "compartment_inuse": {
+        "name": "Compartimento en uso"
+      },
+      "compartment_switch": {
+        "name": "Interruptor de compartimento"
+      },
+      "compressor_condition": {
+        "name": "Estado del compresor"
+      },
+      "compressor_frequency": {
+        "name": "Frecuencia del compresor"
+      },
+      "condensed_watermode": {
+        "name": "Modo de agua condensada"
+      },
+      "control_response_level": {
+        "name": "Nivel de respuesta del control"
+      },
+      "cool_c": {
+        "name": "Fr\u00edo C"
+      },
+      "cool_f": {
+        "name": "Fr\u00edo F"
+      },
+      "cool_fan_speed": {
+        "name": "Velocidad del ventilador en fr\u00edo"
+      },
+      "cool_r": {
+        "name": "Fr\u00edo R"
+      },
+      "crisp_function_available": {
+        "name": "Funci\u00f3n de crujiente disponible",
+        "state": {
+          "function_available": "Funci\u00f3n disponible",
+          "function_not_available": "Funci\u00f3n no disponible"
+        }
       },
       "curent_program_duration": {
         "name": "Duracion del programa actual"
@@ -949,17 +3368,36 @@
       "curent_program_remaining_time": {
         "name": "Tiempo restante programa actual"
       },
+      "curprogdetergentdosage": {
+        "name": "Dosis de detergente del programa actual"
+      },
+      "curprogdetergentdosageno_auto": {
+        "name": "Dosis de detergente del programa actual sin autom\u00e1tico"
+      },
+      "curprogsoftnerdosage": {
+        "name": "Dosis de suavizante del programa actual"
+      },
+      "curprogsoftnerdosageno_auto": {
+        "name": "Dosis de suavizante del programa actual sin autom\u00e1tico"
+      },
       "current_baking_step": {
         "name": "Fase de horneado",
         "state": {
+          "after_bake": "Despu\u00e9s del horneado",
           "after_bake_finished": "Horneado terminado",
+          "pre_bake": "Prehorneado",
           "preheat": "Precalentar",
+          "special": "Especial",
           "step_1": "Paso 1",
           "step_2": "Paso 2",
           "step_3": "Paso 3"
         }
       },
+      "current_baking_step2": {
+        "name": "Paso de cocci\u00f3n actual 2"
+      },
       "current_program_phase": {
+        "name": "Fase actual del programa",
         "state": {
           "anti_crease": "Anti arrugas",
           "delay": "Pospuesto",
@@ -982,9 +3420,76 @@
         }
       },
       "current_programphase": {
+        "name": "Fase actual del programa",
         "state": {
           "running": "En marcha"
         }
+      },
+      "current_set_step": {
+        "name": "Paso configurado actual"
+      },
+      "current_temperature": {
+        "name": "Temperatura actual"
+      },
+      "current_washing_program_phase_2": {
+        "name": "Fase 2 del programa de lavado actual"
+      },
+      "current_washing_program_phase_status": {
+        "name": "Estado de la fase actual del programa de lavado"
+      },
+      "current_water_level": {
+        "name": "Nivel de agua actual"
+      },
+      "currentprogram_high_waterlevel_inflowtime": {
+        "name": "Tiempo de entrada de agua a nivel alto del programa actual"
+      },
+      "currentprogram_high_waterlevel_starting_waterlevelvalue": {
+        "name": "Programa actual: valor del nivel de agua inicial para nivel de agua alto"
+      },
+      "currentprogram_low_waterlevel_inflowtime": {
+        "name": "Tiempo de entrada de agua a nivel bajo del programa actual"
+      },
+      "currentprogram_medium_waterlevel_inflowtime": {
+        "name": "Tiempo de entrada de agua a nivel medio del programa actual"
+      },
+      "currentprogram_medium_waterlevel_starting_waterlevelvalue": {
+        "name": "Programa actual: valor del nivel de agua inicial para nivel de agua medio"
+      },
+      "currentprogramphase": {
+        "name": "Fase actual del programa",
+        "state": {
+          "add_cloth_drain": "Desag\u00fce para a\u00f1adir ropa",
+          "add_cloth_drain_finish": "A\u00f1adir ropa: desag\u00fce finalizado",
+          "anti_crease": "Antiarrgas ",
+          "coolend": "Fin del enfriamiento",
+          "cooling": "Enfriando",
+          "delay": "Pospuesto",
+          "drain_water": "Desag\u00fce",
+          "finished": "Terminado",
+          "prewash": "Prelavando",
+          "rinsing": "Aclarando",
+          "spinning": "Centrifugando",
+          "stop_program": "Cancelado",
+          "wash": "Lavando"
+        }
+      },
+      "currentwatertemperature": {
+        "name": "Temperatura actual del agua"
+      },
+      "currrent_dry_level_time": {
+        "name": "Tiempo del nivel de secado actual"
+      },
+      "custard_room": {
+        "name": "Compartimento de natillas"
+      },
+      "d1_program_id": {
+        "name": "ID de programa D 1"
+      },
+      "d2_program_id": {
+        "name": "ID de programa D 2"
+      },
+      "d3_program_id": {
+        "name": "ID de programa D 3"
       },
       "daily_energy_consumption": {
         "name": "Consumo energia diario"
@@ -992,16 +3497,146 @@
       "daily_energy_kwh": {
         "name": "Consumo energia diario"
       },
+      "daily_water_consumption": {
+        "name": "Consumo diario de agua"
+      },
+      "darhcdq": {
+        "name": "Darhcdq"
+      },
+      "dat3": {
+        "name": "Dat 3"
+      },
+      "data1": {
+        "name": "Dato 1"
+      },
+      "data2": {
+        "name": "Dato 2"
+      },
+      "data4": {
+        "name": "Dato 4"
+      },
+      "data5": {
+        "name": "Dato 5"
+      },
+      "date_display_format_status": {
+        "name": "Estado del formato de fecha"
+      },
+      "date_format_setting": {
+        "name": "Ajuste de formato de fecha"
+      },
+      "date_format_status": {
+        "name": "Estado del formato de fecha"
+      },
+      "date_time_format_day_state": {
+        "name": "Estado del d\u00eda del formato de fecha y hora"
+      },
+      "date_time_format_month_state": {
+        "name": "Estado del mes en formato de fecha y hora"
+      },
+      "date_time_format_year_state": {
+        "name": "Estado del formato de a\u00f1o de fecha y hora"
+      },
+      "dbd_clean_mode": {
+        "name": "Modo de limpieza DBD"
+      },
+      "debacilli_mode": {
+        "name": "Modo antibacterias"
+      },
+      "default_dry_level": {
+        "name": "Nivel de secado predeterminado"
+      },
+      "defaultspinspeed": {
+        "name": "Velocidad de centrifugado predeterminada"
+      },
+      "delay_actions_flag": {
+        "name": "Indicador de acciones diferidas"
+      },
+      "delay_close_dryer_time": {
+        "name": "Tiempo de retardo de apagado de la secadora"
+      },
       "delay_duration_inminutes": {
         "name": "Duraci\u00f3n retraso"
+      },
+      "delay_start_remaining_time": {
+        "name": "Tiempo restrante inicio retrasado"
+      },
+      "delay_start_remaining_time_in_minutes": {
+        "name": "Tiempo restante de inicio diferido en minutos"
+      },
+      "delay_start_set_time": {
+        "name": "Hora ajustada de inicio diferido"
+      },
+      "delay_time_hour_min": {
+        "name": "Tiempo de retardo (h:min)"
+      },
+      "delayclose_flag": {
+        "name": "Indicador de cierre diferido"
+      },
+      "delayendtime": {
+        "name": "Hora de finalizaci\u00f3n diferida"
+      },
+      "delayendtime_minute": {
+        "name": "Minuto de hora de fin diferido"
       },
       "delaystart_delayend_duration_inminutes": {
         "name": "Duracci\u00f3n inicio retrasado"
       },
+      "delaystart_delayend_remaining_time_in_minutes": {
+        "name": "Tiempo restante de inicio/fin diferido"
+      },
       "delaystart_delayend_remaining_timein_minutes": {
         "name": "Tiempo restrante inicio retrasado"
       },
+      "delaystart_delayend_timestamp_status": {
+        "name": "Estado de la marca de tiempo de inicio/fin diferido"
+      },
+      "delaystartcountdowntimer": {
+        "name": "Temporizador de cuenta atr\u00e1s del inicio diferido"
+      },
+      "demo_mode_status": {
+        "name": "Estado del modo demo"
+      },
+      "demomode": {
+        "name": "Modo demostraci\u00f3n"
+      },
+      "descale_status": {
+        "name": "Estado de descalcificaci\u00f3n"
+      },
+      "detergent_buynotifyswitch": {
+        "name": "Interruptor de aviso de compra de detergente"
+      },
+      "detergent_flag": {
+        "name": "Indicador de detergente"
+      },
+      "detergent_indicator": {
+        "name": "Indicador de detergente"
+      },
+      "detergent_leftml": {
+        "name": "Detergente restante"
+      },
+      "detergent_leftnum": {
+        "name": "Dosis de detergente restantes"
+      },
+      "detergent_soften_settingflag": {
+        "name": "Indicador de ajustes de suavizante y detergente"
+      },
+      "detergent_totalml": {
+        "name": "Total de detergente usado"
+      },
+      "detergent_totalnum": {
+        "name": "Total de dosis de detergente usadas"
+      },
+      "detergent_useindex": {
+        "name": "\u00cdndice de uso de detergente"
+      },
+      "detergentstandarddosage": {
+        "name": "Dosis est\u00e1ndar de detergente"
+      },
+      "detergentstandarddosage_flag": {
+        "name": "Indicador de dosificaci\u00f3n est\u00e1ndar de detergente"
+      },
       "device_status": {
+        "name": "Estado del dispositivo",
         "state": {
           "after_bake_finished": "Horneado terminado",
           "delay_time_waiting": "Esperando tiempo de retraso",
@@ -1021,22 +3656,278 @@
           "stand_by": "Suspendido"
         }
       },
+      "devicestatus": {
+        "name": "Estado del dispositivo",
+        "state": {
+          "error": "Error",
+          "idle": "Inactivo",
+          "not_available": "No disponible",
+          "pause": "Pausa",
+          "permanent_error": "Error permanente",
+          "production": "Producci\u00f3n",
+          "program_finished": "Programa finalizado",
+          "program_select": "Selecci\u00f3n de programa",
+          "reserved": "Reservado",
+          "running": "En funcionamiento",
+          "service": "Servicio",
+          "standby": "Suspendida",
+          "temporary_error": "Error temporal"
+        }
+      },
       "display_brightness_setting_status": {
         "name": "Configuracion brillo display"
+      },
+      "display_contrast_setting_status": {
+        "name": "Contraste de la pantalla"
+      },
+      "display_logotype_setting_status": {
+        "name": "Logotipo de la pantalla"
+      },
+      "display_panel_ronshen": {
+        "name": "Panel de la pantalla Ronshen"
+      },
+      "display_switch_to_standby_after_minutes": {
+        "name": "Minutos tras los que la pantalla pasa a espera",
+        "state": {
+          "15_min": "15 min",
+          "30_min": "30 min",
+          "5_min": "5 min"
+        }
+      },
+      "displayboard_brand": {
+        "name": "Marca del panel de display"
+      },
+      "displayboard_key_setting": {
+        "name": "Ajuste de teclas del panel de visualizaci\u00f3n"
+      },
+      "displayboard_type": {
+        "name": "Tipo de placa de pantalla"
+      },
+      "displayboard_version": {
+        "name": "Versi\u00f3n de la placa de la pantalla"
+      },
+      "displaybrightness_setting": {
+        "name": "Ajuste de brillo de la pantalla"
+      },
+      "displaycontrast_setting": {
+        "name": "Ajuste de contraste de la pantalla"
+      },
+      "displaylogo": {
+        "name": "Logotipo en pantalla"
+      },
+      "door_close_light_status": {
+        "name": "Estado de la luz de cierre de puerta"
+      },
+      "door_close_ui_display_status": {
+        "name": "Estado en pantalla de puerta cerrada"
+      },
+      "door_lock_status": {
+        "name": "Estado del bloqueo de la puerta"
+      },
+      "door_num_four_color": {
+        "name": "Puerta 4 - color"
+      },
+      "door_num_one_color": {
+        "name": "Puerta 1 - color"
+      },
+      "door_num_three_color": {
+        "name": "Puerta 3 - color"
+      },
+      "door_num_two_color": {
+        "name": "Puerta 2 - color"
+      },
+      "door_open_light_status": {
+        "name": "Estado de la luz de puerta abierta"
+      },
+      "door_open_notification_setting": {
+        "name": "Ajuste de notificaci\u00f3n de puerta abierta"
+      },
+      "door_open_ui_display_status": {
+        "name": "Estado de visualizaci\u00f3n de puerta abierta"
+      },
+      "door_sensor_setting": {
+        "name": "Ajuste del sensor de puerta"
       },
       "door_status": {
         "name": "Puerta",
         "state": {
           "closed": "Cerrada",
+          "locked": "Cerrado",
           "not_available": "No disponible",
-          "open": "Abierta"
+          "open": "Abierta",
+          "other": "Otro"
         }
+      },
+      "dose_assist_recommended_detergent_quantity_unit_status": {
+        "name": "Asistente de dosificaci\u00f3n: estado de la unidad de cantidad de detergente recomendada"
+      },
+      "dose_assist_recommended_low_concenatration_detergent_quantity": {
+        "name": "Asistente de dosificaci\u00f3n: cantidad de detergente de baja concentraci\u00f3n recomendada"
+      },
+      "dose_detergent_amount": {
+        "name": "Cantidad de dosis de detergente"
+      },
+      "dose_softener_amount": {
+        "name": "Cantidad de dosis de suavizante"
+      },
+      "doseaid": {
+        "name": "Ayuda de dosificaci\u00f3n"
+      },
+      "downlight": {
+        "name": "Luz inferior"
+      },
+      "downlight_lighttime": {
+        "name": "Tiempo de luz inferior"
+      },
+      "downloadprogram": {
+        "name": "Descargar programa"
+      },
+      "drumcleancycle_runsnumber": {
+        "name": "N\u00famero de ciclos de limpieza del tambor realizados"
+      },
+      "drumcleanflag": {
+        "name": "Indicador de limpieza del tambor"
+      },
+      "drumcleanswitch": {
+        "name": "Interruptor de limpieza del tambor"
+      },
+      "drumcleanwashcount": {
+        "name": "Recuento de lavados de limpieza del tambor"
+      },
+      "dry_level_show": {
+        "name": "Visualizaci\u00f3n del nivel de secado"
+      },
+      "dry_lever": {
+        "name": "Palanca de secado"
       },
       "dry_time": {
         "name": "Tipo Secado"
       },
+      "dryfilterremindflag": {
+        "name": "Indicador de recordatorio de secado del filtro"
+      },
+      "drying_linkage_order": {
+        "name": "Orden de vinculaci\u00f3n de secado"
+      },
+      "drying_linkage_preheat_time": {
+        "name": "Tiempo de precalentamiento del enlace de secado"
+      },
+      "drying_linkage_programid": {
+        "name": "ID del programa vinculado de secado"
+      },
+      "drying_washing_linkage_state": {
+        "name": "Estado de vinculaci\u00f3n secado-lavado"
+      },
+      "dryingswitch": {
+        "name": "Interruptor de secado"
+      },
+      "dryingwizzard_clothesdrylevel": {
+        "name": "Asistente de secado nivel de secado de la ropa"
+      },
+      "dryingwizzard_clothesdrylevel1": {
+        "name": "Nivel de secado 1 de la ropa del asistente de secado"
+      },
+      "dryingwizzard_clothesdrytarget": {
+        "name": "Objetivo de secado de ropa del asistente de secado"
+      },
+      "dryingwizzard_clothesdrytarget1": {
+        "name": "Objetivo de secado de ropa 1 del asistente de secado"
+      },
+      "dryingwizzard_clothesmaterialcharacteristics": {
+        "name": "Caracter\u00edsticas del material de la ropa del asistente de secado"
+      },
+      "dryingwizzard_clothesmaterialcharacteristics_first": {
+        "name": "Asistente de secado: caracter\u00edsticas del material de la ropa (primero)"
+      },
+      "dryingwizzard_clothesmaterialcharacteristics_second": {
+        "name": "Asistente de secado: caracter\u00edsticas del material de la ropa (segundo)"
+      },
+      "dryingwizzard_clothesmaterialcharacteristics_third": {
+        "name": "Asistente de secado: caracter\u00edsticas del material de la ropa (tercero)"
+      },
+      "dryingwizzard_clothingtype": {
+        "name": "Tipo de ropa del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_eighth": {
+        "name": "Tipo de prenda (octava) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_eleventh": {
+        "name": "Asistente de secado: tipo de prenda 11"
+      },
+      "dryingwizzard_clothingtype_fifth": {
+        "name": "Tipo de prenda (quinta) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_first": {
+        "name": "Tipo de prenda (primera) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_fourth": {
+        "name": "Tipo de prenda (cuarta) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_ninth": {
+        "name": "Tipo de prenda (novena) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_second": {
+        "name": "Tipo de prenda (segunda) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_seventh": {
+        "name": "Asistente de secado: tipo de prenda 7"
+      },
+      "dryingwizzard_clothingtype_sixth": {
+        "name": "Tipo de prenda (sexta) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_tenth": {
+        "name": "Tipo de prenda (d\u00e9cima) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_third": {
+        "name": "Tipo de prenda (tercera) del asistente de secado"
+      },
+      "dryingwizzard_clothingtype_thirteenth": {
+        "name": "Tipo de ropa del asistente de secado, decimotercero"
+      },
+      "dryingwizzard_clothingtype_twelfth": {
+        "name": "Asistente de secado: tipo de prenda 12"
+      },
+      "dryleve_flag": {
+        "name": "Indicador de nivel de secado"
+      },
+      "drymode_flag": {
+        "name": "Indicador de modo secado"
+      },
+      "drymodel": {
+        "name": "Modelo de secado"
+      },
+      "dryopen_defaultspinspeed": {
+        "name": "Velocidad de centrifugado predeterminada de secado abierto"
+      },
+      "duration_of_clock": {
+        "name": "Duraci\u00f3n del reloj"
+      },
+      "eco_mode_setting": {
+        "name": "Ajuste del modo Eco"
+      },
+      "eco_score_type": {
+        "name": "Tipo de puntuaci\u00f3n ecol\u00f3gica"
+      },
+      "ecomode": {
+        "name": "Modo eco"
+      },
+      "electric_current": {
+        "name": "Corriente el\u00e9ctrica"
+      },
+      "electric_energy_one_tenths_value": {
+        "name": "Valor de energ\u00eda el\u00e9ctrica en d\u00e9cimas"
+      },
+      "electric_energy_percentile_thousands_value": {
+        "name": "Valor de los millares del percentil de energ\u00eda el\u00e9ctrica"
+      },
       "electricit_consumption": {
         "name": "Consumo de electricidad"
+      },
+      "emptywatertank": {
+        "name": "Vaciar el dep\u00f3sito de agua"
+      },
+      "energy": {
+        "name": "Energ\u00eda"
       },
       "energy_consumption_in_running_program": {
         "name": "Energia consumida programa en curso"
@@ -1044,24 +3935,636 @@
       "energy_estimate": {
         "name": "Energia estimada"
       },
+      "energy_save_setting_status": {
+        "name": "Estado del ajuste de ahorro de energ\u00eda"
+      },
+      "enterperformancemode_dry1_conditiontype": {
+        "name": "Tipo de condici\u00f3n del secado 1 del modo de rendimiento"
+      },
+      "enterperformancemode_dry1_mainwashtime": {
+        "name": "Tiempo de lavado principal del secado 1 del modo de rendimiento"
+      },
+      "enterperformancemode_wash1_conditiontype": {
+        "name": "Tipo de condici\u00f3n del lavado 1 del modo de rendimiento"
+      },
+      "enterperformancemode_wash1_mainwashtime": {
+        "name": "Tiempo de lavado principal del lavado 1 del modo de rendimiento"
+      },
+      "enterperformancemode_wash2_conditiontype": {
+        "name": "Tipo de condici\u00f3n del lavado 2 del modo de rendimiento"
+      },
+      "enterperformancemode_wash2_mainwashtime": {
+        "name": "Tiempo de lavado principal del lavado 2 del modo de rendimiento"
+      },
       "environment_humidity": {
         "name": "Humedad ambiental"
+      },
+      "environment_real_temperature": {
+        "name": "Temperatura ambiente real"
+      },
+      "error_0": {
+        "name": "Error 0"
+      },
+      "error_1": {
+        "name": "Error 1"
+      },
+      "error_10": {
+        "name": "Error 10"
+      },
+      "error_11": {
+        "name": "Error 11"
+      },
+      "error_12": {
+        "name": "Error 12"
+      },
+      "error_12_1": {
+        "name": "Error 12_1"
+      },
+      "error_12_10": {
+        "name": "Error 12_10"
+      },
+      "error_12_11": {
+        "name": "Error 12_11"
+      },
+      "error_12_12": {
+        "name": "Error 12_12"
+      },
+      "error_12_13": {
+        "name": "Error 12_13"
+      },
+      "error_12_14": {
+        "name": "Error 12_14"
+      },
+      "error_12_15": {
+        "name": "Error 12_15"
+      },
+      "error_12_16": {
+        "name": "Error 12_16"
+      },
+      "error_12_17": {
+        "name": "Error 12_17"
+      },
+      "error_12_18": {
+        "name": "Error 12_18"
+      },
+      "error_12_2": {
+        "name": "Error 12_2"
+      },
+      "error_12_3": {
+        "name": "Error 12_3"
+      },
+      "error_12_4": {
+        "name": "Error 12_4"
+      },
+      "error_12_5": {
+        "name": "Error 12_5"
+      },
+      "error_12_6": {
+        "name": "Error 12_6"
+      },
+      "error_12_7": {
+        "name": "Error 12_7"
+      },
+      "error_12_8": {
+        "name": "Error 12_8"
+      },
+      "error_12_9": {
+        "name": "Error 12_9"
+      },
+      "error_13": {
+        "name": "Error 13"
+      },
+      "error_13_1": {
+        "name": "Error 13_1"
+      },
+      "error_13_2": {
+        "name": "Error 13_2"
+      },
+      "error_13_3": {
+        "name": "Error 13_3"
+      },
+      "error_14": {
+        "name": "Error 14"
+      },
+      "error_15": {
+        "name": "Error 15"
+      },
+      "error_16": {
+        "name": "Error 16"
+      },
+      "error_17": {
+        "name": "Error 17"
+      },
+      "error_18": {
+        "name": "Error 18"
+      },
+      "error_19": {
+        "name": "Error 19"
+      },
+      "error_2": {
+        "name": "Error 2"
+      },
+      "error_20": {
+        "name": "Error 20"
+      },
+      "error_21": {
+        "name": "Error 21"
+      },
+      "error_22": {
+        "name": "Error 22"
+      },
+      "error_23": {
+        "name": "Error 23"
+      },
+      "error_24": {
+        "name": "Error 24"
+      },
+      "error_25": {
+        "name": "Error 25"
+      },
+      "error_26": {
+        "name": "Error 26"
+      },
+      "error_27": {
+        "name": "Error 27"
+      },
+      "error_28": {
+        "name": "Error 28"
+      },
+      "error_29": {
+        "name": "Error 29"
+      },
+      "error_3": {
+        "name": "Error 3"
+      },
+      "error_30": {
+        "name": "Error 30"
+      },
+      "error_31": {
+        "name": "Error 31"
+      },
+      "error_32": {
+        "name": "Error 32"
+      },
+      "error_33": {
+        "name": "Error 33"
+      },
+      "error_34": {
+        "name": "Error 34"
+      },
+      "error_35": {
+        "name": "Error 35"
+      },
+      "error_36": {
+        "name": "Error 36"
+      },
+      "error_37": {
+        "name": "Error 37"
+      },
+      "error_38": {
+        "name": "Error 38"
+      },
+      "error_38_1": {
+        "name": "Error 38_1"
+      },
+      "error_39": {
+        "name": "Error 39"
+      },
+      "error_4": {
+        "name": "Error 4"
+      },
+      "error_40": {
+        "name": "Error 40"
+      },
+      "error_41": {
+        "name": "Error 41"
+      },
+      "error_42": {
+        "name": "Error 42"
+      },
+      "error_43": {
+        "name": "Error 43"
+      },
+      "error_44": {
+        "name": "Error 44"
+      },
+      "error_45": {
+        "name": "Error 45"
+      },
+      "error_46": {
+        "name": "Error 46"
+      },
+      "error_47": {
+        "name": "Error 47"
+      },
+      "error_48": {
+        "name": "Error 48"
+      },
+      "error_49": {
+        "name": "Error 49"
+      },
+      "error_5": {
+        "name": "Error 5"
+      },
+      "error_50": {
+        "name": "Error 50"
+      },
+      "error_51": {
+        "name": "Error 51"
+      },
+      "error_52": {
+        "name": "Error 52"
+      },
+      "error_6": {
+        "name": "Error 6"
+      },
+      "error_7": {
+        "name": "Error 7"
+      },
+      "error_7_1": {
+        "name": "Error 7_1"
+      },
+      "error_7_2": {
+        "name": "Error 7_2"
+      },
+      "error_8": {
+        "name": "Error 8"
+      },
+      "error_89": {
+        "name": "Error 89"
+      },
+      "error_9": {
+        "name": "Error 9"
+      },
+      "error_90": {
+        "name": "Error 90"
+      },
+      "error_9_1": {
+        "name": "Error 9_1"
       },
       "error_code": {
         "name": "C\u00f3digo error",
         "state": {
+          "error_f01": "F01 - Fallo de entrada de agua",
+          "error_f03": "F03 - Fallo de desag\u00fce de agua",
+          "error_f04": "F04 - Fallo del m\u00f3dulo electr\u00f3nico",
+          "error_f05": "F05 - Fallo del m\u00f3dulo electr\u00f3nico",
+          "error_f06": "F06 - Fallo del m\u00f3dulo electr\u00f3nico",
+          "error_f07": "F07 - Fallo del m\u00f3dulo electr\u00f3nico",
+          "error_f13": "F13 - Fallo de bloqueo de la puerta",
+          "error_f14": "F14 - Fallo de desbloqueo de la puerta",
+          "error_f15": "F15 - Secado anormal",
+          "error_f16": "F16 - Secado anormal",
+          "error_f17": "F17 - Secado anormal",
+          "error_f18": "F18 - Secado anormal",
+          "error_f23": "F23 - Fallo del m\u00f3dulo electr\u00f3nico",
+          "error_f24": "F24 - Desbordamiento del nivel de agua",
           "none": "Ninguno",
           "unbalance_alarm": "Alarma de desequilibrio"
         }
       },
+      "error_f10": {
+        "name": "Error f10"
+      },
+      "error_f11": {
+        "name": "Error f11"
+      },
+      "error_f12": {
+        "name": "Error f12"
+      },
+      "error_f40": {
+        "name": "Error f40"
+      },
+      "error_f41": {
+        "name": "Error f41"
+      },
+      "error_f42": {
+        "name": "Error f42"
+      },
+      "error_f43": {
+        "name": "Error f43"
+      },
+      "error_f44": {
+        "name": "Error f44"
+      },
+      "error_f45": {
+        "name": "Error f45"
+      },
+      "error_f46": {
+        "name": "Error f46"
+      },
+      "error_f52": {
+        "name": "Error f52"
+      },
+      "error_f54": {
+        "name": "Error f54"
+      },
+      "error_f56": {
+        "name": "Error f56"
+      },
+      "error_f61": {
+        "name": "Error f61"
+      },
+      "error_f62": {
+        "name": "Error f62"
+      },
+      "error_f65": {
+        "name": "Error f65"
+      },
+      "error_f67": {
+        "name": "Error f67"
+      },
+      "error_f68": {
+        "name": "Error f68"
+      },
+      "error_f69": {
+        "name": "Error f69"
+      },
+      "error_f70": {
+        "name": "Error f70"
+      },
+      "error_f72": {
+        "name": "Error f72"
+      },
+      "error_f74": {
+        "name": "Error f74"
+      },
+      "error_f75": {
+        "name": "Error f75"
+      },
+      "error_f76": {
+        "name": "Error f76"
+      },
+      "error_read_out_1_code": {
+        "name": "C\u00f3digo de lectura de error 1"
+      },
+      "error_read_out_1_cycle": {
+        "name": "Lectura de error del ciclo 1"
+      },
+      "error_read_out_1_status": {
+        "name": "Estado de lectura de error 1"
+      },
+      "error_read_out_2_code": {
+        "name": "C\u00f3digo de lectura de error 2"
+      },
+      "error_read_out_2_cycle": {
+        "name": "Lectura de error del ciclo 2"
+      },
+      "error_read_out_2_status": {
+        "name": "Estado de lectura de error 2"
+      },
+      "error_read_out_3_code": {
+        "name": "C\u00f3digo de lectura de error 3"
+      },
+      "error_read_out_3_cycle": {
+        "name": "Lectura de error del ciclo 3"
+      },
+      "error_read_out_3_status": {
+        "name": "Estado de lectura de error 3"
+      },
+      "extra_soft": {
+        "name": "Extra suave"
+      },
+      "extra_soft_hideflag": {
+        "name": "Indicador de ocultaci\u00f3n de extra suave"
+      },
+      "extrarinsenum": {
+        "name": "N\u00famero de aclarados extra"
+      },
+      "extrarinsenum_flag": {
+        "name": "Indicador del n\u00famero de aclarados extra"
+      },
+      "extrasoft_runing_flag": {
+        "name": "Indicador de funcionamiento extra suave"
+      },
       "f_cool_qvalue": {
         "name": "Enfriando"
+      },
+      "f_ecm": {
+        "name": "Modo de informe de electricidad"
+      },
+      "f_electricity": {
+        "name": "Electricidad"
       },
       "f_heat_qvalue": {
         "name": "Calentando"
       },
+      "f_matteroriginalproductid": {
+        "name": "ID de producto Matter"
+      },
+      "f_matteroriginalvendorid": {
+        "name": "ID de fabricante de Matter"
+      },
+      "f_matteruniqueid": {
+        "name": "ID \u00fanico de Matter"
+      },
+      "f_power_consumption": {
+        "name": "Consumo de energ\u00eda"
+      },
+      "f_power_display": {
+        "name": "Encendido"
+      },
       "f_votage": {
         "name": "Voltaje"
+      },
+      "factory_reset": {
+        "name": "Restablecer valores de f\u00e1brica"
+      },
+      "failurereadout1": {
+        "name": "Fallo 1"
+      },
+      "failurereadout10": {
+        "name": "Fallo 10"
+      },
+      "failurereadout10lastcycle": {
+        "name": "Fallo 10 en el \u00faltimo ciclo"
+      },
+      "failurereadout10numberofrepetiotion": {
+        "name": "Repeticiones del fallo 10"
+      },
+      "failurereadout11": {
+        "name": "Fallo 11"
+      },
+      "failurereadout11numberofrepetiotion": {
+        "name": "Repeticiones del fallo 11"
+      },
+      "failurereadout12": {
+        "name": "Fallo 12"
+      },
+      "failurereadout12numberofrepetiotion": {
+        "name": "Repeticiones del fallo 12"
+      },
+      "failurereadout1lastcycle": {
+        "name": "Fallo 1 \u00faltimo ciclo"
+      },
+      "failurereadout1numberofrepetiotion": {
+        "name": "Repeticiones del fallo 1"
+      },
+      "failurereadout2": {
+        "name": "Fallo 2"
+      },
+      "failurereadout2lastcycle": {
+        "name": "Fallo 2 \u00faltimo ciclo"
+      },
+      "failurereadout2numberofrepetiotion": {
+        "name": "Repeticiones del fallo 2"
+      },
+      "failurereadout3": {
+        "name": "Fallo 3"
+      },
+      "failurereadout3lastcycle": {
+        "name": "Fallo 3 \u00faltimo ciclo"
+      },
+      "failurereadout3numberofrepetiotion": {
+        "name": "Repeticiones del fallo 3"
+      },
+      "failurereadout4": {
+        "name": "Fallo 4"
+      },
+      "failurereadout4lastcycle": {
+        "name": "Fallo 4 \u00faltimo ciclo"
+      },
+      "failurereadout4numberofrepetiotion": {
+        "name": "Repeticiones del fallo 4"
+      },
+      "failurereadout5": {
+        "name": "Fallo 5"
+      },
+      "failurereadout5lastcycle": {
+        "name": "Fallo 5 \u00faltimo ciclo"
+      },
+      "failurereadout5numberofrepetiotion": {
+        "name": "Repeticiones del fallo 5"
+      },
+      "failurereadout6": {
+        "name": "Fallo 6"
+      },
+      "failurereadout6lastcycle": {
+        "name": "Fallo 6 \u00faltimo ciclo"
+      },
+      "failurereadout6numberofrepetiotion": {
+        "name": "Repeticiones del fallo 6"
+      },
+      "failurereadout7": {
+        "name": "Fallo 7"
+      },
+      "failurereadout7lastcycle": {
+        "name": "Fallo 7 \u00faltimo ciclo"
+      },
+      "failurereadout7numberofrepetiotion": {
+        "name": "Repeticiones del fallo 7"
+      },
+      "failurereadout8": {
+        "name": "Fallo 8"
+      },
+      "failurereadout8lastcycle": {
+        "name": "Fallo 8 \u00faltimo ciclo"
+      },
+      "failurereadout8numberofrepetiotion": {
+        "name": "Repeticiones del fallo 8"
+      },
+      "failurereadout9": {
+        "name": "Fallo 9"
+      },
+      "failurereadout9lastcycle": {
+        "name": "Fallo 9 \u00faltimo ciclo"
+      },
+      "failurereadout9numberofrepetiotion": {
+        "name": "Repeticiones del fallo 9"
+      },
+      "fan_sequence_setting_status": {
+        "name": "Secuencia del ventilador"
+      },
+      "fast_store_mode_exist": {
+        "name": "Modo de almacenamiento r\u00e1pido activo"
+      },
+      "fast_store_mode_status": {
+        "name": "Estado del modo de enfriamiento r\u00e1pido"
+      },
+      "favour_program_id": {
+        "name": "ID de programa favorito"
+      },
+      "filter_alarm_time": {
+        "name": "Tiempo de alarma del filtro"
+      },
+      "filter_state": {
+        "name": "Estado del filtro"
+      },
+      "filterclean_dry": {
+        "name": "Limpieza de filtro seco"
+      },
+      "filterclean_drycount": {
+        "name": "Recuento de secados para limpieza del filtro"
+      },
+      "filterclean_dryflag": {
+        "name": "Indicador de limpieza y secado del filtro"
+      },
+      "filterclean_wash": {
+        "name": "Lavado de limpieza del filtro"
+      },
+      "filterclean_washcound": {
+        "name": "Recuento de lavados para limpieza de filtro"
+      },
+      "filterclean_washcount": {
+        "name": "Recuento de lavados para limpieza de filtro"
+      },
+      "filterclean_washflag": {
+        "name": "Indicador de lavado para limpieza del filtro"
+      },
+      "flexiblespintime_flag": {
+        "name": "Indicador de tiempo de centrifugado flexible"
+      },
+      "fluffysoft": {
+        "name": "Suavidad esponjosa"
+      },
+      "fluffysoft_flag": {
+        "name": "Indicador de suavidad"
+      },
+      "fluffysoft_flag1": {
+        "name": "Indicador de suavidad esponjosa 1"
+      },
+      "fota": {
+        "name": "FOTA",
+        "state": {
+          "confirm_fota": "Confirmar FOTA",
+          "finished": "Terminado",
+          "in_progress": "En curso",
+          "not_available": "No disponible",
+          "waiting_for_confirmation": "Esperando confirmaci\u00f3n"
+        }
+      },
+      "fota_status": {
+        "name": "Estado de FOTA"
+      },
+      "fotastatus": {
+        "name": "Estado de FOTA"
+      },
+      "free_key": {
+        "name": "Tecla libre"
+      },
+      "free_room": {
+        "name": "Compartimento libre"
+      },
+      "free_room_open_2": {
+        "name": "Compartimento libre abierto 2"
+      },
+      "freeri_fan_speed": {
+        "name": "Velocidad del ventilador Freeri"
+      },
+      "freeze_door_open_time": {
+        "name": "Tiempo de puerta del congelador abierta"
+      },
+      "freeze_drawer_room_temp": {
+        "name": "Temperatura del caj\u00f3n congelador"
+      },
+      "freeze_fan_speed": {
+        "name": "Velocidad del ventilador de congelaci\u00f3n"
+      },
+      "freeze_max_temperature": {
+        "name": "Temperatura m\u00e1xima de congelaci\u00f3n"
+      },
+      "freeze_min_temperature": {
+        "name": "Temperatura m\u00ednima de congelaci\u00f3n"
       },
       "freeze_real_temperature": {
         "name": "Temperatura real congelador"
@@ -1069,8 +4572,84 @@
       "freeze_sensor_real_temperature": {
         "name": "Temperatura real sensor congelador"
       },
+      "freezing_powerdown_temp_alarm": {
+        "name": "Alarma de temperatura por apagado de congelaci\u00f3n"
+      },
+      "froze_convert_to_refri_switch_status": {
+        "name": "Estado del interruptor de conversi\u00f3n de congelador a frigor\u00edfico"
+      },
       "fruit_vegetables_temperature": {
         "name": "Temperatura compartimento frutas y vegetales"
+      },
+      "function1_useindex": {
+        "name": "\u00cdndice de uso de funci\u00f3n 1"
+      },
+      "gentle_dry": {
+        "name": "Secado delicado"
+      },
+      "gentledry_flag": {
+        "name": "Indicador de secado delicado"
+      },
+      "getcurrentcityinfoflag": {
+        "name": "Indicador de obtenci\u00f3n de informaci\u00f3n de la ciudad actual"
+      },
+      "gratin_total_allowed_time_in_minutes": {
+        "name": "Tiempo total permitido de gratinado en minutos"
+      },
+      "gratin_total_passed_time_in_minutes": {
+        "name": "Tiempo total transcurrido de gratinado en minutos"
+      },
+      "grease_filter_cleaning_interval_in_hours": {
+        "name": "Intervalo de limpieza del filtro de grasa"
+      },
+      "grease_filter_reset_counter": {
+        "name": "Contador de reinicio del filtro de grasa"
+      },
+      "grease_filter_saturation": {
+        "name": "Saturaci\u00f3n del filtro de grasa"
+      },
+      "grease_filter_set_lifetime_in_hours": {
+        "name": "Vida \u00fatil del filtro de grasa"
+      },
+      "grease_filter_status": {
+        "name": "Estado del filtro de grasa"
+      },
+      "grease_filter_timer_active": {
+        "name": "Temporizador del filtro de grasa activo"
+      },
+      "grease_filter_used_hours": {
+        "name": "Horas de uso del filtro de grasa"
+      },
+      "greasefiltercleaningintervalinhours": {
+        "name": "Intervalo de limpieza del filtro de grasa en horas"
+      },
+      "greasefilterusedhours": {
+        "name": "Horas de uso del filtro de grasa"
+      },
+      "grill_plate_measured_temperature": {
+        "name": "Temperatura medida de la placa de grill"
+      },
+      "half_load": {
+        "name": "Media carga"
+      },
+      "hard_pairing_commond": {
+        "name": "Comando de emparejamiento forzado"
+      },
+      "hard_pairing_status": {
+        "name": "Estado de emparejamiento dif\u00edcil"
+      },
+      "hardpairingstatus": {
+        "name": "Estado de emparejamiento dif\u00edcil",
+        "state": {
+          "active": "Activo",
+          "not_active": "No activo",
+          "pairing_active": "Emparejamiento activo",
+          "reserved": "Reservado",
+          "unpair_all_users": "Desvincular todos los usuarios"
+        }
+      },
+      "heat_pump_setting_status": {
+        "name": "Bomba de calor"
       },
       "high_humidity": {
         "name": "Humedad alta"
@@ -1078,8 +4657,217 @@
       "high_temperature": {
         "name": "Temperatura alta"
       },
+      "high_temperature_status": {
+        "name": "Estado de temperatura alta"
+      },
+      "hob_warming_zone_power_level": {
+        "name": "Nivel de potencia de la zona de mantenimiento de calor",
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Media"
+        }
+      },
+      "hob_zone_1_status": {
+        "name": "Estado de la zona 1 de la placa",
+        "state": {
+          "off_hot": "Apagado, a\u00fan caliente"
+        }
+      },
+      "hob_zone_2_status": {
+        "name": "Estado de la zona 2 de la placa",
+        "state": {
+          "off_hot": "Apagado, a\u00fan caliente"
+        }
+      },
+      "hob_zone_3_status": {
+        "name": "Estado de la zona 3 de la placa",
+        "state": {
+          "off_hot": "Apagado, a\u00fan caliente"
+        }
+      },
+      "hob_zone_4_status": {
+        "name": "Estado de la zona 4 de la placa",
+        "state": {
+          "off_hot": "Apagado, a\u00fan caliente"
+        }
+      },
+      "hob_zone_5_status": {
+        "name": "Estado de la zona 5 de la placa",
+        "state": {
+          "off_hot": "Apagado, a\u00fan caliente"
+        }
+      },
+      "hood_connected_via_rf": {
+        "name": "Campana conectada por RF"
+      },
+      "hood_fan_speed": {
+        "name": "Velocidad del ventilador de la campana"
+      },
+      "hood_light": {
+        "name": "Luz de la campana"
+      },
+      "hood_status": {
+        "name": "Estado de la campana"
+      },
+      "hood_total_used_hours": {
+        "name": "Horas de funcionamiento de la campana"
+      },
+      "hottime": {
+        "name": "Tiempo en caliente"
+      },
+      "human_on_off_status": {
+        "name": "Estado de detecci\u00f3n de presencia"
+      },
+      "human_sense_light_status": {
+        "name": "Estado de la luz de detecci\u00f3n de presencia"
+      },
+      "human_sense_ui_display_state": {
+        "name": "Estado en pantalla de detecci\u00f3n de presencia"
+      },
+      "human_sensor_switch_exist": {
+        "name": "Interruptor del sensor de presencia disponible"
+      },
+      "humanbody_sensor_switch_status": {
+        "name": "Estado del interruptor del sensor de presencia"
+      },
+      "humdy_test_switch_state": {
+        "name": "Estado del interruptor de prueba de humedad"
+      },
+      "humiditysensor": {
+        "name": "Sensor humedad"
+      },
+      "ice_machine_actual_temp": {
+        "name": "Temperatura real de la m\u00e1quina de hielo"
+      },
+      "ice_make_room_switch": {
+        "name": "Interruptor del compartimento de hielo"
+      },
+      "ice_making_fast_status": {
+        "name": "Estado de fabricaci\u00f3n r\u00e1pida de hielo"
+      },
+      "ice_making_full_status": {
+        "name": "Estado de dep\u00f3sito de hielo lleno"
+      },
+      "ice_room_actual_temp": {
+        "name": "Temperatura real del compartimento de hielo"
+      },
+      "id1": {
+        "name": "ID 1"
+      },
+      "id2": {
+        "name": "ID 2"
+      },
+      "id3": {
+        "name": "ID 3"
+      },
+      "id4": {
+        "name": "ID 4"
+      },
+      "id5": {
+        "name": "ID 5"
+      },
+      "idcode": {
+        "name": "C\u00f3digo ID"
+      },
+      "identified": {
+        "name": "Identificado"
+      },
+      "idmachine": {
+        "name": "ID de la m\u00e1quina"
+      },
+      "inactivity_timeout": {
+        "name": "Tiempo de espera por inactividad"
+      },
+      "initializationprogramid": {
+        "name": "ID del programa de inicializaci\u00f3n"
+      },
+      "intensive_flag": {
+        "name": "Indicador de lavado intensivo"
+      },
+      "intensivewash": {
+        "name": "Lavado intensivo"
+      },
+      "interior_light_status": {
+        "name": "Luz interior"
+      },
+      "ion_preservation_switch": {
+        "name": "Interruptor de conservaci\u00f3n por iones"
+      },
+      "ion_refresh": {
+        "name": "Refresco por iones"
+      },
+      "iron_dry_time": {
+        "name": "Tiempo de secado plancha"
+      },
+      "iscloudprogramflag": {
+        "name": "Indicador de programa en la nube"
+      },
+      "ispower_flag": {
+        "name": "Indicador de encendido"
+      },
+      "kettle_install_status": {
+        "name": "Estado de instalaci\u00f3n del hervidor"
+      },
+      "kettle_overflow_alarm": {
+        "name": "Alarma de desbordamiento del hervidor"
+      },
+      "key_press_sound_volume": {
+        "name": "Volumen del sonido de las teclas"
+      },
+      "key_sensitivity_level": {
+        "name": "Nivel de sensibilidad de las teclas"
+      },
+      "key_sound_level": {
+        "name": "Volumen del sonido de teclas"
+      },
+      "language": {
+        "name": "Idioma"
+      },
+      "language_select": {
+        "name": "Selecci\u00f3n de idioma"
+      },
+      "language_setting": {
+        "name": "Ajuste de idioma"
+      },
+      "language_status": {
+        "name": "Idioma"
+      },
+      "last_completed_running_process": {
+        "name": "\u00daltimo proceso completado"
+      },
       "last_run_program_id": {
         "name": "\u00daltimo programa"
+      },
+      "lidopenflag": {
+        "name": "Indicador de tapa abierta"
+      },
+      "lights_duration_setting": {
+        "name": "Ajuste de duraci\u00f3n de las luces"
+      },
+      "lightsbrightness_setting": {
+        "name": "Ajuste de brillo de las luces"
+      },
+      "lightscolor_temperature_setting": {
+        "name": "Ajuste de temperatura de color de las luces"
+      },
+      "load_operation_status2": {
+        "name": "Estado de funcionamiento de carga 2"
+      },
+      "loadlevel": {
+        "name": "Nivel de carga"
+      },
+      "lock_key": {
+        "name": "Tecla de bloqueo"
+      },
+      "lockpin_code": {
+        "name": "C\u00f3digo PIN de bloqueo"
+      },
+      "logo": {
+        "name": "Logo"
+      },
+      "logo_setting_status": {
+        "name": "Estado de ajuste del logotipo"
       },
       "low_humidity": {
         "name": "Humedad baja"
@@ -1087,14 +4875,51 @@
       "low_temperature": {
         "name": "Temperatura baja"
       },
+      "lumin_value_of_interior_light": {
+        "name": "Valor de luminosidad de la luz interior"
+      },
       "machine_status": {
         "name": "Estado Maquina",
         "state": {
           "alarm": "Alarma",
           "off": "Apagada",
+          "paused": "Pausado",
           "running": "En Marcha",
           "standby": "Suspendida"
         }
+      },
+      "mainboard_type": {
+        "name": "Tipo de placa base"
+      },
+      "mainboard_version": {
+        "name": "Versi\u00f3n de la placa base"
+      },
+      "mainwashtime": {
+        "name": "Tiempo de lavado principal"
+      },
+      "mainwashtime_flag": {
+        "name": "Indicador de tiempo de lavado principal"
+      },
+      "mainwashtimelist": {
+        "name": "Lista de tiempos de lavado principal"
+      },
+      "mainwashtimeuseindex": {
+        "name": "\u00cdndice de tiempo de lavado principal"
+      },
+      "market_mode_exist": {
+        "name": "Modo tienda disponible"
+      },
+      "maxtimeevent": {
+        "name": "Evento de tiempo m\u00e1ximo"
+      },
+      "mdo_on_demand": {
+        "name": "MDO bajo demanda"
+      },
+      "mdo_on_demand_allowed": {
+        "name": "MDO bajo demanda permitido"
+      },
+      "measured_grid_voltage": {
+        "name": "Tensi\u00f3n de red medida"
       },
       "measured_vibrations": {
         "name": "Vivbraciones"
@@ -1105,14 +4930,307 @@
       "meat_probe_set_temperature": {
         "name": "Temperatura sonda de carne"
       },
+      "meat_probe_status": {
+        "name": "Estado de la sonda de carne",
+        "state": {
+          "active_hob": "Placa activa",
+          "active_oven": "Horno activo",
+          "not_active": "No activo"
+        }
+      },
       "medium_humidity": {
         "name": "Humedad media"
       },
       "medium_temperature": {
         "name": "Temperatura media"
       },
+      "mian_wash_time": {
+        "name": "Tiempo de lavado principal"
+      },
+      "micro_water_supply_mode": {
+        "name": "Modo de microsuministro de agua"
+      },
+      "mode_key": {
+        "name": "Tecla de modo"
+      },
+      "model_type": {
+        "name": "Tipo de modelo"
+      },
+      "monitor": {
+        "name": "Monitor"
+      },
+      "monitor_set": {
+        "name": "Configuraci\u00f3n del monitor"
+      },
+      "monitor_set_act": {
+        "name": "Ajuste de monitorizaci\u00f3n activo"
+      },
+      "motor": {
+        "name": "Motor"
+      },
+      "motor_level": {
+        "name": "Nivel del motor"
+      },
+      "navigation_sound_setting": {
+        "name": "Ajuste de sonido de navegaci\u00f3n"
+      },
+      "night_dry": {
+        "name": "Secado nocturno"
+      },
+      "night_mode_end_hour": {
+        "name": "Hora de fin del modo nocturno"
+      },
+      "night_mode_light_dark_level": {
+        "name": "Nivel de oscuridad de la luz en modo nocturno"
+      },
+      "night_mode_off_hour": {
+        "name": "Hora de desactivaci\u00f3n del modo nocturno"
+      },
+      "night_mode_off_minute": {
+        "name": "Minuto de apagado del modo nocturno"
+      },
+      "night_mode_on_hour": {
+        "name": "Hora de activaci\u00f3n del modo nocturno"
+      },
+      "night_mode_on_minute": {
+        "name": "Minuto de activaci\u00f3n del modo noche"
+      },
+      "night_mode_screen_dark_level": {
+        "name": "Nivel de oscuridad de pantalla en modo nocturno"
+      },
+      "night_mode_start_hour": {
+        "name": "Hora de inicio del modo nocturno"
+      },
+      "night_mode_start_min": {
+        "name": "Minuto de inicio del modo noche"
+      },
+      "night_modedisplay_brightness_setting": {
+        "name": "Ajuste de brillo de la pantalla en modo nocturno"
+      },
+      "night_modelight_brightness_setting": {
+        "name": "Ajuste de brillo de la luz en modo nocturno"
+      },
+      "night_modevolume_setting": {
+        "name": "Ajuste de volumen del modo nocturno"
+      },
+      "night_start_setting_status_102": {
+        "name": "Estado de configuraci\u00f3n de inicio nocturno 102"
+      },
+      "nightmode_flag": {
+        "name": "Indicador de modo nocturno"
+      },
+      "no_autodoseswitch": {
+        "name": "Sin interruptor de dosis autom\u00e1tica"
+      },
+      "normal_sound_size": {
+        "name": "Volumen de sonido normal"
+      },
+      "not_active": {
+        "name": "No activo"
+      },
+      "notification_pitch_sound_setting": {
+        "name": "Ajuste de tono del sonido de notificaci\u00f3n"
+      },
+      "notification_sounds_volume_setting": {
+        "name": "Ajuste de volumen de sonidos de notificaci\u00f3n"
+      },
+      "ntc_sensor_1": {
+        "name": "Sensor NTC 1"
+      },
+      "ntc_sensor_2": {
+        "name": "Sensor NTC 2"
+      },
+      "number_of_rinses": {
+        "name": "N\u00famero de aclarados"
+      },
+      "odor_sensor_fault_flag": {
+        "name": "Indicador de fallo del sensor de olores"
+      },
+      "odor_sensor_no_disturb_mode_status": {
+        "name": "Estado del modo no molestar del sensor de olores"
+      },
+      "odor_sensor_sensitivity": {
+        "name": "Sensibilidad del sensor de olores"
+      },
+      "odor_sensor_swithc_status": {
+        "name": "Estado del sensor de olores"
+      },
+      "once_rinse_step_time": {
+        "name": "Tiempo de la fase de un aclarado"
+      },
+      "once_strong_step_time": {
+        "name": "Tiempo del paso potente \u00fanico"
+      },
+      "oncewaterinrinse_time": {
+        "name": "Tiempo de entrada de agua en aclarado"
+      },
+      "onlyrinse_model": {
+        "name": "Modelo solo aclarado"
+      },
+      "onlyspin_model": {
+        "name": "Modelo solo centrifugado"
+      },
+      "onlywash_model": {
+        "name": "Modelo solo lavado"
+      },
+      "order_time_minimum_hour": {
+        "name": "Hora m\u00ednima del tiempo de orden"
+      },
+      "ota_num1": {
+        "name": "N\u00famero OTA 1"
+      },
+      "ota_sucess": {
+        "name": "OTA correcta"
+      },
+      "oven_measured_temperature": {
+        "name": "Temperatura medida del horno"
+      },
       "oven_temperature": {
         "name": "Temperatura horno"
+      },
+      "oven_usage_value_alarm_limit": {
+        "name": "L\u00edmite de alarma del valor de uso del horno"
+      },
+      "oven_usage_value_time_since_last_cleaning": {
+        "name": "Valor de uso del horno: tiempo desde la \u00faltima limpieza"
+      },
+      "paidbycoinbox": {
+        "name": "Pagado con monedero"
+      },
+      "paidbycoinboxoreadbs": {
+        "name": "Pagado por monedero / EADBS"
+      },
+      "pairing": {
+        "name": "Emparejamiento"
+      },
+      "pairing_active": {
+        "name": "Emparejamiento activo"
+      },
+      "parse_lib_ota": {
+        "name": "An\u00e1lisis de biblioteca OTA"
+      },
+      "parse_lib_ver": {
+        "name": "Versi\u00f3n de la librer\u00eda de an\u00e1lisis"
+      },
+      "party_mode_switch_status": {
+        "name": "Estado del interruptor de modo fiesta"
+      },
+      "pause_anticrease_flag": {
+        "name": "Indicador de pausa anti-arrugas"
+      },
+      "paymentenabledtimer": {
+        "name": "Temporizador de pago activado"
+      },
+      "paymentsystem": {
+        "name": "Sistema de pago"
+      },
+      "performancemode_flag": {
+        "name": "Indicador de modo de rendimiento"
+      },
+      "performancemode_mainwashtime": {
+        "name": "Tiempo de lavado principal en modo rendimiento"
+      },
+      "permanent_remote_start": {
+        "name": "Inicio remoto permanente"
+      },
+      "position_of_tower": {
+        "name": "Posici\u00f3n de la torre"
+      },
+      "power_one_tenths_value": {
+        "name": "Valor de potencia en d\u00e9cimas"
+      },
+      "power_save": {
+        "name": "Ahorro de energ\u00eda"
+      },
+      "power_value": {
+        "name": "Valor de potencia"
+      },
+      "power_voltage": {
+        "name": "Tensi\u00f3n de alimentaci\u00f3n"
+      },
+      "powersavedeletetime": {
+        "name": "Tiempo de borrado del ahorro de energ\u00eda"
+      },
+      "ppuonlinecoinsystem": {
+        "name": "Sistema de monedas en l\u00ednea PPU"
+      },
+      "ppurecipss": {
+        "name": "PPU RECIPSS"
+      },
+      "ppuwashenabled": {
+        "name": "Lavado PPU activado"
+      },
+      "presoak": {
+        "name": "Remojo previo"
+      },
+      "presoak_index": {
+        "name": "\u00cdndice de prerremojo"
+      },
+      "presoak_runing_flag": {
+        "name": "Indicador de prerremojo en curso"
+      },
+      "presoakflag": {
+        "name": "Indicador de prerremojo"
+      },
+      "pressure_calibration_setting_status": {
+        "name": "Calibraci\u00f3n de presi\u00f3n"
+      },
+      "prewashstepfinishnotifyswitch": {
+        "name": "Interruptor de aviso de fin del paso de prelavado"
+      },
+      "program_end_to_shutdown_time_in_minutes": {
+        "name": "Tiempo del fin del programa al apagado en minutos"
+      },
+      "program_settingsdefault": {
+        "name": "Ajustes del programa por defecto"
+      },
+      "program_settingsstart_key_duation_formw": {
+        "name": "Duraci\u00f3n de la tecla de inicio en los ajustes del programa para microondas"
+      },
+      "programfunctionvalueid": {
+        "name": "ID de valor de funci\u00f3n del programa"
+      },
+      "programremainingtime": {
+        "name": "Tiempo restante del programa"
+      },
+      "proximity_sensor_setting": {
+        "name": "Ajuste del sensor de proximidad"
+      },
+      "proximity_sensor_settingclose_user_detecteddisplay_change_to": {
+        "name": "Ajuste del sensor de proximidad: cambio de pantalla al detectar un usuario cercano"
+      },
+      "proximity_sensor_settingclose_user_detectedlight_change_to": {
+        "name": "Ajuste del sensor de proximidad: cambio de luz al detectar un usuario cercano"
+      },
+      "proximity_sensor_settingdistant_user_detecteddisplay_change_to": {
+        "name": "Ajuste del sensor de proximidad: cambio de pantalla al detectar un usuario lejano"
+      },
+      "proximity_sensor_settingdistant_user_detectedlight_change_to": {
+        "name": "Ajuste del sensor de proximidad: cambio de luz al detectar un usuario lejano"
+      },
+      "proximitysensor": {
+        "name": "Sensor de proximidad"
+      },
+      "proximitysensorreactiontime": {
+        "name": "Tiempo de reacci\u00f3n del sensor de proximidad"
+      },
+      "proximitysensorsensitivity": {
+        "name": "Sensibilidad del sensor de proximidad"
+      },
+      "pumcleanflag": {
+        "name": "Indicador de limpieza de la bomba"
+      },
+      "pumcleanremaintime": {
+        "name": "Tiempo restante de limpieza de la bomba"
+      },
+      "pumcleantotaltime": {
+        "name": "Tiempo total de limpieza de la bomba"
+      },
+      "quickermode": {
+        "name": "Modo m\u00e1s r\u00e1pido"
+      },
+      "quiet_model": {
+        "name": "Modo silencioso"
       },
       "real_humidity": {
         "name": "Humedad real"
@@ -1123,20 +5241,251 @@
       "real_humidity_c": {
         "name": "Humedad real c"
       },
+      "recirculation_filter_1_lifetime_in_hours": {
+        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculation_filter_1_reset_counter": {
+        "name": "Contador de reinicios del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculation_filter_1_set_lifetime_in_hours": {
+        "name": "Vida \u00fatil ajustada del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculation_filter_1_set_type": {
+        "name": "Tipo configurado del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculation_filter_1_status": {
+        "name": "Estado del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculation_filter_1_timer_active": {
+        "name": "Temporizador del filtro de recirculaci\u00f3n 1 activo"
+      },
+      "recirculation_filter_1_type": {
+        "name": "Tipo de filtro de recirculaci\u00f3n 1"
+      },
+      "recirculation_filter_1_used_hours": {
+        "name": "Horas de uso del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculationfilter1lifetimeinhours": {
+        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 1 en horas"
+      },
+      "recirculationfilter1status": {
+        "name": "Estado del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculationfilter1type": {
+        "name": "Tipo de filtro de recirculaci\u00f3n 1"
+      },
+      "recirculationfilter1usedhours": {
+        "name": "Horas de uso del filtro de recirculaci\u00f3n 1"
+      },
+      "recirculationfilter2lifetimeinhours": {
+        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 2 en horas"
+      },
+      "recirculationfilter2status": {
+        "name": "Estado del filtro de recirculaci\u00f3n 2"
+      },
+      "recirculationfilter2type": {
+        "name": "Tipo de filtro de recirculaci\u00f3n 2"
+      },
+      "recirculationfilter2usedhours": {
+        "name": "Horas de uso del filtro de recirculaci\u00f3n 2"
+      },
+      "ref_light": {
+        "name": "Luz del frigor\u00edfico"
+      },
+      "refr_key": {
+        "name": "Tecla de refresco"
+      },
+      "refr_room": {
+        "name": "Compartimento frigor\u00edfico"
+      },
+      "refrigerator_door_open_time": {
+        "name": "Tiempo de puerta abierta del frigor\u00edfico"
+      },
+      "refrigerator_freeze_swith": {
+        "name": "Interruptor de congelaci\u00f3n del frigor\u00edfico"
+      },
+      "refrigerator_freeze_swith_state": {
+        "name": "Estado del interruptor de congelaci\u00f3n del frigor\u00edfico"
+      },
+      "refrigerator_key": {
+        "name": "Tecla del frigor\u00edfico"
+      },
+      "refrigerator_max_temperature": {
+        "name": "Frigorifico temperatura m\u00e1xima"
+      },
+      "refrigerator_min_temperature": {
+        "name": "Frigorifico temperatura m\u00ednima"
+      },
+      "refrigerator_poweroff_ad": {
+        "name": "Aviso de apagado del frigor\u00edfico"
+      },
+      "refrigerator_poweron_ad": {
+        "name": "Anuncio de encendido del frigor\u00edfico"
+      },
       "refrigerator_real_temperature": {
         "name": "Temperatura real refrigerador"
+      },
+      "refrigerator_room": {
+        "name": "Compartimento del frigor\u00edfico"
       },
       "refrigerator_sensor_real_temperature": {
         "name": "Temperatura real sensor refrigerador"
       },
+      "remaining_time_of_selected_program": {
+        "name": "Tiempo restante programa seleccionado"
+      },
+      "remote_control_mode": {
+        "name": "Modo de control remoto"
+      },
+      "remote_control_mode_monitoring": {
+        "name": "Monitoreo del modo de control remoto"
+      },
+      "remote_control_monitoring_set_commands": {
+        "name": "Comandos configurados de supervisi\u00f3n del control remoto"
+      },
+      "remote_control_monitoring_set_commands_actions": {
+        "name": "Acciones de comandos de configuraci\u00f3n de supervisi\u00f3n del control remoto"
+      },
+      "remotecontrolmode": {
+        "name": "Modo de control remoto"
+      },
+      "remotecontrolmonitoringsetcommands": {
+        "name": "Comandos configurados de supervisi\u00f3n del control remoto"
+      },
+      "remotecontrolmonitoringsetcommandsactions": {
+        "name": "Acciones de comandos de configuraci\u00f3n de supervisi\u00f3n del control remoto"
+      },
+      "remotesetcontrolenabled": {
+        "name": "Control remoto habilitado"
+      },
+      "remotestartduration": {
+        "name": "Duraci\u00f3n del inicio remoto"
+      },
+      "remotestartenabled": {
+        "name": "Inicio remoto activado"
+      },
+      "rfpairingstatus": {
+        "name": "Estado de emparejamiento RF"
+      },
+      "rgb_atmosphere_mode_b_value": {
+        "name": "Valor B del modo ambiente RGB"
+      },
+      "rgb_atmosphere_mode_g_value": {
+        "name": "Valor G del modo ambiente RGB"
+      },
+      "rgb_atmosphere_mode_r_value": {
+        "name": "Valor R del modo ambiente RGB"
+      },
+      "rgb_function_mode_b_value": {
+        "name": "Valor B del modo de funci\u00f3n RGB"
+      },
+      "rgb_function_mode_g_value": {
+        "name": "Valor G del modo de funci\u00f3n RGB"
+      },
+      "rgb_function_mode_r_value": {
+        "name": "Valor R del modo de funci\u00f3n RGB"
+      },
+      "rgb_light_atmosphere_brightness": {
+        "name": "Brillo de la luz ambiental RGB"
+      },
+      "rgb_light_atmosphere_on_time": {
+        "name": "Tiempo de encendido de la luz ambiental RGB"
+      },
+      "rgb_light_function_brightness": {
+        "name": "Brillo de la funci\u00f3n de luz RGB"
+      },
+      "rgb_light_function_on_time": {
+        "name": "Tiempo de encendido de la funci\u00f3n de luz RGB"
+      },
+      "rgb_light_normal_brightness": {
+        "name": "Brillo normal de la luz RGB"
+      },
+      "rgb_light_normal_on_time": {
+        "name": "Tiempo de encendido normal de la luz RGB"
+      },
+      "rgb_light_state": {
+        "name": "Estado de la luz RGB"
+      },
+      "rgb_normal_mode_b_value": {
+        "name": "Valor B del modo normal RGB"
+      },
+      "rgb_normal_mode_g_value": {
+        "name": "Valor G del modo normal RGB"
+      },
+      "rgb_normal_mode_r_value": {
+        "name": "Valor R del modo normal RGB"
+      },
+      "rinse_flag": {
+        "name": "Indicador de aclarado"
+      },
       "rinsenum": {
         "name": "Aclarados extra"
+      },
+      "rinsenum_containextrarinse": {
+        "name": "N\u00famero de aclarados incluye aclarado extra"
+      },
+      "rinsenum_index": {
+        "name": "\u00cdndice de n\u00famero de aclarados"
+      },
+      "rinsestepfinishnotifyswitch": {
+        "name": "Interruptor de aviso de fin del aclarado"
+      },
+      "run_status_flag_5": {
+        "name": "Indicador de estado de funcionamiento 5"
+      },
+      "runing_zero_flag": {
+        "name": "Indicador de puesta a cero"
+      },
+      "running_status": {
+        "name": "Estado de funcionamiento"
+      },
+      "running_status3": {
+        "name": "Estado de funcionamiento 3"
+      },
+      "sabbath_mode_setting": {
+        "name": "Ajuste del modo sab\u00e1tico"
+      },
+      "sabbath_mode_setting_activate_weekly": {
+        "name": "Ajuste del modo sab\u00e1tico: activar semanalmente"
+      },
+      "sabbath_mode_settingbakingend_athour": {
+        "name": "Hora de fin del horneado del modo sab\u00e1tico"
+      },
+      "sabbath_mode_settingbakingend_atminute": {
+        "name": "Minuto de fin del horneado del modo sab\u00e1tico"
+      },
+      "sabbath_mode_settingbakingstart_athour": {
+        "name": "Hora de inicio del horneado del modo sab\u00e1tico"
+      },
+      "sabbath_mode_settingbakingstart_atminute": {
+        "name": "Minuto de inicio del horneado del modo sab\u00e1tico"
+      },
+      "sabbath_mode_settingcavity_light_during_sabbath": {
+        "name": "Ajuste del modo sab\u00e1tico: luz de la cavidad durante el modo sab\u00e1tico"
+      },
+      "sabbath_mode_settingend_timehour": {
+        "name": "Ajuste del modo sab\u00e1tico: hora de finalizaci\u00f3n"
+      },
+      "sabbath_mode_settingend_timeminute": {
+        "name": "Ajuste del modo sab\u00e1tico: minuto de finalizaci\u00f3n"
+      },
+      "sabbath_mode_settingset_heater_system": {
+        "name": "Ajuste del modo sab\u00e1tico del sistema de calentamiento"
+      },
+      "sabbath_mode_settingstart_timehour": {
+        "name": "Ajuste del modo sab\u00e1tico: hora de inicio"
+      },
+      "sabbath_mode_settingstart_timeminute": {
+        "name": "Minuto de la hora de inicio del modo sab\u00e1tico"
       },
       "sabbath_mode_status": {
         "name": "Estado del modo Sabbath"
       },
       "sand_timer1_duration_in_seconds": {
         "name": "Duraci\u00f1on temporizador 1"
+      },
+      "sand_timer1_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de inicio del temporizador de arena 1"
       },
       "sand_timer1_status": {
         "name": "Temporizador 1",
@@ -1149,6 +5498,9 @@
       "sand_timer2_duration_in_seconds": {
         "name": "Duraci\u00f1on temporizador 12"
       },
+      "sand_timer2_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de inicio del temporizador de arena 2"
+      },
       "sand_timer2_status": {
         "name": "Temporizador 2",
         "state": {
@@ -1160,6 +5512,9 @@
       "sand_timer3_duration_in_seconds": {
         "name": "Duraci\u00f1on temporizador 3"
       },
+      "sand_timer3_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de inicio del temporizador de arena 3"
+      },
       "sand_timer3_status": {
         "name": "Temporizador 3",
         "state": {
@@ -1168,23 +5523,169 @@
           "stopped": "Parado"
         }
       },
+      "sand_timer_1_duration": {
+        "name": "Duraci\u00f1on temporizador 1"
+      },
+      "sand_timer_1_end_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de fin del temporizador de arena 1"
+      },
+      "sand_timer_1_paused_total_seconds": {
+        "name": "Total en pausa del temporizador de arena 1"
+      },
+      "sand_timer_1_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de inicio del temporizador de arena 1"
+      },
+      "sand_timer_1_status": {
+        "name": "Estado del temporizador de arena 1",
+        "state": {
+          "ended": "Finalizado",
+          "not_active": "No activo",
+          "paused": "Pausado",
+          "running": "En funcionamiento",
+          "stopped": "Parado"
+        }
+      },
+      "sand_timer_2_duration": {
+        "name": "Duraci\u00f3n del temporizador de arena 2"
+      },
+      "sand_timer_2_end_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de fin del temporizador de arena 2"
+      },
+      "sand_timer_2_paused_total_seconds": {
+        "name": "Total en pausa del temporizador de arena 2"
+      },
+      "sand_timer_2_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de inicio del temporizador de arena 2"
+      },
+      "sand_timer_2_status": {
+        "name": "Estado del temporizador de arena 2",
+        "state": {
+          "ended": "Finalizado",
+          "not_active": "No activo",
+          "paused": "Pausado",
+          "running": "En funcionamiento",
+          "stopped": "Parado"
+        }
+      },
+      "sand_timer_3_duration": {
+        "name": "Duraci\u00f3n del temporizador de arena 3"
+      },
+      "sand_timer_3_end_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de fin del temporizador de arena 3"
+      },
+      "sand_timer_3_paused_total_seconds": {
+        "name": "Total en pausa del temporizador de arena 3"
+      },
+      "sand_timer_3_start_utc_datetime_bdc_timestamp": {
+        "name": "Marca de tiempo BDC UTC de inicio del temporizador de arena 3"
+      },
+      "sand_timer_3_status": {
+        "name": "Estado del temporizador de arena 3",
+        "state": {
+          "ended": "Finalizado",
+          "not_active": "No activo",
+          "paused": "Pausado",
+          "running": "En funcionamiento",
+          "stopped": "Parado"
+        }
+      },
+      "sani_lock": {
+        "name": "Bloqueo Sani"
+      },
+      "sani_lock_allowed": {
+        "name": "Bloqueo higi\u00e9nico permitido"
+      },
+      "saveelectricitvalue_decimal": {
+        "name": "Decimal del valor de ahorro de electricidad"
+      },
+      "saveelectricitvalue_int": {
+        "name": "Valor de ahorro de electricidad (int)"
+      },
+      "screen_display_brightness": {
+        "name": "Brillo de la pantalla"
+      },
+      "screen_display_lock": {
+        "name": "Bloqueo de pantalla"
+      },
+      "screen_to_clock_time": {
+        "name": "Tiempo para pasar la pantalla a reloj"
+      },
+      "screen_to_standby_time": {
+        "name": "Tiempo de pantalla a espera"
+      },
+      "screensavertime": {
+        "name": "Tiempo del salvapantallas"
+      },
+      "second_ice_maker_full_status": {
+        "name": "Estado de lleno del segundo fabricador de hielo"
+      },
+      "second_ice_maker_init_fault": {
+        "name": "Fallo de inicializaci\u00f3n del segundo productor de hielo"
+      },
+      "second_ice_maker_sensor_fault": {
+        "name": "Fallo del sensor del segundo fabricador de hielo"
+      },
+      "selected_program": {
+        "name": "Programa seleccionado"
+      },
+      "selected_program_dry_function": {
+        "name": "Funci\u00f3n de secado del programa seleccionado"
+      },
+      "selected_program_duration_in_minutes": {
+        "name": "Duraci\u00f3n del programa seleccionado"
+      },
+      "selected_program_eco_disinfection": {
+        "name": "Desinfecci\u00f3n ecol\u00f3gica del programa seleccionado"
+      },
+      "selected_program_eco_score": {
+        "name": "Puntuaci\u00f3n eco del programa seleccionado"
+      },
+      "selected_program_eco_small_load": {
+        "name": "Media carga eco del programa seleccionado"
+      },
+      "selected_program_extra_drying_function": {
+        "name": "Funci\u00f3n de secado extra del programa seleccionado"
+      },
+      "selected_program_green_leaves_anticrease": {
+        "name": "Antiarrugas ecol\u00f3gico del programa seleccionado"
+      },
+      "selected_program_green_leaves_entry_steam": {
+        "name": "Vapor inicial ecol\u00f3gico del programa seleccionado"
+      },
+      "selected_program_green_leaves_prewash": {
+        "name": "Prelavado ecol\u00f3gico del programa seleccionado"
+      },
       "selected_program_id": {
         "name": "Programa seleccionado",
         "state": {
+          "allergy_care": "Antialergias",
+          "auto": "Auto",
           "baby_care": "Ropa beb\u00e9",
           "bedding": "Ropa de cama",
+          "cotton": "Algodon",
+          "cotton_dry": "Secado Agod\u00f3n",
           "cotton_storage": "Algod\u00f3n",
+          "drum_clean": "Limpieza Tambor",
+          "eco_40_60": "Eco 40-60",
           "extra_hygiene": "Extra higiene",
           "fast89": "Fast 89",
           "iron": "Plancha",
+          "jeans": "Jeans",
           "mix": "Mix",
           "none": "Nada",
+          "power_49": "Power 49",
+          "quick_15": "Rapido 15\u00b4",
+          "refresh": "Refrescar",
           "remote": "Remoto",
+          "rinse_spin": "Aclarado y Centrifugado",
           "sensitive": "Delicados",
           "shirts": "Camisas",
+          "silk_delicate": "Delicados",
+          "spin": "Centrifugar",
           "sportswear": "Ropa deporte",
           "standard": "Est\u00e1ndar",
           "synthetic": "Sint\u00e9ticos",
+          "synthetic_dry": "Secado Sinteticos",
           "time": "Tiempo",
           "wool": "Lana"
         }
@@ -1192,20 +5693,138 @@
       "selected_program_id_status": {
         "name": "Programa seleccionado"
       },
+      "selected_program_intensive_mode": {
+        "name": "Modo intensivo del programa seleccionado"
+      },
+      "selected_program_load_status": {
+        "name": "Estado de carga del programa seleccionado"
+      },
+      "selected_program_lower_wash_function": {
+        "name": "Funci\u00f3n de lavado inferior del programa seleccionado"
+      },
+      "selected_program_mode": {
+        "name": "Modo de programa seleccionado"
+      },
+      "selected_program_mode_status": {
+        "name": "Modo de programa",
+        "state": {
+          "extra_fast": "Extra r\u00e1pido",
+          "fast": "R\u00e1pido",
+          "normal": "Normal",
+          "not_available": "No disponible"
+        }
+      },
+      "selected_program_night_mode": {
+        "name": "Modo nocturno del programa seleccionado"
+      },
       "selected_program_remaining_time_in_minutes": {
         "name": "Tiempo restante programa seleccionado"
+      },
+      "selected_program_storage_function": {
+        "name": "Funci\u00f3n de almacenamiento del programa seleccionado"
+      },
+      "selected_program_super_rinse": {
+        "name": "Superaclarado del programa seleccionado"
+      },
+      "selected_program_total_running_time": {
+        "name": "Tiempo total programa seleccionado en curso"
       },
       "selected_program_total_running_time_in_minutes": {
         "name": "Tiempo total programa seleccionado en curso"
       },
+      "selected_program_total_time": {
+        "name": "Tiempo total programa seleccionado"
+      },
       "selected_program_total_time_in_minutes": {
         "name": "Tiempo total programa seleccionado"
+      },
+      "selected_program_upper_wash_function": {
+        "name": "Funci\u00f3n de lavado superior del programa seleccionado"
+      },
+      "selected_program_uv_function": {
+        "name": "Funci\u00f3n UV del programa seleccionado"
+      },
+      "selected_program_washing_spin_speed_rpm_status": {
+        "name": "Centrifugado",
+        "state": {
+          "0_rpm": "0",
+          "1000_rpm": "1000",
+          "1200_rpm": "1200",
+          "1400_rpm": "1400",
+          "400_rpm": "400",
+          "800_rpm": "800",
+          "no_spin": "Sin centrifugado",
+          "not_available": "No disponible"
+        }
+      },
+      "selected_program_water_add": {
+        "name": "Agua a\u00f1adida del programa seleccionado"
       },
       "selected_programduration_inminutes": {
         "name": "Duraci\u00f3n programa seleccionado"
       },
+      "selected_programid_ota": {
+        "name": "ID del programa seleccionado OTA"
+      },
       "selected_programremaining_time_inminutes": {
         "name": "Tiempo restante programa seleccionado"
+      },
+      "selectedbasicid": {
+        "name": "ID b\u00e1sico seleccionado"
+      },
+      "selectedderivedid": {
+        "name": "ID derivado seleccionado"
+      },
+      "selectedprogram": {
+        "name": "Programa seleccionado"
+      },
+      "sensor3d": {
+        "name": "Sensor 3D"
+      },
+      "sensor_failure_status": {
+        "name": "Estado de fallo del sensor"
+      },
+      "sensor_failure_status2": {
+        "name": "Estado de fallo del sensor 2"
+      },
+      "session_pairing_active": {
+        "name": "Emparejamiento de sesiones activo",
+        "state": {
+          "close_session": "Cerrar sesi\u00f3n",
+          "no_active_session": "Sin sesi\u00f3n activa",
+          "request_denied": "Solicitud denegada",
+          "session_is_active": "Sesi\u00f3n activa"
+        }
+      },
+      "session_pairing_commond": {
+        "name": "Comando de emparejamiento de sesi\u00f3n"
+      },
+      "session_pairing_confirmation": {
+        "name": "Confirmaci\u00f3n de emparejamiento de sesi\u00f3n"
+      },
+      "session_pairing_setting": {
+        "name": "Ajuste de emparejamiento de sesi\u00f3n"
+      },
+      "session_pairing_states": {
+        "name": "Estados de emparejamiento de sesi\u00f3n"
+      },
+      "session_pairing_status": {
+        "name": "Estado de emparejamiento de sesi\u00f3n"
+      },
+      "sessionpairing": {
+        "name": "Emparejamiento de sesi\u00f3n"
+      },
+      "sessionpairingactive": {
+        "name": "Emparejamiento de sesiones activo"
+      },
+      "sessionpairingconfirmation": {
+        "name": "Confirmaci\u00f3n de emparejamiento de sesi\u00f3n"
+      },
+      "sessionpairingrequest": {
+        "name": "Solicitud de emparejamiento de sesi\u00f3n"
+      },
+      "sessionpairingsetting": {
+        "name": "Ajuste de emparejamiento de sesi\u00f3n"
       },
       "set_progress_type": {
         "name": "Tipo progreso",
@@ -1225,6 +5844,78 @@
           "warming": "Calentando"
         }
       },
+      "set_time_hour": {
+        "name": "Ajustar hora"
+      },
+      "set_time_minutes": {
+        "name": "Minutos de tiempo configurados"
+      },
+      "settings_day": {
+        "name": "D\u00eda de ajuste"
+      },
+      "settings_hour": {
+        "name": "Hora de ajuste"
+      },
+      "settings_minute": {
+        "name": "Minutos configurados"
+      },
+      "settings_month": {
+        "name": "Mes de configuraci\u00f3n"
+      },
+      "settings_year": {
+        "name": "A\u00f1o de ajuste"
+      },
+      "sf_sr_mutex_mode": {
+        "name": "Modo exclusivo SF/SR"
+      },
+      "shelf_light_a_state": {
+        "name": "Estado de la luz del estante A"
+      },
+      "shelf_light_atmosphere_brightness": {
+        "name": "Brillo ambiental de la luz del estante"
+      },
+      "shelf_light_atmosphere_mode_brightness": {
+        "name": "Brillo del modo ambiente de la luz del estante"
+      },
+      "shelf_light_b_state": {
+        "name": "Estado de la luz del estante B"
+      },
+      "shelf_light_c_state": {
+        "name": "Estado de la luz del estante C"
+      },
+      "shelf_light_function_mode_brightness": {
+        "name": "Brillo del modo de funci\u00f3n de luz de estante"
+      },
+      "shelf_light_function_on_time": {
+        "name": "Tiempo de encendido de la luz del estante"
+      },
+      "shelf_light_normal_on_time": {
+        "name": "Tiempo de encendido normal de la luz del estante"
+      },
+      "shop_mode_setting": {
+        "name": "Ajuste del modo tienda"
+      },
+      "show_date_setting": {
+        "name": "Ajuste de mostrar fecha"
+      },
+      "show_mode": {
+        "name": "Modo demostraci\u00f3n"
+      },
+      "silence_on_demand": {
+        "name": "Silencio a demanda"
+      },
+      "silence_on_demand_allowed": {
+        "name": "Silencio a demanda permitido"
+      },
+      "singleairdry": {
+        "name": "Secado al aire simple"
+      },
+      "skipdelayprocess": {
+        "name": "Omitir proceso de retardo"
+      },
+      "sl": {
+        "name": "Sl"
+      },
       "sl1_active_timer": {
         "name": "Zona 1 temporizador activo",
         "state": {
@@ -1233,26 +5924,128 @@
           "timer": "Tiempo"
         }
       },
+      "sl1_bridged_to_zone": {
+        "name": "Destino de puente de zona 1"
+      },
+      "sl1_cooking_method": {
+        "name": "M\u00e9todo de cocci\u00f3n de la zona 1",
+        "state": {
+          "method_1": "M\u00e9todo 1",
+          "method_2": "M\u00e9todo 2",
+          "none": "No centrifugar"
+        }
+      },
+      "sl1_function_status": {
+        "name": "Estado de funci\u00f3n de la zona 1",
+        "state": {
+          "function_1": "Funci\u00f3n 1",
+          "function_2": "Funci\u00f3n 2",
+          "none": "No centrifugar"
+        }
+      },
       "sl1_functions": {
         "name": "Zona 1 funciones",
         "state": {
           "boil": "Hervir",
+          "fry": "Fre\u00edr",
           "grill": "Parrilla",
+          "heat_up_and_fry": "Calentar y fre\u00edr",
           "keep_warm": "Mantener caliente",
+          "keep_warm_and_heat_up": "Mantener caliente y calentar",
           "none": "Nada",
           "roast": "Asar",
           "simmer": "Hervir a fuego lento",
+          "slow_cook": "Cocci\u00f3n lenta",
           "wok": "Wok"
         }
+      },
+      "sl1_hestan_cue_cookware_type": {
+        "name": "Zona 1 tipo de utensilio Hestan Cue"
+      },
+      "sl1_hestan_cue_next_step_required_warning": {
+        "name": "Zona 1 Hestan Cue: siguiente paso requerido"
+      },
+      "sl1_hestan_cue_set_temperature": {
+        "name": "Temperatura ajustada Hestan Cue de la zona 1"
+      },
+      "sl1_hestan_cue_temperature": {
+        "name": "Temperatura Hestan Cue de la zona 1"
       },
       "sl1_ntc_sensor": {
         "name": "Zona 1 sensor NTC"
       },
       "sl1_power_level": {
-        "name": "Zona 1 nivel potencia"
+        "name": "Zona 1 nivel potencia",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl1_power_level_max": {
         "name": "Zona 1 maximo nivel potencia"
+      },
+      "sl1_sand_timer_paused_total_seconds": {
+        "name": "Temporizador de arena de la zona 1 en pausa"
+      },
+      "sl1_sand_timer_status": {
+        "name": "Estado del temporizador de arena de la zona 1",
+        "state": {
+          "active": "Activo",
+          "ended": "Finalizado",
+          "inactive": "Inactivo",
+          "paused": "Pausado",
+          "stopped": "Parado"
+        }
+      },
+      "sl1_sand_timer_utc_start_time_hours": {
+        "name": "Zona 1 horas de inicio del temporizador de arena"
+      },
+      "sl1_sand_timer_utc_start_time_minutes": {
+        "name": "Zona 1 minutos de inicio del temporizador de arena"
+      },
+      "sl1_sand_timer_utc_start_time_seconds": {
+        "name": "Zona 1 segundos de inicio del temporizador de arena"
+      },
+      "sl1_stopwatch_paused_total_seconds": {
+        "name": "Cron\u00f3metro de la zona 1 en pausa"
+      },
+      "sl1_stopwatch_status": {
+        "name": "Estado del cron\u00f3metro de la zona 1",
+        "state": {
+          "active": "Activo",
+          "hold": "En pausa",
+          "inactive": "Inactivo",
+          "paused": "Pausado"
+        }
+      },
+      "sl1_stopwatch_utc_start_time_hours": {
+        "name": "Hora de inicio del cron\u00f3metro de la zona 1"
+      },
+      "sl1_stopwatch_utc_start_time_minutes": {
+        "name": "Zona 1 minutos de inicio del cron\u00f3metro"
+      },
+      "sl1_stopwatch_utc_start_time_seconds": {
+        "name": "Zona 1 segundos de inicio del cron\u00f3metro"
+      },
+      "sl1_temperature": {
+        "name": "Temperatura de la zona 1"
+      },
+      "sl1_timer_utc_end_time_hours": {
+        "name": "Horas de fin del temporizador de la zona 1"
+      },
+      "sl1_timer_utc_end_time_minutes": {
+        "name": "Minutos de fin del temporizador de la zona 1"
+      },
+      "sl1_timer_utc_end_time_seconds": {
+        "name": "Segundos de fin del temporizador de la zona 1"
+      },
+      "sl1_timer_utc_paused_hours": {
+        "name": "Horas en pausa del temporizador zona 1"
+      },
+      "sl1_timer_utc_paused_minutes": {
+        "name": "Minutos de pausa del temporizador de la zona 1"
+      },
+      "sl1_timer_utc_paused_seconds": {
+        "name": "Segundos de pausa del temporizador de la zona 1"
       },
       "sl1_zone_shape": {
         "name": "Zona 1 forma",
@@ -1272,26 +6065,128 @@
           "timer": "Tiempo"
         }
       },
+      "sl2_bridged_to_zone": {
+        "name": "Destino de puente de zona 2"
+      },
+      "sl2_cooking_method": {
+        "name": "M\u00e9todo de cocci\u00f3n de la zona 2",
+        "state": {
+          "method_1": "M\u00e9todo 1",
+          "method_2": "M\u00e9todo 2",
+          "none": "No centrifugar"
+        }
+      },
+      "sl2_function_status": {
+        "name": "Estado de funci\u00f3n de la zona 2",
+        "state": {
+          "function_1": "Funci\u00f3n 1",
+          "function_2": "Funci\u00f3n 2",
+          "none": "No centrifugar"
+        }
+      },
       "sl2_functions": {
         "name": "Zona 2 funciones",
         "state": {
           "boil": "Hervir",
+          "fry": "Fre\u00edr",
           "grill": "Parrilla",
+          "heat_up_and_fry": "Calentar y fre\u00edr",
           "keep_warm": "Mantener caliente",
+          "keep_warm_and_heat_up": "Mantener caliente y calentar",
           "none": "Nada",
           "roast": "Asar",
           "simmer": "Hervir a fuego lento",
+          "slow_cook": "Cocci\u00f3n lenta",
           "wok": "Wok"
         }
+      },
+      "sl2_hestan_cue_cookware_type": {
+        "name": "Zona 2 tipo de utensilio Hestan Cue"
+      },
+      "sl2_hestan_cue_next_step_required_warning": {
+        "name": "Zona 2 Hestan Cue: siguiente paso requerido"
+      },
+      "sl2_hestan_cue_set_temperature": {
+        "name": "Temperatura ajustada Hestan Cue de la zona 2"
+      },
+      "sl2_hestan_cue_temperature": {
+        "name": "Zona 2 temperatura Hestan Cue"
       },
       "sl2_ntc_sensor": {
         "name": "Zona 2 sensor NTC"
       },
       "sl2_power_level": {
-        "name": "Zona 2 nivel potencia"
+        "name": "Zona 2 nivel potencia",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl2_power_level_max": {
         "name": "Zona 2 m\u00e1ximo nivel potencia"
+      },
+      "sl2_sand_timer_paused_total_seconds": {
+        "name": "Temporizador de arena zona 2 en pausa"
+      },
+      "sl2_sand_timer_status": {
+        "name": "Estado del temporizador de arena zona 2",
+        "state": {
+          "active": "Activo",
+          "ended": "Finalizado",
+          "inactive": "Inactivo",
+          "paused": "Pausado",
+          "stopped": "Parado"
+        }
+      },
+      "sl2_sand_timer_utc_start_time_hours": {
+        "name": "Zona 2 horas de inicio del temporizador de arena"
+      },
+      "sl2_sand_timer_utc_start_time_minutes": {
+        "name": "Minutos de inicio del temporizador de arena de la zona 2"
+      },
+      "sl2_sand_timer_utc_start_time_seconds": {
+        "name": "Segundos de inicio del temporizador de arena de la zona 2"
+      },
+      "sl2_stopwatch_paused_total_seconds": {
+        "name": "Cron\u00f3metro de la zona 2 en pausa"
+      },
+      "sl2_stopwatch_status": {
+        "name": "Estado del cron\u00f3metro de la zona 2",
+        "state": {
+          "active": "Activo",
+          "hold": "En pausa",
+          "inactive": "Inactivo",
+          "paused": "Pausado"
+        }
+      },
+      "sl2_stopwatch_utc_start_time_hours": {
+        "name": "Hora de inicio del cron\u00f3metro de la zona 2"
+      },
+      "sl2_stopwatch_utc_start_time_minutes": {
+        "name": "Zona 2 minutos de inicio del cron\u00f3metro"
+      },
+      "sl2_stopwatch_utc_start_time_seconds": {
+        "name": "Zona 2 segundos de inicio del cron\u00f3metro"
+      },
+      "sl2_temperature": {
+        "name": "Temperatura de la zona 2"
+      },
+      "sl2_timer_utc_end_time_hours": {
+        "name": "Horas de fin del temporizador de la zona 2"
+      },
+      "sl2_timer_utc_end_time_minutes": {
+        "name": "Minutos de fin del temporizador zona 2"
+      },
+      "sl2_timer_utc_end_time_seconds": {
+        "name": "Segundos de fin del temporizador zona 2"
+      },
+      "sl2_timer_utc_paused_hours": {
+        "name": "Horas en pausa del temporizador zona 2"
+      },
+      "sl2_timer_utc_paused_minutes": {
+        "name": "Minutos de pausa del temporizador de la zona 2"
+      },
+      "sl2_timer_utc_paused_seconds": {
+        "name": "Segundos de pausa del temporizador de la zona 2"
       },
       "sl2_zone_shape": {
         "name": "Zona 2 forma",
@@ -1311,26 +6206,128 @@
           "timer": "Tiempo"
         }
       },
+      "sl3_bridged_to_zone": {
+        "name": "Destino de puente de zona 3"
+      },
+      "sl3_cooking_method": {
+        "name": "M\u00e9todo de cocci\u00f3n de la zona 3",
+        "state": {
+          "method_1": "M\u00e9todo 1",
+          "method_2": "M\u00e9todo 2",
+          "none": "No centrifugar"
+        }
+      },
+      "sl3_function_status": {
+        "name": "Estado de funci\u00f3n de la zona 3",
+        "state": {
+          "function_1": "Funci\u00f3n 1",
+          "function_2": "Funci\u00f3n 2",
+          "none": "No centrifugar"
+        }
+      },
       "sl3_functions": {
         "name": "Zona 3 funciones",
         "state": {
           "boil": "Hervir",
+          "fry": "Fre\u00edr",
           "grill": "Parrilla",
+          "heat_up_and_fry": "Calentar y fre\u00edr",
           "keep_warm": "Mantener caliente",
+          "keep_warm_and_heat_up": "Mantener caliente y calentar",
           "none": "Nada",
           "roast": "Asar",
           "simmer": "Hervir a fuego lento",
+          "slow_cook": "Cocci\u00f3n lenta",
           "wok": "Wok"
         }
+      },
+      "sl3_hestan_cue_cookware_type": {
+        "name": "Tipo de utensilio Hestan Cue de la zona 3"
+      },
+      "sl3_hestan_cue_next_step_required_warning": {
+        "name": "Zona 3 Hestan Cue: siguiente paso requerido"
+      },
+      "sl3_hestan_cue_set_temperature": {
+        "name": "Temperatura ajustada Hestan Cue de la zona 3"
+      },
+      "sl3_hestan_cue_temperature": {
+        "name": "Zona 3 temperatura Hestan Cue"
       },
       "sl3_ntc_sensor": {
         "name": "Zona 3 sensor NTC"
       },
       "sl3_power_level": {
-        "name": "Zona 3 nivel potencia"
+        "name": "Zona 3 nivel potencia",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl3_power_level_max": {
         "name": "Zona 3 m\u00e1ximo nivel potencia"
+      },
+      "sl3_sand_timer_paused_total_seconds": {
+        "name": "Temporizador de arena zona 3 en pausa"
+      },
+      "sl3_sand_timer_status": {
+        "name": "Estado del temporizador de arena zona 3",
+        "state": {
+          "active": "Activo",
+          "ended": "Finalizado",
+          "inactive": "Inactivo",
+          "paused": "Pausado",
+          "stopped": "Parado"
+        }
+      },
+      "sl3_sand_timer_utc_start_time_hours": {
+        "name": "Zona 3 horas de inicio del temporizador de arena"
+      },
+      "sl3_sand_timer_utc_start_time_minutes": {
+        "name": "Minutos de inicio del temporizador de arena de la zona 3"
+      },
+      "sl3_sand_timer_utc_start_time_seconds": {
+        "name": "Segundos de inicio del temporizador de arena de la zona 3"
+      },
+      "sl3_stopwatch_paused_total_seconds": {
+        "name": "Cron\u00f3metro de la zona 3 en pausa"
+      },
+      "sl3_stopwatch_status": {
+        "name": "Estado del cron\u00f3metro de la zona 3",
+        "state": {
+          "active": "Activo",
+          "hold": "En pausa",
+          "inactive": "Inactivo",
+          "paused": "Pausado"
+        }
+      },
+      "sl3_stopwatch_utc_start_time_hours": {
+        "name": "Hora de inicio del cron\u00f3metro de la zona 3"
+      },
+      "sl3_stopwatch_utc_start_time_minutes": {
+        "name": "Zona 3 minutos de inicio del cron\u00f3metro"
+      },
+      "sl3_stopwatch_utc_start_time_seconds": {
+        "name": "Zona 3 segundos de inicio del cron\u00f3metro"
+      },
+      "sl3_temperature": {
+        "name": "Temperatura de la zona 3"
+      },
+      "sl3_timer_utc_end_time_hours": {
+        "name": "Horas de fin del temporizador de la zona 3"
+      },
+      "sl3_timer_utc_end_time_minutes": {
+        "name": "Minutos de fin del temporizador zona 3"
+      },
+      "sl3_timer_utc_end_time_seconds": {
+        "name": "Segundos de fin del temporizador zona 3"
+      },
+      "sl3_timer_utc_paused_hours": {
+        "name": "Horas en pausa del temporizador zona 3"
+      },
+      "sl3_timer_utc_paused_minutes": {
+        "name": "Minutos de pausa del temporizador de la zona 3"
+      },
+      "sl3_timer_utc_paused_seconds": {
+        "name": "Segundos de pausa del temporizador de la zona 3"
       },
       "sl3_zone_shape": {
         "name": "Zona 3 forma",
@@ -1350,26 +6347,128 @@
           "timer": "Tiempo"
         }
       },
+      "sl4_bridged_to_zone": {
+        "name": "Destino de puente de zona 4"
+      },
+      "sl4_cooking_method": {
+        "name": "M\u00e9todo de cocci\u00f3n de la zona 4",
+        "state": {
+          "method_1": "M\u00e9todo 1",
+          "method_2": "M\u00e9todo 2",
+          "none": "No centrifugar"
+        }
+      },
+      "sl4_function_status": {
+        "name": "Estado de funci\u00f3n de la zona 4",
+        "state": {
+          "function_1": "Funci\u00f3n 1",
+          "function_2": "Funci\u00f3n 2",
+          "none": "No centrifugar"
+        }
+      },
       "sl4_functions": {
         "name": "Zona 4 funciones",
         "state": {
           "boil": "Hervir",
+          "fry": "Fre\u00edr",
           "grill": "Parrilla",
+          "heat_up_and_fry": "Calentar y fre\u00edr",
           "keep_warm": "Mantener caliente",
+          "keep_warm_and_heat_up": "Mantener caliente y calentar",
           "none": "Nada",
           "roast": "Asar",
           "simmer": "Hervir a fuego lento",
+          "slow_cook": "Cocci\u00f3n lenta",
           "wok": "Wok"
         }
+      },
+      "sl4_hestan_cue_cookware_type": {
+        "name": "Tipo de utensilio Hestan Cue de la zona 4"
+      },
+      "sl4_hestan_cue_next_step_required_warning": {
+        "name": "Zona 4 Hestan Cue: siguiente paso requerido"
+      },
+      "sl4_hestan_cue_set_temperature": {
+        "name": "Temperatura ajustada Hestan Cue de la zona 4"
+      },
+      "sl4_hestan_cue_temperature": {
+        "name": "Zona 4 temperatura Hestan Cue"
       },
       "sl4_ntc_sensor": {
         "name": "Zona 4 sensor NTC"
       },
       "sl4_power_level": {
-        "name": "Zona 4 nivel potencia"
+        "name": "Zona 4 nivel potencia",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl4_power_level_max": {
         "name": "Zona 4 m\u00e1ximo nivel potencia"
+      },
+      "sl4_sand_timer_paused_total_seconds": {
+        "name": "Temporizador de arena zona 4 en pausa"
+      },
+      "sl4_sand_timer_status": {
+        "name": "Estado del temporizador de arena zona 4",
+        "state": {
+          "active": "Activo",
+          "ended": "Finalizado",
+          "inactive": "Inactivo",
+          "paused": "Pausado",
+          "stopped": "Parado"
+        }
+      },
+      "sl4_sand_timer_utc_start_time_hours": {
+        "name": "Zona 4 horas de inicio del temporizador de arena"
+      },
+      "sl4_sand_timer_utc_start_time_minutes": {
+        "name": "Minutos de inicio del temporizador de arena de la zona 4"
+      },
+      "sl4_sand_timer_utc_start_time_seconds": {
+        "name": "Segundos de inicio del temporizador de arena de la zona 4"
+      },
+      "sl4_stopwatch_paused_total_seconds": {
+        "name": "Cron\u00f3metro de la zona 4 en pausa"
+      },
+      "sl4_stopwatch_status": {
+        "name": "Estado del cron\u00f3metro de la zona 4",
+        "state": {
+          "active": "Activo",
+          "hold": "En pausa",
+          "inactive": "Inactivo",
+          "paused": "Pausado"
+        }
+      },
+      "sl4_stopwatch_utc_start_time_hours": {
+        "name": "Hora de inicio del cron\u00f3metro de la zona 4"
+      },
+      "sl4_stopwatch_utc_start_time_minutes": {
+        "name": "Zona 4 minutos de inicio del cron\u00f3metro"
+      },
+      "sl4_stopwatch_utc_start_time_seconds": {
+        "name": "Zona 4 segundos de inicio del cron\u00f3metro"
+      },
+      "sl4_temperature": {
+        "name": "Temperatura de la zona 4"
+      },
+      "sl4_timer_utc_end_time_hours": {
+        "name": "Horas de fin del temporizador de la zona 4"
+      },
+      "sl4_timer_utc_end_time_minutes": {
+        "name": "Minutos de fin del temporizador zona 4"
+      },
+      "sl4_timer_utc_end_time_seconds": {
+        "name": "Segundos de fin del temporizador zona 4"
+      },
+      "sl4_timer_utc_paused_hours": {
+        "name": "Horas en pausa del temporizador zona 4"
+      },
+      "sl4_timer_utc_paused_minutes": {
+        "name": "Minutos de pausa del temporizador de la zona 4"
+      },
+      "sl4_timer_utc_paused_seconds": {
+        "name": "Segundos de pausa del temporizador de la zona 4"
       },
       "sl4_zone_shape": {
         "name": "Zona 4 forma",
@@ -1389,26 +6488,128 @@
           "timer": "Tiempo"
         }
       },
+      "sl5_bridged_to_zone": {
+        "name": "Destino de puente de zona 5"
+      },
+      "sl5_cooking_method": {
+        "name": "M\u00e9todo de cocci\u00f3n de la zona 5",
+        "state": {
+          "method_1": "M\u00e9todo 1",
+          "method_2": "M\u00e9todo 2",
+          "none": "No centrifugar"
+        }
+      },
+      "sl5_function_status": {
+        "name": "Estado de funci\u00f3n de la zona 5",
+        "state": {
+          "function_1": "Funci\u00f3n 1",
+          "function_2": "Funci\u00f3n 2",
+          "none": "No centrifugar"
+        }
+      },
       "sl5_functions": {
         "name": "Zona 5 funciones",
         "state": {
           "boil": "Hervir",
+          "fry": "Fre\u00edr",
           "grill": "Parrilla",
+          "heat_up_and_fry": "Calentar y fre\u00edr",
           "keep_warm": "Mantener caliente",
+          "keep_warm_and_heat_up": "Mantener caliente y calentar",
           "none": "Nada",
           "roast": "Asar",
           "simmer": "Hervir a fuego lento",
+          "slow_cook": "Cocci\u00f3n lenta",
           "wok": "Wok"
         }
+      },
+      "sl5_hestan_cue_cookware_type": {
+        "name": "Tipo de utensilio Hestan Cue de la zona 5"
+      },
+      "sl5_hestan_cue_next_step_required_warning": {
+        "name": "Zona 5 Hestan Cue: siguiente paso requerido"
+      },
+      "sl5_hestan_cue_set_temperature": {
+        "name": "Temperatura ajustada Hestan Cue de la zona 5"
+      },
+      "sl5_hestan_cue_temperature": {
+        "name": "Zona 5 temperatura Hestan Cue"
       },
       "sl5_ntc_sensor": {
         "name": "Zona 5 sensor NTC"
       },
       "sl5_power_level": {
-        "name": "Zona 5 nivel potencia"
+        "name": "Zona 5 nivel potencia",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl5_power_level_max": {
         "name": "Zona 5 m\u00e1ximo nivel potencia"
+      },
+      "sl5_sand_timer_paused_total_seconds": {
+        "name": "Temporizador de arena zona 5 en pausa"
+      },
+      "sl5_sand_timer_status": {
+        "name": "Estado del temporizador de arena zona 5",
+        "state": {
+          "active": "Activo",
+          "ended": "Finalizado",
+          "inactive": "Inactivo",
+          "paused": "Pausado",
+          "stopped": "Parado"
+        }
+      },
+      "sl5_sand_timer_utc_start_time_hours": {
+        "name": "Zona 5 horas de inicio del temporizador de arena"
+      },
+      "sl5_sand_timer_utc_start_time_minutes": {
+        "name": "Minutos de inicio del temporizador de arena de la zona 5"
+      },
+      "sl5_sand_timer_utc_start_time_seconds": {
+        "name": "Segundos de inicio del temporizador de arena de la zona 5"
+      },
+      "sl5_stopwatch_paused_total_seconds": {
+        "name": "Cron\u00f3metro de la zona 5 en pausa"
+      },
+      "sl5_stopwatch_status": {
+        "name": "Estado del cron\u00f3metro de la zona 5",
+        "state": {
+          "active": "Activo",
+          "hold": "En pausa",
+          "inactive": "Inactivo",
+          "paused": "Pausado"
+        }
+      },
+      "sl5_stopwatch_utc_start_time_hours": {
+        "name": "Hora de inicio del cron\u00f3metro de la zona 5"
+      },
+      "sl5_stopwatch_utc_start_time_minutes": {
+        "name": "Zona 5 minutos de inicio del cron\u00f3metro"
+      },
+      "sl5_stopwatch_utc_start_time_seconds": {
+        "name": "Zona 5 segundos de inicio del cron\u00f3metro"
+      },
+      "sl5_temperature": {
+        "name": "Temperatura de la zona 5"
+      },
+      "sl5_timer_utc_end_time_hours": {
+        "name": "Horas de fin del temporizador de la zona 5"
+      },
+      "sl5_timer_utc_end_time_minutes": {
+        "name": "Minutos de fin del temporizador zona 5"
+      },
+      "sl5_timer_utc_end_time_seconds": {
+        "name": "Segundos de fin del temporizador zona 5"
+      },
+      "sl5_timer_utc_paused_hours": {
+        "name": "Horas en pausa del temporizador zona 5"
+      },
+      "sl5_timer_utc_paused_minutes": {
+        "name": "Minutos de pausa del temporizador de la zona 5"
+      },
+      "sl5_timer_utc_paused_seconds": {
+        "name": "Segundos de pausa del temporizador de la zona 5"
       },
       "sl5_zone_shape": {
         "name": "Zona 5 forma",
@@ -1428,26 +6629,128 @@
           "timer": "Tiempo"
         }
       },
+      "sl6_bridged_to_zone": {
+        "name": "Destino de puente de zona 6"
+      },
+      "sl6_cooking_method": {
+        "name": "M\u00e9todo de cocci\u00f3n de la zona 6",
+        "state": {
+          "method_1": "M\u00e9todo 1",
+          "method_2": "M\u00e9todo 2",
+          "none": "No centrifugar"
+        }
+      },
+      "sl6_function_status": {
+        "name": "Estado de funci\u00f3n de la zona 6",
+        "state": {
+          "function_1": "Funci\u00f3n 1",
+          "function_2": "Funci\u00f3n 2",
+          "none": "No centrifugar"
+        }
+      },
       "sl6_functions": {
         "name": "Zona 6 funciones",
         "state": {
           "boil": "Hervir",
+          "fry": "Fre\u00edr",
           "grill": "Parrilla",
+          "heat_up_and_fry": "Calentar y fre\u00edr",
           "keep_warm": "Mantener caliente",
+          "keep_warm_and_heat_up": "Mantener caliente y calentar",
           "none": "Nada",
           "roast": "Asar",
           "simmer": "Hervir a fuego lento",
+          "slow_cook": "Cocci\u00f3n lenta",
           "wok": "Wok"
         }
+      },
+      "sl6_hestan_cue_cookware_type": {
+        "name": "Tipo de utensilio Hestan Cue de la zona 6"
+      },
+      "sl6_hestan_cue_next_step_required_warning": {
+        "name": "Zona 6 Hestan Cue: siguiente paso requerido"
+      },
+      "sl6_hestan_cue_set_temperature": {
+        "name": "Temperatura ajustada Hestan Cue de la zona 6"
+      },
+      "sl6_hestan_cue_temperature": {
+        "name": "Zona 6 temperatura Hestan Cue"
       },
       "sl6_ntc_sensor": {
         "name": "Zona 6 sensor NTC"
       },
       "sl6_power_level": {
-        "name": "Zona 6 nivel potencia"
+        "name": "Zona 6 nivel potencia",
+        "state": {
+          "boost": "Boost"
+        }
       },
       "sl6_power_level_max": {
         "name": "Zona 6 maximo nivel potencia"
+      },
+      "sl6_sand_timer_paused_total_seconds": {
+        "name": "Temporizador de arena zona 6 en pausa"
+      },
+      "sl6_sand_timer_status": {
+        "name": "Estado del temporizador de arena zona 6",
+        "state": {
+          "active": "Activo",
+          "ended": "Finalizado",
+          "inactive": "Inactivo",
+          "paused": "Pausado",
+          "stopped": "Parado"
+        }
+      },
+      "sl6_sand_timer_utc_start_time_hours": {
+        "name": "Zona 6 horas de inicio del temporizador de arena"
+      },
+      "sl6_sand_timer_utc_start_time_minutes": {
+        "name": "Minutos de inicio del temporizador de arena de la zona 6"
+      },
+      "sl6_sand_timer_utc_start_time_seconds": {
+        "name": "Segundos de inicio del temporizador de arena de la zona 6"
+      },
+      "sl6_stopwatch_paused_total_seconds": {
+        "name": "Cron\u00f3metro de la zona 6 en pausa"
+      },
+      "sl6_stopwatch_status": {
+        "name": "Estado del cron\u00f3metro de la zona 6",
+        "state": {
+          "active": "Activo",
+          "hold": "En pausa",
+          "inactive": "Inactivo",
+          "paused": "Pausado"
+        }
+      },
+      "sl6_stopwatch_utc_start_time_hours": {
+        "name": "Hora de inicio del cron\u00f3metro de la zona 6"
+      },
+      "sl6_stopwatch_utc_start_time_minutes": {
+        "name": "Zona 6 minutos de inicio del cron\u00f3metro"
+      },
+      "sl6_stopwatch_utc_start_time_seconds": {
+        "name": "Zona 6 segundos de inicio del cron\u00f3metro"
+      },
+      "sl6_temperature": {
+        "name": "Temperatura de la zona 6"
+      },
+      "sl6_timer_utc_end_time_hours": {
+        "name": "Horas de fin del temporizador de la zona 6"
+      },
+      "sl6_timer_utc_end_time_minutes": {
+        "name": "Minutos de fin del temporizador zona 6"
+      },
+      "sl6_timer_utc_end_time_seconds": {
+        "name": "Segundos de fin del temporizador zona 6"
+      },
+      "sl6_timer_utc_paused_hours": {
+        "name": "Horas en pausa del temporizador zona 6"
+      },
+      "sl6_timer_utc_paused_minutes": {
+        "name": "Minutos de pausa del temporizador de la zona 6"
+      },
+      "sl6_timer_utc_paused_seconds": {
+        "name": "Segundos de pausa del temporizador de la zona 6"
       },
       "sl6_zone_shape": {
         "name": "Zona 6 forma",
@@ -1459,15 +6762,195 @@
           "square": "Cuadrada"
         }
       },
+      "slotdry": {
+        "name": "Slotdry"
+      },
+      "slotdry_flag": {
+        "name": "Indicador de secado por ranura"
+      },
+      "slotdry_flag1": {
+        "name": "Indicador de secado por ranura 1"
+      },
+      "soft_pairing_setting": {
+        "name": "Ajuste de emparejamiento suave"
+      },
+      "soft_pairing_status": {
+        "name": "Estado de emparejamiento suave"
+      },
+      "softener_buynotifyswitch": {
+        "name": "Interruptor de aviso de compra de suavizante"
+      },
+      "softener_compartment": {
+        "name": "Compartimento del suavizante"
+      },
+      "softener_indicator": {
+        "name": "Indicador de suavizante"
+      },
+      "softener_leftml": {
+        "name": "Suavizante restante"
+      },
+      "softener_leftnum": {
+        "name": "Usos de suavizante restantes"
+      },
+      "softener_tank": {
+        "name": "Dep\u00f3sito de suavizante"
+      },
+      "softener_totalml": {
+        "name": "Total de suavizante usado"
+      },
+      "softener_totalnum": {
+        "name": "Total de dosis de suavizante usadas"
+      },
+      "softenercompartment_flag": {
+        "name": "Indicador del compartimento de suavizante"
+      },
+      "softer_flag": {
+        "name": "Indicador de suavizado"
+      },
+      "softner_useindex": {
+        "name": "\u00cdndice de uso de suavizante"
+      },
+      "softnerstandarddosage": {
+        "name": "Dosis est\u00e1ndar de suavizante"
+      },
+      "softnerstandarddosage_flag": {
+        "name": "Indicador de dosis est\u00e1ndar de suavizante"
+      },
+      "softpairing": {
+        "name": "Emparejamiento suave"
+      },
+      "softpairingsetting": {
+        "name": "Ajuste de emparejamiento suave"
+      },
+      "soil_lever": {
+        "name": "Nivel de suciedad"
+      },
+      "soilleverflag": {
+        "name": "Indicador de nivel de suciedad"
+      },
+      "sound_setting": {
+        "name": "Ajuste de sonido"
+      },
+      "special_space": {
+        "name": "Espacio especial"
+      },
+      "speed_flag": {
+        "name": "Indicador de velocidad"
+      },
+      "speed_on_demand": {
+        "name": "Velocidad bajo demanda"
+      },
+      "spend_on_demand_allowed": {
+        "name": "Gasto bajo demanda permitido"
+      },
+      "spin_speed_rpm": {
+        "name": "Velocidad de centrifugado rpm"
+      },
+      "spin_time": {
+        "name": "Tiempo de centrifugado"
+      },
+      "spinrange": {
+        "name": "Rango de centrifugado"
+      },
+      "spinspeeduseindex": {
+        "name": "\u00cdndice de uso de velocidad de centrifugado"
+      },
+      "spinstepfinishnotifyswitch": {
+        "name": "Interruptor de aviso de fin del centrifugado"
+      },
+      "spintime": {
+        "name": "Tiempo de centrifugado"
+      },
+      "spintime_flag": {
+        "name": "Indicador de tiempo de centrifugado"
+      },
       "spintime_index": {
         "name": "Duraci\u00f3n centrifugado"
       },
+      "spintime_useindex": {
+        "name": "\u00cdndice de uso de tiempo de centrifugado"
+      },
+      "stage_lights_setting": {
+        "name": "Ajuste de las luces de escena"
+      },
+      "stain_program_set_clothes_type_status": {
+        "name": "Estado del tipo de ropa del programa de manchas"
+      },
+      "stain_program_set_stain_status": {
+        "name": "Estado de mancha configurado del programa antimanchas"
+      },
+      "stain_removal": {
+        "name": "Eliminaci\u00f3n de manchas"
+      },
+      "stand_by_time": {
+        "name": "Tiempo en espera"
+      },
+      "standardelectricitconsumption": {
+        "name": "Consumo el\u00e9ctrico est\u00e1ndar"
+      },
+      "standardwaterconsumption": {
+        "name": "Consumo de agua est\u00e1ndar"
+      },
+      "standby_mode_state": {
+        "name": "Estado del modo en espera"
+      },
+      "standby_mode_valid": {
+        "name": "Modo en espera v\u00e1lido"
+      },
+      "standbychoice": {
+        "name": "Selecci\u00f3n de espera"
+      },
       "status": {
+        "name": "Estado del dispositivo",
         "state": {
           "add_clothes": "A\u00f1adir ropa",
+          "delay_time_waiting": "Esperando tiempo de retraso",
+          "error": "Error",
+          "idle": "Inactivo",
+          "not_avaliable": "No disponible",
+          "pause": "Pausa",
+          "production": "Producci\u00f3n",
           "program_select": "Selecci\u00f3n de programa",
-          "service": "Mantenimiento"
+          "running": "En funcionamiento",
+          "service": "Mantenimiento",
+          "standby": "Suspendida"
         }
+      },
+      "status_fan_c_switch": {
+        "name": "Estado del interruptor del ventilador C"
+      },
+      "status_fan_f_switch": {
+        "name": "Estado del interruptor del ventilador F"
+      },
+      "status_fan_ln_switch": {
+        "name": "Estado del interruptor del ventilador LN"
+      },
+      "status_fan_r_switch": {
+        "name": "Estado del interruptor del ventilador R"
+      },
+      "status_heater_c_switch": {
+        "name": "Estado del interruptor de la resistencia C"
+      },
+      "status_heater_f_switch": {
+        "name": "Estado del interruptor de la resistencia F"
+      },
+      "status_heater_r_switch": {
+        "name": "Estado del interruptor de la resistencia R"
+      },
+      "steam": {
+        "name": "Vapor"
+      },
+      "steam_assist_time_used": {
+        "name": "Tiempo de asistencia de vapor utilizado"
+      },
+      "steam_reduction_at_door_opening_setting": {
+        "name": "Ajuste de reducci\u00f3n de vapor al abrir la puerta"
+      },
+      "steam_reduction_at_program_end_setting": {
+        "name": "Ajuste de reducci\u00f3n de vapor al final del programa"
+      },
+      "steamenginelackwaterstate": {
+        "name": "Estado de falta de agua del generador de vapor"
       },
       "step1_duration": {
         "name": "Fase 1 duraci\u00f3n"
@@ -1520,6 +7003,42 @@
       "step1_set_temperature": {
         "name": "Fase 1 temperatura"
       },
+      "step1_setmulti_level_baking": {
+        "name": "Horneado multinivel ajustado del paso 1"
+      },
+      "step1_steam_assist_intensity": {
+        "name": "Intensidad de asistencia de vapor del paso 1",
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Media",
+          "not_active": "No activo"
+        }
+      },
+      "step1_steam_assistset_time_in_minutes": {
+        "name": "Tiempo ajustado de asistencia de vapor del paso 1"
+      },
+      "step1add_moist_status": {
+        "name": "Estado de a\u00f1adir humedad paso 1"
+      },
+      "step1add_moiststart_at_minute": {
+        "name": "Minuto de inicio de la aportaci\u00f3n de humedad del paso 1"
+      },
+      "step1add_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad paso 1"
+      },
+      "step1alarm_after_step": {
+        "name": "Alarma tras el paso 1"
+      },
+      "step1grill_intensity": {
+        "name": "Intensidad del grill del paso 1"
+      },
+      "step1pause_after_step": {
+        "name": "Pausa tras el paso 1"
+      },
+      "step1remove_moiststart_at_minute": {
+        "name": "Paso 1: inicio de eliminaci\u00f3n de humedad en el minuto"
+      },
       "step2_duration": {
         "name": "Fase 2 duraci\u00f3n"
       },
@@ -1552,6 +7071,7 @@
           "plates": "Platos",
           "pro_roasting": "Pro tostado",
           "programs": "Programas",
+          "pyrolysis": "Pirolysis",
           "quick": "R\u00e1pido",
           "regenerate": "Regeneraci\u00f3n",
           "sabbath": "Sabbath",
@@ -1569,6 +7089,42 @@
       },
       "step2_set_temperature": {
         "name": "Fase 2 temperatura"
+      },
+      "step2_setmulti_level_baking": {
+        "name": "Horneado multinivel ajustado del paso 2"
+      },
+      "step2_steam_assist_intensity": {
+        "name": "Intensidad de asistencia de vapor del paso 2",
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Media",
+          "not_active": "No activo"
+        }
+      },
+      "step2_steam_assistset_time_in_minutes": {
+        "name": "Tiempo ajustado de asistencia de vapor del paso 2"
+      },
+      "step2add_moist_status": {
+        "name": "Estado de a\u00f1adir humedad paso 2"
+      },
+      "step2add_moiststart_at_minute": {
+        "name": "Minuto de inicio de la aportaci\u00f3n de humedad del paso 2"
+      },
+      "step2add_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad paso 2"
+      },
+      "step2alarm_after_step": {
+        "name": "Alarma tras el paso 2"
+      },
+      "step2grill_intensity": {
+        "name": "Intensidad del grill del paso 2"
+      },
+      "step2pause_after_step": {
+        "name": "Pausa tras el paso 2"
+      },
+      "step2remove_moiststart_at_minute": {
+        "name": "Paso 2: inicio de eliminaci\u00f3n de humedad en el minuto"
       },
       "step3_duration": {
         "name": "Fase 1 duraci\u00f3n"
@@ -1621,11 +7177,866 @@
       "step3_set_temperature": {
         "name": "Fase 3 temperatura"
       },
+      "step3_setmulti_level_baking": {
+        "name": "Horneado multinivel ajustado del paso 3"
+      },
+      "step3_steam_assist_intensity": {
+        "name": "Intensidad de asistencia de vapor del paso 3",
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "medium": "Media",
+          "not_active": "No activo"
+        }
+      },
+      "step3_steam_assistset_time_in_minutes": {
+        "name": "Tiempo ajustado de asistencia de vapor del paso 3"
+      },
+      "step3add_moist_status": {
+        "name": "Estado de a\u00f1adir humedad paso 3"
+      },
+      "step3add_moiststart_at_minute": {
+        "name": "Minuto de inicio de la aportaci\u00f3n de humedad del paso 3"
+      },
+      "step3add_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad paso 3"
+      },
+      "step3alarm_after_step": {
+        "name": "Alarma tras el paso 3"
+      },
+      "step3grill_intensity": {
+        "name": "Intensidad del grill del paso 3"
+      },
+      "step3pause_after_step": {
+        "name": "Pausa tras el paso 3"
+      },
+      "step3remove_moiststart_at_minute": {
+        "name": "Paso 3: inicio de eliminaci\u00f3n de humedad en el minuto"
+      },
+      "step4_bake_mode": {
+        "name": "Modo de cocci\u00f3n del paso 4"
+      },
+      "step4_duration": {
+        "name": "Duraci\u00f3n del paso 4"
+      },
+      "step4_passed_time": {
+        "name": "Tiempo transcurrido del paso 4"
+      },
+      "step4_remaining_time": {
+        "name": "Tiempo restante del paso 4"
+      },
+      "step4_set_heater_system": {
+        "name": "Sistema de calentamiento del paso 4"
+      },
+      "step4_set_microwave_wattage": {
+        "name": "Potencia del microondas ajustada del paso 4"
+      },
+      "step4_set_temperature": {
+        "name": "Temperatura ajustada del paso 4"
+      },
+      "step4_setmulti_level_baking": {
+        "name": "Horneado multinivel ajustado del paso 4"
+      },
+      "step4_status": {
+        "name": "Estado del paso 4"
+      },
+      "step4_steam_available": {
+        "name": "Vapor disponible en el paso 4"
+      },
+      "step4_time_unit": {
+        "name": "Unidad de tiempo del paso 4"
+      },
+      "step4add_moist_status": {
+        "name": "Estado de a\u00f1adir humedad paso 4"
+      },
+      "step4add_moiststart_at_minute": {
+        "name": "Minuto de inicio de la aportaci\u00f3n de humedad del paso 4"
+      },
+      "step4add_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad paso 4"
+      },
+      "step4alarm_after_step": {
+        "name": "Alarma tras el paso 4"
+      },
+      "step4grill_intensity": {
+        "name": "Intensidad del grill del paso 4"
+      },
+      "step4pause_after_step": {
+        "name": "Pausa tras el paso 4"
+      },
+      "step4remove_moiststart_at_minute": {
+        "name": "Paso 4: inicio de eliminaci\u00f3n de humedad en el minuto"
+      },
+      "step4steam_assist": {
+        "name": "Asistencia de vapor paso 4"
+      },
+      "step4steam_assist_intensity": {
+        "name": "Intensidad de asistencia de vapor del paso 4"
+      },
+      "step4steam_assistset_time_in_minutes": {
+        "name": "Tiempo de asistencia de vapor paso 4 en minutos"
+      },
+      "step5_bake_mode": {
+        "name": "Modo de cocci\u00f3n del paso 5"
+      },
+      "step5_duration": {
+        "name": "Duraci\u00f3n del paso 5"
+      },
+      "step5_passed_time": {
+        "name": "Tiempo transcurrido del paso 5"
+      },
+      "step5_remaining_time": {
+        "name": "Tiempo restante del paso 5"
+      },
+      "step5_set_heater_system": {
+        "name": "Sistema de calentamiento del paso 5"
+      },
+      "step5_set_microwave_wattage": {
+        "name": "Potencia del microondas ajustada del paso 5"
+      },
+      "step5_set_temperature": {
+        "name": "Temperatura ajustada del paso 5"
+      },
+      "step5_setmulti_level_baking": {
+        "name": "Horneado multinivel ajustado del paso 5"
+      },
+      "step5_status": {
+        "name": "Estado del paso 5"
+      },
+      "step5_steam_available": {
+        "name": "Vapor disponible en el paso 5"
+      },
+      "step5_time_unit": {
+        "name": "Unidad de tiempo del paso 5"
+      },
+      "step5add_moist_status": {
+        "name": "Estado de a\u00f1adir humedad paso 5"
+      },
+      "step5add_moiststart_at_minute": {
+        "name": "Minuto de inicio de la aportaci\u00f3n de humedad del paso 5"
+      },
+      "step5add_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad paso 5"
+      },
+      "step5alarm_after_step": {
+        "name": "Alarma tras el paso 5"
+      },
+      "step5grill_intensity": {
+        "name": "Intensidad del grill del paso 5"
+      },
+      "step5pause_after_step": {
+        "name": "Pausa tras el paso 5"
+      },
+      "step5remove_moiststart_at_minute": {
+        "name": "Paso 5: inicio de eliminaci\u00f3n de humedad en el minuto"
+      },
+      "step5steam_assist": {
+        "name": "Asistencia de vapor paso 5"
+      },
+      "step5steam_assist_intensity": {
+        "name": "Intensidad de asistencia de vapor del paso 5"
+      },
+      "step5steam_assistset_time_in_minutes": {
+        "name": "Tiempo de asistencia de vapor paso 5 en minutos"
+      },
+      "step_1_duration": {
+        "name": "Duraci\u00f3n del paso 1"
+      },
+      "step_1_passed_time": {
+        "name": "Tiempo transcurrido del paso 1"
+      },
+      "step_1_remaining_time": {
+        "name": "Fase 1 tiempo restante"
+      },
+      "step_1_set_heater_system": {
+        "name": "Sistema de calentamiento del paso 1",
+        "state": {
+          "3d_hot_ai": "Aire caliente 3D",
+          "air_fry": "Fre\u00edr al aire",
+          "aquaclean": "AquaClean",
+          "bake": "Hornear",
+          "bottom": "Abajo",
+          "bottom_infra": "Inferior + infrarrojos",
+          "bottom_infra_fan": "Inferior + infrarrojos + ventilador",
+          "bottom_top_heat": "Calor inferior + superior",
+          "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
+          "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
+          "bottomfan": "Resistencia inferior + ventilador",
+          "broil": "Gratinar",
+          "cleanair": "Limpieza aire",
+          "convection_bake": "Aire caliente",
+          "convection_roast": "Asado por convecci\u00f3n",
+          "count": "Recuento",
+          "crisp": "Crujiente",
+          "defrost": "Descongelar",
+          "defrost_auto": "Descongelado automatico",
+          "dehydrate": "Deshidratar",
+          "descale": "Desincrustar",
+          "eco": "Eco",
+          "ecohotair": "Aire Caliente ECO",
+          "fastpreheat": "Precalentado r\u00e1pido",
+          "frozen_bake": "Horneado de congelados",
+          "gentle_bake": "Horneado suave",
+          "gratin": "Gratinar",
+          "grillfanmicro": "Grill + ventilador + microondas",
+          "hot_air_bottomheat": "Aire caliente + calor inferior",
+          "hot_air_infra": "Aire caliente + infrarrojos",
+          "hot_air_upper": "Aire caliente + calor superior",
+          "hotair": "Aire Caliente",
+          "hotairbottom": "Aire caliente + inferior",
+          "hotairmicro": "Aire caliente + microondas",
+          "hotairsteam1": "Aire caliente + vapor 1",
+          "hotairsteam2": "Aire caliente + vapor 2",
+          "hotairsteam3": "Aire caliente + vapor 3",
+          "keepwarm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_bottom": "Grill grande + inferior",
+          "large_grill_bottom_fan": "Grill grande + inferior + ventilador",
+          "large_grill_bottom_hot_air": "Grill grande + inferior + aire caliente",
+          "large_grill_fan_steam": "Grill grande + ventilador + vapor",
+          "largegrill": "Parrilla grande",
+          "largegrill_pyro": "Grill grande pir\u00f3lisis",
+          "largegrillfan": "Grill grande + ventilador",
+          "largegrillfan_pyro": "Grill grande + ventilador pir\u00f3lisis",
+          "largegrillsteak_pyro": "Grill grande para carne pir\u00f3lisis",
+          "lowtempsteam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "mwclean": "Microondas limpieza",
+          "mwdefrost": "Microondas descongelar",
+          "none": "No centrifugar",
+          "pizza": "Pizza",
+          "plates": "Platos",
+          "programs": "Programas",
+          "proof": "Fermentaci\u00f3n",
+          "proroasting": "Pro tostado",
+          "pyro": "Pyro",
+          "pyrolize": "Pir\u00f3lisis",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "self_clean": "Autolimpieza",
+          "smallgrill": "Parrilla peque\u00f1a",
+          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "sousvide": "Al vacio",
+          "steam": "Vapor",
+          "steamclean": "Limpieza vapor",
+          "top": "Arriba",
+          "topbottom": "Superior + inferior",
+          "undefined": "Sin definir",
+          "warming": "Calentando"
+        }
+      },
+      "step_1_set_temperature": {
+        "name": "Fase 1 temperatura"
+      },
+      "step_1_steam_available": {
+        "name": "Vapor disponible en el paso 1",
+        "state": {
+          "active": "Activo",
+          "available": "Disponible",
+          "not_active": "No activo"
+        }
+      },
+      "step_2_duration": {
+        "name": "Fase 2 duraci\u00f3n"
+      },
+      "step_2_passed_time": {
+        "name": "Tiempo transcurrido del paso 2"
+      },
+      "step_2_remaining_time": {
+        "name": "Tiempo restante del paso 2"
+      },
+      "step_2_set_heater_system": {
+        "name": "Sistema de calentamiento del paso 2",
+        "state": {
+          "3d_hot_ai": "Aire caliente 3D",
+          "air_fry": "Fre\u00edr al aire",
+          "aquaclean": "AquaClean",
+          "bake": "Hornear",
+          "bottom": "Abajo",
+          "bottom_infra": "Inferior + infrarrojos",
+          "bottom_infra_fan": "Inferior + infrarrojos + ventilador",
+          "bottom_top_heat": "Calor inferior + superior",
+          "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
+          "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
+          "bottomfan": "Resistencia inferior + ventilador",
+          "broil": "Gratinar",
+          "cleanair": "Limpieza aire",
+          "convection_bake": "Aire caliente",
+          "convection_roast": "Asado por convecci\u00f3n",
+          "count": "Recuento",
+          "crisp": "Crujiente",
+          "defrost": "Descongelar",
+          "defrost_auto": "Descongelado automatico",
+          "dehydrate": "Deshidratar",
+          "descale": "Desincrustar",
+          "eco": "Eco",
+          "ecohotair": "Aire Caliente ECO",
+          "fastpreheat": "Precalentado r\u00e1pido",
+          "frozen_bake": "Horneado de congelados",
+          "gentle_bake": "Horneado suave",
+          "gratin": "Gratinar",
+          "grillfanmicro": "Grill + ventilador + microondas",
+          "hot_air_bottomheat": "Aire caliente + calor inferior",
+          "hot_air_infra": "Aire caliente + infrarrojos",
+          "hot_air_upper": "Aire caliente + calor superior",
+          "hotair": "Aire Caliente",
+          "hotairbottom": "Aire caliente + inferior",
+          "hotairmicro": "Aire caliente + microondas",
+          "hotairsteam1": "Aire caliente + vapor 1",
+          "hotairsteam2": "Aire caliente + vapor 2",
+          "hotairsteam3": "Aire caliente + vapor 3",
+          "keepwarm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_bottom": "Grill grande + inferior",
+          "large_grill_bottom_fan": "Grill grande + inferior + ventilador",
+          "large_grill_bottom_hot_air": "Grill grande + inferior + aire caliente",
+          "large_grill_fan_steam": "Grill grande + ventilador + vapor",
+          "largegrill": "Parrilla grande",
+          "largegrill_pyro": "Grill grande pir\u00f3lisis",
+          "largegrillfan": "Grill grande + ventilador",
+          "largegrillfan_pyro": "Grill grande + ventilador pir\u00f3lisis",
+          "largegrillsteak_pyro": "Grill grande para carne pir\u00f3lisis",
+          "lowtempsteam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "mwclean": "Microondas limpieza",
+          "mwdefrost": "Microondas descongelar",
+          "none": "No centrifugar",
+          "pizza": "Pizza",
+          "plates": "Platos",
+          "programs": "Programas",
+          "proof": "Fermentaci\u00f3n",
+          "proroasting": "Pro tostado",
+          "pyro": "Pyro",
+          "pyrolize": "Pir\u00f3lisis",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "self_clean": "Autolimpieza",
+          "smallgrill": "Parrilla peque\u00f1a",
+          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "sousvide": "Al vacio",
+          "steam": "Vapor",
+          "steamclean": "Limpieza vapor",
+          "top": "Arriba",
+          "topbottom": "Superior + inferior",
+          "undefined": "Sin definir",
+          "warming": "Calentando"
+        }
+      },
+      "step_2_set_temperature": {
+        "name": "Temperatura ajustada del paso 2"
+      },
+      "step_2_steam_available": {
+        "name": "Vapor disponible en el paso 2",
+        "state": {
+          "active": "Activo",
+          "available": "Disponible",
+          "not_active": "No activo"
+        }
+      },
+      "step_3_duration": {
+        "name": "Duraci\u00f3n del paso 3"
+      },
+      "step_3_passed_time": {
+        "name": "Tiempo transcurrido del paso 3"
+      },
+      "step_3_remaining_time": {
+        "name": "Tiempo restante del paso 3"
+      },
+      "step_3_set_heater_system": {
+        "name": "Sistema de calentamiento del paso 3",
+        "state": {
+          "3d_hot_ai": "Aire caliente 3D",
+          "air_fry": "Fre\u00edr al aire",
+          "aquaclean": "AquaClean",
+          "bake": "Hornear",
+          "bottom": "Abajo",
+          "bottom_infra": "Inferior + infrarrojos",
+          "bottom_infra_fan": "Inferior + infrarrojos + ventilador",
+          "bottom_top_heat": "Calor inferior + superior",
+          "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
+          "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
+          "bottomfan": "Resistencia inferior + ventilador",
+          "broil": "Gratinar",
+          "cleanair": "Limpieza aire",
+          "convection_bake": "Aire caliente",
+          "convection_roast": "Asado por convecci\u00f3n",
+          "count": "Recuento",
+          "crisp": "Crujiente",
+          "defrost": "Descongelar",
+          "defrost_auto": "Descongelado automatico",
+          "dehydrate": "Deshidratar",
+          "descale": "Desincrustar",
+          "eco": "Eco",
+          "ecohotair": "Aire Caliente ECO",
+          "fastpreheat": "Precalentado r\u00e1pido",
+          "frozen_bake": "Horneado de congelados",
+          "gentle_bake": "Horneado suave",
+          "gratin": "Gratinar",
+          "grillfanmicro": "Grill + ventilador + microondas",
+          "hot_air_bottomheat": "Aire caliente + calor inferior",
+          "hot_air_infra": "Aire caliente + infrarrojos",
+          "hot_air_upper": "Aire caliente + calor superior",
+          "hotair": "Aire Caliente",
+          "hotairbottom": "Aire caliente + inferior",
+          "hotairmicro": "Aire caliente + microondas",
+          "hotairsteam1": "Aire caliente + vapor 1",
+          "hotairsteam2": "Aire caliente + vapor 2",
+          "hotairsteam3": "Aire caliente + vapor 3",
+          "keepwarm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_bottom": "Grill grande + inferior",
+          "large_grill_bottom_fan": "Grill grande + inferior + ventilador",
+          "large_grill_bottom_hot_air": "Grill grande + inferior + aire caliente",
+          "large_grill_fan_steam": "Grill grande + ventilador + vapor",
+          "largegrill": "Parrilla grande",
+          "largegrill_pyro": "Grill grande pir\u00f3lisis",
+          "largegrillfan": "Grill grande + ventilador",
+          "largegrillfan_pyro": "Grill grande + ventilador pir\u00f3lisis",
+          "largegrillsteak_pyro": "Grill grande para carne pir\u00f3lisis",
+          "lowtempsteam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "mwclean": "Microondas limpieza",
+          "mwdefrost": "Microondas descongelar",
+          "none": "No centrifugar",
+          "pizza": "Pizza",
+          "plates": "Platos",
+          "programs": "Programas",
+          "proof": "Fermentaci\u00f3n",
+          "proroasting": "Pro tostado",
+          "pyro": "Pyro",
+          "pyrolize": "Pir\u00f3lisis",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "self_clean": "Autolimpieza",
+          "smallgrill": "Parrilla peque\u00f1a",
+          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "sousvide": "Al vacio",
+          "steam": "Vapor",
+          "steamclean": "Limpieza vapor",
+          "top": "Arriba",
+          "topbottom": "Superior + inferior",
+          "undefined": "Sin definir",
+          "warming": "Calentando"
+        }
+      },
+      "step_3_set_temperature": {
+        "name": "Temperatura ajustada del paso 3"
+      },
+      "step_3_status": {
+        "name": "Estado paso 3",
+        "state": {
+          "active": "Activo",
+          "available": "Disponible",
+          "not_active": "No activo"
+        }
+      },
+      "step_3_steam_available": {
+        "name": "Vapor disponible en el paso 3",
+        "state": {
+          "active": "Activo",
+          "available": "Disponible",
+          "not_active": "No activo"
+        }
+      },
+      "step_after_bake_duration": {
+        "name": "Duraci\u00f3n tras la cocci\u00f3n del paso"
+      },
+      "step_after_bake_passed_time": {
+        "name": "Tiempo transcurrido tras el horneado del paso"
+      },
+      "step_after_bake_remaining_time": {
+        "name": "Tiempo restante de la fase posterior al horneado"
+      },
+      "step_after_bake_set_heater_system": {
+        "name": "Sistema de calentamiento del paso posterior al horneado",
+        "state": {
+          "3d_hot_ai": "Aire caliente 3D",
+          "air_fry": "Fre\u00edr al aire",
+          "aquaclean": "AquaClean",
+          "bake": "Hornear",
+          "bottom": "Abajo",
+          "bottom_infra": "Inferior + infrarrojos",
+          "bottom_infra_fan": "Inferior + infrarrojos + ventilador",
+          "bottom_top_heat": "Calor inferior + superior",
+          "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
+          "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
+          "bottomfan": "Resistencia inferior + ventilador",
+          "broil": "Gratinar",
+          "cleanair": "Limpieza aire",
+          "convection_bake": "Aire caliente",
+          "convection_roast": "Asado por convecci\u00f3n",
+          "count": "Recuento",
+          "crisp": "Crujiente",
+          "defrost": "Descongelar",
+          "defrost_auto": "Descongelado automatico",
+          "dehydrate": "Deshidratar",
+          "descale": "Desincrustar",
+          "eco": "Eco",
+          "ecohotair": "Aire Caliente ECO",
+          "fastpreheat": "Precalentado r\u00e1pido",
+          "frozen_bake": "Horneado de congelados",
+          "gentle_bake": "Horneado suave",
+          "gratin": "Gratinar",
+          "grillfanmicro": "Grill + ventilador + microondas",
+          "hot_air_bottomheat": "Aire caliente + calor inferior",
+          "hot_air_infra": "Aire caliente + infrarrojos",
+          "hot_air_upper": "Aire caliente + calor superior",
+          "hotair": "Aire Caliente",
+          "hotairbottom": "Aire caliente + inferior",
+          "hotairmicro": "Aire caliente + microondas",
+          "hotairsteam1": "Aire caliente + vapor 1",
+          "hotairsteam2": "Aire caliente + vapor 2",
+          "hotairsteam3": "Aire caliente + vapor 3",
+          "keepwarm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_bottom": "Grill grande + inferior",
+          "large_grill_bottom_fan": "Grill grande + inferior + ventilador",
+          "large_grill_bottom_hot_air": "Grill grande + inferior + aire caliente",
+          "large_grill_fan_steam": "Grill grande + ventilador + vapor",
+          "largegrill": "Parrilla grande",
+          "largegrill_pyro": "Grill grande pir\u00f3lisis",
+          "largegrillfan": "Grill grande + ventilador",
+          "largegrillfan_pyro": "Grill grande + ventilador pir\u00f3lisis",
+          "largegrillsteak_pyro": "Grill grande para carne pir\u00f3lisis",
+          "lowtempsteam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "mwclean": "Microondas limpieza",
+          "mwdefrost": "Microondas descongelar",
+          "none": "No centrifugar",
+          "pizza": "Pizza",
+          "plates": "Platos",
+          "programs": "Programas",
+          "proof": "Fermentaci\u00f3n",
+          "proroasting": "Pro tostado",
+          "pyro": "Pyro",
+          "pyrolize": "Pir\u00f3lisis",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "self_clean": "Autolimpieza",
+          "smallgrill": "Parrilla peque\u00f1a",
+          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "sousvide": "Al vacio",
+          "steam": "Vapor",
+          "steamclean": "Limpieza vapor",
+          "top": "Arriba",
+          "topbottom": "Superior + inferior",
+          "undefined": "Sin definir",
+          "warming": "Calentando"
+        }
+      },
+      "step_after_bake_set_temperature": {
+        "name": "Temperatura configurada de la fase posterior al horneado"
+      },
+      "step_after_bake_setmulti_level_baking": {
+        "name": "Ajuste de cocci\u00f3n multinivel del paso posterior al horneado"
+      },
+      "step_after_bakeadd_moist_status": {
+        "name": "Estado de aportaci\u00f3n de humedad del paso posterior al horneado"
+      },
+      "step_after_bakeadd_moiststart_at_minute": {
+        "name": "Minuto de inicio de la humedad del paso posterior al horneado"
+      },
+      "step_after_bakeadd_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad en el paso posterior al horneado"
+      },
+      "step_after_bakeremove_moiststart_at_minute": {
+        "name": "Minuto de inicio de la extracci\u00f3n de humedad del paso posterior al horneado"
+      },
+      "step_pre_bake_duration": {
+        "name": "Duraci\u00f3n del paso previo al horneado"
+      },
+      "step_pre_bake_passed_time": {
+        "name": "Tiempo transcurrido antes de la cocci\u00f3n del paso"
+      },
+      "step_pre_bake_remaining_time": {
+        "name": "Tiempo restante del paso de precocci\u00f3n"
+      },
+      "step_pre_bake_set_heater_system": {
+        "name": "Sistema de calentamiento de la fase previa al horneado",
+        "state": {
+          "3d_hot_ai": "Aire caliente 3D",
+          "air_fry": "Fre\u00edr al aire",
+          "aquaclean": "AquaClean",
+          "bake": "Hornear",
+          "bottom": "Abajo",
+          "bottom_infra": "Inferior + infrarrojos",
+          "bottom_infra_fan": "Inferior + infrarrojos + ventilador",
+          "bottom_top_heat": "Calor inferior + superior",
+          "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
+          "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
+          "bottomfan": "Resistencia inferior + ventilador",
+          "broil": "Gratinar",
+          "cleanair": "Limpieza aire",
+          "convection_bake": "Aire caliente",
+          "convection_roast": "Asado por convecci\u00f3n",
+          "count": "Recuento",
+          "crisp": "Crujiente",
+          "defrost": "Descongelar",
+          "defrost_auto": "Descongelado automatico",
+          "dehydrate": "Deshidratar",
+          "descale": "Desincrustar",
+          "eco": "Eco",
+          "ecohotair": "Aire Caliente ECO",
+          "fastpreheat": "Precalentado r\u00e1pido",
+          "frozen_bake": "Horneado de congelados",
+          "gentle_bake": "Horneado suave",
+          "gratin": "Gratinar",
+          "grillfanmicro": "Grill + ventilador + microondas",
+          "hot_air_bottomheat": "Aire caliente + calor inferior",
+          "hot_air_infra": "Aire caliente + infrarrojos",
+          "hot_air_upper": "Aire caliente + calor superior",
+          "hotair": "Aire Caliente",
+          "hotairbottom": "Aire caliente + inferior",
+          "hotairmicro": "Aire caliente + microondas",
+          "hotairsteam1": "Aire caliente + vapor 1",
+          "hotairsteam2": "Aire caliente + vapor 2",
+          "hotairsteam3": "Aire caliente + vapor 3",
+          "keepwarm": "Mantener caliente",
+          "large_grill": "Parrilla grande",
+          "large_grill_bottom": "Grill grande + inferior",
+          "large_grill_bottom_fan": "Grill grande + inferior + ventilador",
+          "large_grill_bottom_hot_air": "Grill grande + inferior + aire caliente",
+          "large_grill_fan_steam": "Grill grande + ventilador + vapor",
+          "largegrill": "Parrilla grande",
+          "largegrill_pyro": "Grill grande pir\u00f3lisis",
+          "largegrillfan": "Grill grande + ventilador",
+          "largegrillfan_pyro": "Grill grande + ventilador pir\u00f3lisis",
+          "largegrillsteak_pyro": "Grill grande para carne pir\u00f3lisis",
+          "lowtempsteam": "Vapor baja temperatura",
+          "micro": "Micro",
+          "mwclean": "Microondas limpieza",
+          "mwdefrost": "Microondas descongelar",
+          "none": "No centrifugar",
+          "pizza": "Pizza",
+          "plates": "Platos",
+          "programs": "Programas",
+          "proof": "Fermentaci\u00f3n",
+          "proroasting": "Pro tostado",
+          "pyro": "Pyro",
+          "pyrolize": "Pir\u00f3lisis",
+          "quick": "R\u00e1pido",
+          "regenerate": "Regeneraci\u00f3n",
+          "sabbath": "Sabbath",
+          "self_clean": "Autolimpieza",
+          "smallgrill": "Parrilla peque\u00f1a",
+          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "sousvide": "Al vacio",
+          "steam": "Vapor",
+          "steamclean": "Limpieza vapor",
+          "top": "Arriba",
+          "topbottom": "Superior + inferior",
+          "undefined": "Sin definir",
+          "warming": "Calentando"
+        }
+      },
+      "step_pre_bake_set_temperature": {
+        "name": "Temperatura ajustada del paso de precocci\u00f3n"
+      },
+      "step_pre_bake_setmulti_level_baking": {
+        "name": "Paso de precocci\u00f3n: horneado multinivel ajustado"
+      },
+      "step_pre_bakeadd_moist_status": {
+        "name": "Estado de humedad de la fase previa al horneado"
+      },
+      "step_pre_bakeadd_moiststart_at_minute": {
+        "name": "Minuto de inicio de la humedad del paso previo al horneado"
+      },
+      "step_pre_bakeadd_moistvalve_open_percentage": {
+        "name": "Porcentaje de apertura de la v\u00e1lvula de humedad del paso previo al horneado"
+      },
+      "step_pre_bakeremove_moiststart_at_minute": {
+        "name": "Minuto de inicio de la extracci\u00f3n de humedad del paso previo al horneado"
+      },
+      "steri_puri_cycle_flag": {
+        "name": "Indicador de ciclo de esterilizaci\u00f3n"
+      },
+      "stoprunning_flag": {
+        "name": "Indicador de parada"
+      },
+      "storage_mode_allowed": {
+        "name": "Modo de almacenamiento permitido"
+      },
+      "storage_mode_on_demand_stat": {
+        "name": "Estado del modo de almacenamiento bajo demanda"
+      },
+      "store_dry_time": {
+        "name": "Tiempo de secado para guardar"
+      },
+      "summerwinter_timeautomatic_setting": {
+        "name": "Ajuste autom\u00e1tico de horario de verano/invierno"
+      },
+      "super_rinse_on_demand": {
+        "name": "Superaclarado a demanda"
+      },
+      "super_rinse_on_demand_allowed": {
+        "name": "Superaclarado bajo demanda permitido"
+      },
+      "super_rinse_status": {
+        "name": "Estado de superaclarado"
+      },
+      "super_water_supply_mode": {
+        "name": "Modo de suministro de agua Super"
+      },
+      "support_preheat_state": {
+        "name": "Estado de precalentamiento compatible"
+      },
+      "synchro_start_level": {
+        "name": "Nivel de inicio sincronizado"
+      },
+      "synchro_stop_level": {
+        "name": "Nivel de parada sincronizada"
+      },
       "t_beep": {
         "name": "Beep"
       },
+      "t_fan_speed": {
+        "name": "Velocidad del ventilador T"
+      },
+      "tankclean": {
+        "name": "Limpieza del dep\u00f3sito"
+      },
+      "tankclean_flag": {
+        "name": "Indicador de limpieza del dep\u00f3sito"
+      },
+      "tankclean_flag1": {
+        "name": "Indicador de limpieza del dep\u00f3sito 1"
+      },
+      "temp_auto_ctrl_mode_exist": {
+        "name": "Existe modo de control autom\u00e1tico de temperatura"
+      },
+      "temp_auto_ctrl_mode_state": {
+        "name": "Estado del modo de control autom\u00e1tico de temperatura"
+      },
+      "temp_index": {
+        "name": "\u00cdndice de temperatura"
+      },
+      "temp_runing_flag": {
+        "name": "Indicador de temperatura en curso"
+      },
+      "temp_wave": {
+        "name": "Onda de temperatura"
+      },
+      "temp_wave_flag": {
+        "name": "Indicador de onda de temperatura"
+      },
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "temperature_0_defaultmainwashtime": {
+        "name": "Tiempo predeterminado de lavado principal a temperatura 0"
+      },
+      "temperature_2_defaultmainwashtime": {
+        "name": "Tiempo predeterminado de lavado principal a temperatura 2"
+      },
+      "temperature_3_defaultmainwashtime": {
+        "name": "Tiempo predeterminado de lavado principal a temperatura 3"
+      },
+      "temperature_4_defaultmainwashtime": {
+        "name": "Tiempo predeterminado de lavado principal a temperatura 4"
+      },
+      "temperature_6_defaultmainwashtime": {
+        "name": "Tiempo predeterminado de lavado principal a temperatura 6"
+      },
+      "temperature_9_defaultmainwashtime": {
+        "name": "Tiempo predeterminado de lavado principal a temperatura 9"
+      },
+      "temperature_default_defaultmainwashtime": {
+        "name": "Temperatura predeterminada, tiempo de lavado principal predeterminado"
+      },
+      "temperature_reached_notification_setting": {
+        "name": "Ajuste de notificaci\u00f3n de temperatura alcanzada"
+      },
       "temperature_room_judge": {
         "name": "Temperature room judge"
+      },
+      "temperature_unit_status": {
+        "name": "Estado de la unidad de temperatura"
+      },
+      "temperaturesensor1": {
+        "name": "Sensor de temperatura 1"
+      },
+      "temperaturesensor2": {
+        "name": "Sensor de temperatura 2"
+      },
+      "temperatureunit": {
+        "name": "Unidad de temperatura",
+        "state": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit"
+        }
+      },
+      "temporarylanguageselected": {
+        "name": "Idioma temporal seleccionado"
+      },
+      "temporarylanguagesettingenabled": {
+        "name": "Ajuste de idioma temporal activado"
+      },
+      "testdata_data": {
+        "name": "Datos de prueba"
+      },
+      "testdata_month": {
+        "name": "Mes de datos de prueba"
+      },
+      "testdata_year": {
+        "name": "A\u00f1o de datos de prueba"
+      },
+      "text_size_setting": {
+        "name": "Ajuste del tama\u00f1o de texto"
+      },
+      "theme_color": {
+        "name": "Color del tema"
+      },
+      "time_autoflag": {
+        "name": "Indicador de tiempo autom\u00e1tico"
+      },
+      "time_program_set_duration_status": {
+        "name": "Duraci\u00f3n del programa temporizado"
+      },
+      "time_program_set_time_status": {
+        "name": "Estado del tiempo ajustado del programa por tiempo"
+      },
+      "time_zone_setting": {
+        "name": "Ajuste de zona horaria"
+      },
+      "timedateautomatic_setting": {
+        "name": "Ajuste autom\u00e1tico de hora y fecha"
+      },
+      "timeremaining": {
+        "name": "Tiempo restante"
+      },
+      "timerendtime": {
+        "name": "Hora de finalizaci\u00f3n del temporizador"
+      },
+      "timerpausedtime": {
+        "name": "Tiempo de pausa del temporizador"
+      },
+      "timerpausedtotalseconds": {
+        "name": "Total de segundos de pausa del temporizador"
+      },
+      "timerstarttime": {
+        "name": "Hora de inicio del temporizador"
+      },
+      "timerstatus": {
+        "name": "Estado del temporizador",
+        "state": {
+          "ended": "Finalizado",
+          "not_active": "No activo",
+          "not_available": "No disponible",
+          "paused": "Pausado",
+          "reserved": "Reservado",
+          "running": "En funcionamiento",
+          "stopped": "Parado"
+        }
+      },
+      "timezone": {
+        "name": "Zona horaria"
+      },
+      "total_duration_in_seconds": {
+        "name": "Duraci\u00f3n total"
       },
       "total_energy_consumption": {
         "name": "Total consumo de energia"
@@ -1633,10 +8044,19 @@
       "total_number_of_cycles": {
         "name": "N\u00famero total de ciclos"
       },
+      "total_oven_usage_value": {
+        "name": "Valor de uso total del horno"
+      },
       "total_passed_time": {
         "name": "Tiempo transcurrido"
       },
+      "total_passed_time_seconds": {
+        "name": "Tiempo transcurrido"
+      },
       "total_remaining_time": {
+        "name": "Tiempo restante"
+      },
+      "total_remaining_time_seconds": {
         "name": "Tiempo restante"
       },
       "total_run_time": {
@@ -1645,11 +8065,77 @@
       "total_time_of_cooking_in_hours": {
         "name": "Tiempo total cocinado"
       },
+      "total_time_of_cooking_in_minute": {
+        "name": "Tiempo total cocinado"
+      },
       "total_water_consumption": {
         "name": "Total agua consumida"
       },
+      "totalprogramcycles": {
+        "name": "Total de ciclos de programa"
+      },
+      "totalprogramscycles": {
+        "name": "Total de ciclos de programa"
+      },
+      "unfreeze_run_status": {
+        "name": "Estado de funcionamiento de descongelaci\u00f3n"
+      },
+      "unfreeze_switch_status": {
+        "name": "Estado del interruptor de descongelaci\u00f3n"
+      },
+      "unpair_all_users": {
+        "name": "Desvincular todos los usuarios"
+      },
+      "user_debacilli_mode": {
+        "name": "Modo antibacterias del usuario"
+      },
       "utc_datetime_bdc_delaystart_delayend_timestamp": {
         "name": "BDC DelayStart DelayEnd"
+      },
+      "uv_light": {
+        "name": "Luz UV"
+      },
+      "uv_mode_on_demand": {
+        "name": "Modo UV a demanda"
+      },
+      "uv_mode_on_demand_allowed": {
+        "name": "Modo UV a demanda permitido"
+      },
+      "uv_steri_status": {
+        "name": "Estado de esterilizaci\u00f3n UV"
+      },
+      "uv_sterilization": {
+        "name": "Esterilizaci\u00f3n UV"
+      },
+      "var_room_open_2": {
+        "name": "Sala variable abierta 2"
+      },
+      "vari_fan_speed": {
+        "name": "Velocidad variable del ventilador"
+      },
+      "vari_key": {
+        "name": "Tecla Vari"
+      },
+      "vari_room": {
+        "name": "Compartimento variable"
+      },
+      "variable_temperature_space": {
+        "name": "Zona de temperatura variable"
+      },
+      "variation_door_open_time": {
+        "name": "Variaci\u00f3n del tiempo de puerta abierta"
+      },
+      "variation_max_temperature": {
+        "name": "Variaci\u00f3n temperatura m\u00e1xima"
+      },
+      "variation_min_temperature": {
+        "name": "Variaci\u00f3n temperatura m\u00ednima"
+      },
+      "variation_poweroff_ad": {
+        "name": "Variaci\u00f3n de anuncio de apagado"
+      },
+      "variation_poweron_ad": {
+        "name": "Variaci\u00f3n de encendido publicitario"
       },
       "variation_real_temperature": {
         "name": "Variacion real de temperatura"
@@ -1657,8 +8143,315 @@
       "variation_sensor_real_temperature": {
         "name": "Sensor variaci\u00f3n real de temperatura"
       },
+      "volume_setting": {
+        "name": "Ajuste de volumen"
+      },
+      "warmwaterwashing": {
+        "name": "Lavado con agua caliente"
+      },
+      "wash_step_time_drain_water_spin_and_stop": {
+        "name": "Tiempo del paso de lavado: desag\u00fce, centrifugado y parada"
+      },
+      "washer_to_dryer_available_for_hours_v": {
+        "name": "Horas disponibles de lavadora a secadora v"
+      },
+      "washer_to_dryer_program_id": {
+        "name": "ID de programa de lavadora a secadora"
+      },
+      "washer_to_dryerwizard_trigger_status": {
+        "name": "Estado de activaci\u00f3n del asistente de lavadora a secadora"
+      },
+      "washfunction1": {
+        "name": "Funci\u00f3n de lavado 1"
+      },
+      "washing_drying_linkage_flag": {
+        "name": "Indicador de enlace lavado-secado"
+      },
+      "washing_drying_linkage_state": {
+        "name": "Estado de vinculaci\u00f3n lavado-secado"
+      },
+      "washing_machine_type": {
+        "name": "Tipo de lavadora"
+      },
+      "washing_machine_type_kg": {
+        "name": "Tipo de lavadora en kg"
+      },
+      "washing_machine_type_max_speed": {
+        "name": "Velocidad m\u00e1xima seg\u00fan tipo de lavadora"
+      },
+      "washing_program_kg": {
+        "name": "Peso del programa de lavado"
+      },
+      "washingtime": {
+        "name": "Tiempo de lavado"
+      },
+      "washingtime_presoak_flag": {
+        "name": "Indicador de prerremojo del tiempo de lavado"
+      },
+      "washingtime_useindex": {
+        "name": "\u00cdndice de uso del tiempo de lavado"
+      },
+      "washingtime_waterlevel_flag": {
+        "name": "Indicador del nivel de agua del tiempo de lavado"
+      },
+      "washingtimeindex": {
+        "name": "\u00cdndice de tiempo de lavado"
+      },
+      "washingwizzard_cloth": {
+        "name": "Tejido del asistente de lavado"
+      },
+      "washingwizzard_cloth_colour": {
+        "name": "Color de la ropa del asistente de lavado"
+      },
+      "washingwizzard_cloth_colour_fifth": {
+        "name": "Color de la ropa (quinta) del asistente de lavado"
+      },
+      "washingwizzard_cloth_colour_fourth": {
+        "name": "Asistente de lavado: color de la prenda 4"
+      },
+      "washingwizzard_cloth_colour_second": {
+        "name": "Asistente de lavado: color de la prenda 2"
+      },
+      "washingwizzard_cloth_colour_third": {
+        "name": "Color de la ropa (tercera) del asistente de lavado"
+      },
+      "washingwizzard_cloth_dirty": {
+        "name": "Suciedad de la ropa del asistente de lavado"
+      },
+      "washingwizzard_cloth_dirty_first": {
+        "name": "Suciedad de la ropa (primera) del asistente de lavado"
+      },
+      "washingwizzard_cloth_dirty_second": {
+        "name": "Suciedad de la ropa (segunda) del asistente de lavado"
+      },
+      "washingwizzard_cloth_dirty_third": {
+        "name": "Suciedad de la ropa (tercera) del asistente de lavado"
+      },
+      "washingwizzard_cloth_olour_first": {
+        "name": "Color de la ropa (primera) del asistente de lavado"
+      },
+      "washingwizzard_cloth_sensitive": {
+        "name": "Asistente de lavado ropa delicada"
+      },
+      "washingwizzard_cloth_sensitive_first": {
+        "name": "Asistente de lavado: sensibilidad de la prenda 1"
+      },
+      "washingwizzard_cloth_sensitive_second": {
+        "name": "Sensibilidad del tejido del asistente de lavado, segundo"
+      },
+      "washingwizzard_cloth_sensitive_third": {
+        "name": "Asistente de lavado: sensibilidad de la prenda 3"
+      },
+      "washingwizzard_cloth_stains_eighth": {
+        "name": "Asistente de lavado: manchas de la prenda 8"
+      },
+      "washingwizzard_cloth_stains_fifth": {
+        "name": "Manchas de la ropa (quinta) del asistente de lavado"
+      },
+      "washingwizzard_cloth_stains_first": {
+        "name": "Manchas de la ropa (primera) del asistente de lavado"
+      },
+      "washingwizzard_cloth_stains_fourth": {
+        "name": "Asistente de lavado: manchas de la prenda 4"
+      },
+      "washingwizzard_cloth_stains_ninth": {
+        "name": "Manchas de la ropa (novena) del asistente de lavado"
+      },
+      "washingwizzard_cloth_stains_second": {
+        "name": "Asistente de lavado: manchas de la prenda 2"
+      },
+      "washingwizzard_cloth_stains_seventh": {
+        "name": "Asistente de lavado: manchas de la prenda 7"
+      },
+      "washingwizzard_cloth_stains_sixth": {
+        "name": "Manchas de la ropa (sexta) del asistente de lavado"
+      },
+      "washingwizzard_cloth_stains_third": {
+        "name": "Manchas de la ropa (tercera) del asistente de lavado"
+      },
+      "washingwizzard_clothingtype": {
+        "name": "Tipo de prenda del asistente de lavado"
+      },
+      "washingwizzard_clothingtype_eighth": {
+        "name": "Asistente de lavado: tipo de prenda 8"
+      },
+      "washingwizzard_clothingtype_eleventh": {
+        "name": "Tipo de ropa del asistente de lavado, und\u00e9cimo"
+      },
+      "washingwizzard_clothingtype_fifth": {
+        "name": "Asistente de lavado: tipo de prenda 5"
+      },
+      "washingwizzard_clothingtype_first": {
+        "name": "Asistente de lavado: tipo de prenda 1"
+      },
+      "washingwizzard_clothingtype_fourth": {
+        "name": "Asistente de lavado: tipo de prenda 4"
+      },
+      "washingwizzard_clothingtype_ninth": {
+        "name": "Asistente de lavado: tipo de prenda 9"
+      },
+      "washingwizzard_clothingtype_second": {
+        "name": "Asistente de lavado: tipo de prenda 2"
+      },
+      "washingwizzard_clothingtype_seventh": {
+        "name": "Asistente de lavado: tipo de prenda 7"
+      },
+      "washingwizzard_clothingtype_sixth": {
+        "name": "Asistente de lavado: tipo de prenda 6"
+      },
+      "washingwizzard_clothingtype_tenth": {
+        "name": "Asistente de lavado: tipo de prenda 10"
+      },
+      "washingwizzard_clothingtype_third": {
+        "name": "Asistente de lavado: tipo de prenda 3"
+      },
+      "washingwizzard_clothingtype_thirteenth": {
+        "name": "Tipo de ropa del asistente de lavado, decimotercero"
+      },
+      "washingwizzard_clothingtype_twelfth": {
+        "name": "Asistente de lavado: tipo de prenda 12"
+      },
+      "washingwizzard_flag": {
+        "name": "Indicador del asistente de lavado"
+      },
+      "washstepfinishnotifyswitch": {
+        "name": "Interruptor de aviso de fin del lavado"
+      },
+      "water_box_alarm_switch_state": {
+        "name": "Estado del interruptor de alarma del dep\u00f3sito de agua"
+      },
+      "water_box_lack_status": {
+        "name": "Estado de falta de agua en el dep\u00f3sito"
+      },
+      "water_box_mode_status": {
+        "name": "Estado del modo de dep\u00f3sito de agua"
+      },
+      "water_consumption": {
+        "name": "Consumo de agua"
+      },
       "water_consumption_in_running_program": {
         "name": "Agua consumida en programa actual"
+      },
+      "water_estimate": {
+        "name": "Estimaci\u00f3n de agua"
+      },
+      "water_fill_actual_temp": {
+        "name": "Temperatura real del llenado de agua"
+      },
+      "water_filter_surplus_time": {
+        "name": "Tiempo restante del filtro de agua"
+      },
+      "water_filter_time_reset": {
+        "name": "Reinicio del tiempo del filtro de agua"
+      },
+      "water_hardness_setting": {
+        "name": "Ajuste de dureza del agua"
+      },
+      "water_heat_switch": {
+        "name": "Interruptor de calentamiento de agua"
+      },
+      "water_inlet_setting_status": {
+        "name": "Entrada de agua"
+      },
+      "water_save_setting_status": {
+        "name": "Ahorro de agua"
+      },
+      "water_tank": {
+        "name": "Dep\u00f3sito de agua",
+        "state": {
+          "not_detected": "No detectado",
+          "present": "Presente"
+        }
+      },
+      "water_tank_install_state": {
+        "name": "Estado de instalaci\u00f3n del dep\u00f3sito de agua"
+      },
+      "water_tank_level": {
+        "name": "Nivel del dep\u00f3sito de agua"
+      },
+      "waterlevel": {
+        "name": "Nivel de agua"
+      },
+      "waterlevel_runing_flag": {
+        "name": "Indicador de nivel de agua en curso"
+      },
+      "waterlevelflag": {
+        "name": "Indicador de nivel de agua"
+      },
+      "waterlevelindex": {
+        "name": "\u00cdndice de nivel de agua"
+      },
+      "wear_dry_time": {
+        "name": "Tiempo de secado listo para usar"
+      },
+      "weight_runningend": {
+        "name": "Fin de la medici\u00f3n de peso"
+      },
+      "weight_startrunning": {
+        "name": "Peso al iniciar"
+      },
+      "weight_unit_setting": {
+        "name": "Ajuste de unidad de peso"
+      },
+      "wet_and_dry_space": {
+        "name": "Espacio h\u00famedo y seco"
+      },
+      "wifi_fault_flag": {
+        "name": "Indicador de fallo de WiFi"
+      },
+      "wifi_handshake_fault_flag": {
+        "name": "Indicador de fallo de conexi\u00f3n WiFi"
+      },
+      "wifi_next_sendtime": {
+        "name": "Pr\u00f3ximo env\u00edo WiFi"
+      },
+      "wifi_rx_fault_flag": {
+        "name": "Indicador de fallo de recepci\u00f3n WiFi"
+      },
+      "wifi_setting": {
+        "name": "Ajuste de WiFi"
+      },
+      "wifi_tx_fault_flag": {
+        "name": "Indicador de fallo de transmisi\u00f3n WiFi"
+      },
+      "wild_vegetable_heat_switch": {
+        "name": "Interruptor de calor para verduras silvestres"
+      },
+      "will_fresh_light_status": {
+        "name": "Estado de la luz de frescura"
+      },
+      "will_fress_light_exist": {
+        "name": "Existencia de luz de frescura"
+      },
+      "will_light_market_mode_state": {
+        "name": "Estado del modo tienda de la iluminaci\u00f3n"
+      },
+      "will_light_mode_exist": {
+        "name": "Existe el modo de luz"
+      },
+      "will_light_mode_state": {
+        "name": "Estado del modo de luz"
+      },
+      "will_light_switch_state": {
+        "name": "Estado del interruptor de luz"
+      },
+      "winddrying": {
+        "name": "Secado por aire"
+      },
+      "winddryingflag": {
+        "name": "Indicador de secado por aire"
+      },
+      "window_status": {
+        "name": "Estado de la ventana"
+      },
+      "wine_area_switch_status": {
+        "name": "Estado del interruptor de la zona de vinos"
+      },
+      "wine_b_switch_area": {
+        "name": "Zona conmutable B de vino"
+      },
+      "wine_light": {
+        "name": "Luz de la vinoteca"
       },
       "wine_zone_lower_real_temperature": {
         "name": "Temperatura zona inferior"
@@ -1666,22 +8459,103 @@
       "wine_zone_upper_real_temperature": {
         "name": "Temperatura zona superior"
       },
+      "work_mode1": {
+        "name": "Modo de trabajo 1"
+      },
+      "work_mode2": {
+        "name": "Modo de trabajo 2"
+      },
+      "zibian_program_id": {
+        "name": "ID de programa Zibian"
+      },
       "zone_number": {
         "name": "N\u00famero de zonas"
       }
     },
     "switch": {
+      "activemodelightstatus": {
+        "name": "Luz de modo activo"
+      },
+      "activemodemotorlevelstatus": {
+        "name": "Motor de modo activo"
+      },
+      "activemodestatus": {
+        "name": "Modo activo"
+      },
+      "adapt_sense_setting_status": {
+        "name": "Detecci\u00f3n adaptativa"
+      },
+      "adaptive_sense_setting": {
+        "name": "Ajuste de detecci\u00f3n adaptativa"
+      },
+      "addclothes": {
+        "name": "A\u00f1adir ropa"
+      },
+      "air_shower_setting_status": {
+        "name": "Ducha de aire"
+      },
+      "allergymodeenable": {
+        "name": "Modo antialergias"
+      },
+      "ambientlightstatus": {
+        "name": "Luz ambiental"
+      },
       "anticrease": {
         "name": "Antiarrugas"
       },
+      "aus_zone1_power": {
+        "name": "Zona 1"
+      },
+      "aus_zone2_power": {
+        "name": "Zona 2"
+      },
+      "aus_zone3_power": {
+        "name": "Zona 3"
+      },
+      "aus_zone4_power": {
+        "name": "Zona 4"
+      },
+      "aus_zone5_power": {
+        "name": "Zona 5"
+      },
+      "aus_zone6_power": {
+        "name": "Zona 6"
+      },
+      "aus_zone7_power": {
+        "name": "Zona 7"
+      },
+      "aus_zone8_power": {
+        "name": "Zona 8"
+      },
       "auto_dose_setting_status": {
+        "name": "Configuracion autodosificador"
+      },
+      "auto_dose_system_setting_status": {
+        "name": "Sistema de dosificaci\u00f3n autom\u00e1tica"
+      },
+      "auto_fast_preheat": {
+        "name": "Precalentamiento r\u00e1pido autom\u00e1tico"
+      },
+      "auto_super_rinse_setting_status": {
+        "name": "Superaclarado autom\u00e1tico"
+      },
+      "autodose": {
         "name": "Configuracion autodosificador"
       },
       "automatic_ice_making": {
         "name": "Fabricaci\u00f3n autom\u00e1tica de hielo"
       },
+      "autotubclean": {
+        "name": "Autolimpieza del tambor"
+      },
+      "buzzer_setting": {
+        "name": "Zumbador"
+      },
       "child_lock": {
         "name": "Bloqueo para ni\u00f1os"
+      },
+      "child_lock_setting_status": {
+        "name": "Bloqueo ni\u00f1os"
       },
       "child_lock_status": {
         "name": "Bloqueo ni\u00f1os"
@@ -1692,20 +8566,131 @@
       "child_lock_switch_status": {
         "name": "Bloqueo para ni\u00f1os"
       },
+      "childlockenabled": {
+        "name": "Bloqueo ni\u00f1os"
+      },
+      "cleanairstatus": {
+        "name": "Limpieza aire"
+      },
+      "cleaning_reminder_setting": {
+        "name": "Recordatorio de limpieza"
+      },
+      "coldwash": {
+        "name": "Lavado en fr\u00edo"
+      },
+      "color_sensor_setting_status": {
+        "name": "Sensor de color"
+      },
+      "crisp_function_status": {
+        "name": "Estado de la funci\u00f3n crujiente"
+      },
+      "demo_mode": {
+        "name": "Modo demostraci\u00f3n"
+      },
+      "demo_mode_status": {
+        "name": "Modo demostraci\u00f3n"
+      },
+      "display_standby": {
+        "name": "Pantalla en espera"
+      },
+      "dose_assist_status": {
+        "name": "Asistente de dosificaci\u00f3n"
+      },
+      "drum_illumination": {
+        "name": "Luz tambor"
+      },
       "drum_light": {
         "name": "Luz tambor"
+      },
+      "drum_light_setting_status": {
+        "name": "Luz tambor"
+      },
+      "drumvleanprogramwarning": {
+        "name": "Aviso del programa de limpieza del tambor"
+      },
+      "extra_rinse": {
+        "name": "Aclarado extra"
+      },
+      "extra_rinse_status": {
+        "name": "Aclarado extra"
+      },
+      "extrarinse": {
+        "name": "Aclarado extra"
+      },
+      "fota_cmd": {
+        "name": "Actualizaci\u00f3n de firmware"
+      },
+      "greasefilterstatus": {
+        "name": "Temporizador de filtro de grasa"
+      },
+      "heater2enable": {
+        "name": "Calentador auxiliar"
+      },
+      "heating_power_setting": {
+        "name": "Potencia de calentamiento"
+      },
+      "heatingsteps": {
+        "name": "Niveles de calentamiento"
+      },
+      "hide_setting": {
+        "name": "Ocultar ajuste"
       },
       "holiday_mode": {
         "name": "Modo vacaciones"
       },
+      "ice_making_b_switch_status": {
+        "name": "Estado del interruptor de producci\u00f3n de hielo B"
+      },
+      "ice_making_state": {
+        "name": "Estado de fabricaci\u00f3n de hielo"
+      },
+      "interior_light": {
+        "name": "Luz interior"
+      },
+      "interior_light_at_power_off_setting_status": {
+        "name": "Luz interior al apagar"
+      },
+      "key_sound": {
+        "name": "Sonido de teclas"
+      },
+      "lightstatus": {
+        "name": "Luz"
+      },
+      "logo_setting_status": {
+        "name": "Logo"
+      },
       "mute": {
         "name": "Silenciar"
+      },
+      "natural_dry": {
+        "name": "Secado natural"
+      },
+      "night_mode_status": {
+        "name": "Estado del modo noche"
       },
       "no_sound_status": {
         "name": "Silencio"
       },
+      "notification_setting": {
+        "name": "Notificaciones"
+      },
+      "odor_control_setting": {
+        "name": "Control de olores"
+      },
+      "power_save_status": {
+        "name": "Ahorro de energ\u00eda"
+      },
       "prewash": {
         "name": "Prelavado"
+      },
+      "programoptionanticrease": {
+        "name": "Antiarrgas "
+      },
+      "proximitysensorsetavalibility": {
+        "name": "Sensor de proximidad disponible"
+      },
+      "proximitysensorstatus": {
+        "name": "Sensor de proximidad"
       },
       "sabbath_mode_switch_status": {
         "name": "Modo Sabbath"
@@ -1713,20 +8698,104 @@
       "save_mode": {
         "name": "Modo ahorro"
       },
+      "selected_program_anticrease_status": {
+        "name": "Antiarrgas "
+      },
+      "selected_program_entry_steam_status": {
+        "name": "Vapor inicial"
+      },
+      "selected_program_prewash_status": {
+        "name": "Prelavado"
+      },
+      "selected_program_rinse_hold_status": {
+        "name": "Mantener aclarado"
+      },
+      "selected_program_small_load_status": {
+        "name": "Carga reducida"
+      },
+      "selected_program_water_pluse_status": {
+        "name": "Pulso de agua"
+      },
+      "session_pairing_status": {
+        "name": "Emparejamiento de sesi\u00f3n"
+      },
+      "sf_mode": {
+        "name": "Modo SF"
+      },
+      "sf_sr_mutex_mode": {
+        "name": "Modo exclusivo SF/SR"
+      },
+      "showmeasuredtemperature": {
+        "name": "Mostrar temperatura medida"
+      },
+      "smart_sync_setting": {
+        "name": "Sincronizaci\u00f3n inteligente"
+      },
+      "smart_sync_setting_status": {
+        "name": "Sincronizaci\u00f3n inteligente"
+      },
+      "soft_pairing_status": {
+        "name": "Emparejamiento suave"
+      },
+      "sound": {
+        "name": "Sonido"
+      },
+      "sr_mode": {
+        "name": "Modo SR"
+      },
       "standby_mode_status": {
         "name": "Modo en espera"
+      },
+      "startdelayfunction": {
+        "name": "Inicio diferido"
       },
       "steam": {
         "name": "Vapor"
       },
+      "step_1_fastpreheat_function": {
+        "name": "Funci\u00f3n de precalentamiento r\u00e1pido del paso 1"
+      },
+      "step_after_bake_status": {
+        "name": "Estado del paso posterior al horneado"
+      },
+      "step_pre_bake_status": {
+        "name": "Estado previo al horneado"
+      },
+      "super_rinse_setting_status": {
+        "name": "Superaclarado"
+      },
+      "t_8heat": {
+        "name": "Protecci\u00f3n antihielo"
+      },
       "t_air": {
         "name": "Aire"
+      },
+      "t_anion": {
+        "name": "Ionizador"
+      },
+      "t_dal": {
+        "name": "DAL"
+      },
+      "t_demand_response": {
+        "name": "Respuesta a la demanda"
+      },
+      "t_dimmer": {
+        "name": "Regulador"
       },
       "t_eco": {
         "name": "Eco"
       },
       "t_fan_mute": {
         "name": "Silenciar ventilador"
+      },
+      "t_fresh_air": {
+        "name": "Aire fresco"
+      },
+      "t_left_right": {
+        "name": "Oscilaci\u00f3n horizontal"
+      },
+      "t_pump": {
+        "name": "Bomba"
       },
       "t_purify": {
         "name": "Purificador"
@@ -1740,11 +8809,32 @@
       "t_super": {
         "name": "Super"
       },
+      "t_talr": {
+        "name": "TALR"
+      },
       "t_tms": {
         "name": "AI"
       },
       "t_up_down": {
         "name": "Oscilaci\u00f3n vertical"
+      },
+      "tab_setting_status": {
+        "name": "Pastilla de detergente"
+      },
+      "time_save": {
+        "name": "Ahorro de tiempo"
+      },
+      "time_save_status": {
+        "name": "Ahorro de tiempo"
+      },
+      "turbidity_sensor_setting_status": {
+        "name": "Sensor de turbidez"
+      },
+      "washer_to_dryersetting_status": {
+        "name": "Sincronizaci\u00f3n lavadora-secadora"
+      },
+      "welcome": {
+        "name": "Bienvenida"
       },
       "wine_light": {
         "name": "Luz de la vinoteca"
@@ -1759,6 +8849,29 @@
     }
   },
   "issues": {
+    "orphaned_statistics": {
+      "fix_flow": {
+        "abort": {
+          "entry_not_loaded": "La entrada de configuraci\u00f3n de ConnectLife ya no est\u00e1 cargada.",
+          "issue_ignored": "Se ignoraron las estad\u00edsticas a largo plazo hu\u00e9rfanas de los sensores de ConnectLife."
+        },
+        "step": {
+          "clear": {
+            "description": "Esto eliminar\u00e1 permanentemente las estad\u00edsticas a largo plazo de {count} sensores de ConnectLife. \u00bfContinuar?",
+            "title": "Borrar estad\u00edsticas a largo plazo hu\u00e9rfanas"
+          },
+          "init": {
+            "description": "{count} sensores de ConnectLife tienen estad\u00edsticas a largo plazo (LTS) almacenadas, pero ya no informan de una clase de estado. Home Assistant emite una reparaci\u00f3n independiente para cada uno.\n\nEsto se debe a un cambio reciente en la integraci\u00f3n: las propiedades num\u00e9ricas ya no toman `state_class: measurement` de forma predeterminada, por lo que los c\u00f3digos de estado, los indicadores de modo y las consignas ya no se registran como LTS.\n\n**Borrar estad\u00edsticas hu\u00e9rfanas** elimina las filas de LTS almacenadas de los {count} sensores de una sola vez. Los datos hist\u00f3ricos de estos sensores en Ajustes \u2192 Estad\u00edsticas se eliminar\u00e1n y no podr\u00e1n recuperarse. Las reparaciones por entidad de Home Assistant desaparecer\u00e1n la pr\u00f3xima vez que Home Assistant vuelva a validar las estad\u00edsticas, lo que ocurre al abrir Herramientas para desarrolladores \u2192 Estad\u00edsticas. Esta reparaci\u00f3n masiva no volver\u00e1 a aparecer en esta entrada de configuraci\u00f3n.\n\n**Ignorar** oculta esta acci\u00f3n masiva y mantiene las reparaciones por entidad; corrige o ignora cada una individualmente si quieres un control m\u00e1s preciso sobre qu\u00e9 sensores conservan su historial. Puedes volver a la acci\u00f3n masiva m\u00e1s tarde seleccionando \u00abMostrar reparaciones ignoradas\u00bb en el men\u00fa desplegable de la parte superior derecha de Ajustes \u2192 Reparaciones y reabriendo esta reparaci\u00f3n.\n\nPara revisar las reparaciones de sensores individuales antes de decidir, simplemente cierra esta ventana: la reparaci\u00f3n masiva permanece disponible tal cual.\n\nNota: este problema se marca como cr\u00edtico solo para que aparezca por encima de las reparaciones del registrador por entidad. No es urgente.",
+            "menu_options": {
+              "clear": "Borrar estad\u00edsticas hu\u00e9rfanas",
+              "ignore": "Ignorar"
+            },
+            "title": "Estad\u00edsticas a largo plazo hu\u00e9rfanas ({count} sensores)"
+          }
+        }
+      },
+      "title": "Estad\u00edsticas a largo plazo hu\u00e9rfanas ({count} sensores)"
+    },
     "unavailable_device": {
       "fix_flow": {
         "abort": {
@@ -1780,6 +8893,24 @@
         }
       },
       "title": "{device_name} no est\u00e1 disponible"
+    },
+    "unsupported_beep": {
+      "fix_flow": {
+        "abort": {
+          "issue_ignored": "Se ignor\u00f3 \u00abLa desactivaci\u00f3n del pitido no es compatible con {device_name}\u00bb."
+        },
+        "step": {
+          "init": {
+            "description": "El dispositivo \u00ab{device_name}\u00bb no admite la opci\u00f3n de desactivar el pitido.",
+            "menu_options": {
+              "confirm": "Actualizar configuraci\u00f3n",
+              "ignore": "Ignorar"
+            },
+            "title": "Desactivar el pitido no es compatible con {device_name}"
+          }
+        }
+      },
+      "title": "Desactivar el pitido no es compatible con {device_name}"
     }
   },
   "options": {
@@ -1807,7 +8938,27 @@
       }
     }
   },
+  "selector": {
+    "actions": {
+      "options": {
+        "1": "Detener",
+        "2": "Iniciar",
+        "3": "Pausa",
+        "4": "Abrir puerta"
+      }
+    }
+  },
   "services": {
+    "set_action": {
+      "description": "Establece la acci\u00f3n del dispositivo. Usar con precauci\u00f3n.",
+      "fields": {
+        "action": {
+          "description": "Acci\u00f3n a establecer.",
+          "name": "Acci\u00f3n"
+        }
+      },
+      "name": "Establecer acci\u00f3n"
+    },
     "set_value": {
       "description": "Asignar valor al estado. Usar con cuidado.",
       "fields": {
@@ -1817,6 +8968,16 @@
         }
       },
       "name": "Asignar valor"
+    },
+    "update": {
+      "description": "Actualiza todas las propiedades definidas en el campo de datos.",
+      "fields": {
+        "data": {
+          "description": "Propiedades que se deben actualizar",
+          "name": "Datos"
+        }
+      },
+      "name": "Actualizar dispositivo"
     }
   }
 }

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -114,7 +114,7 @@
         "name": "Alarma de horneado finalizada"
       },
       "alarm_baking_stoped": {
-        "name": "Alarma de cocci\u00f3n detenida"
+        "name": "Alarma de horneado detenido"
       },
       "alarm_child_lock_deactivated_on_the_oven": {
         "name": "Alarma de bloqueo infantil desactivada en el horno"
@@ -468,7 +468,7 @@
         "name": "Tiempo restante del filtro de carb\u00f3n"
       },
       "charcoal_filter_time_reset": {
-        "name": "Restablecimiento del tiempo del filtro de carb\u00f3n"
+        "name": "Restablecimiento del tiempo del filtro de carb\u00f3n activo"
       },
       "chef_mode": {
         "name": "Modo chef"
@@ -831,7 +831,7 @@
         "name": "Error 9"
       },
       "existing_fuzzy_mode": {
-        "name": "Modo difuso existente"
+        "name": "Modo fuzzy existente"
       },
       "existing_holiday_mode": {
         "name": "Modo vacaciones activo"
@@ -897,7 +897,7 @@
         "name": "Fallo de detecci\u00f3n de cruce por cero de la tensi\u00f3n interior"
       },
       "f_e_inwifi": {
-        "name": "Fallo de comunicaci\u00f3n entre el panel de control WiFi y el panel de control interior"
+        "name": "Fallo de comunicaci\u00f3n entre el panel de control Wi-Fi y el panel de control interior"
       },
       "f_e_outcoiltemp": {
         "name": "Fallo del sensor de temperatura de la bater\u00eda exterior"
@@ -969,7 +969,7 @@
         "name": "Falla en el cabezal sensor de temperatura del congelador"
       },
       "freeze_poweroff_ad": {
-        "name": "Anuncio de apagado por congelaci\u00f3n"
+        "name": "Aviso de apagado por congelaci\u00f3n"
       },
       "freeze_poweron_ad": {
         "name": "Anuncio de encendido por congelaci\u00f3n"
@@ -1053,7 +1053,7 @@
         "name": "Luz"
       },
       "lock_fresh_mode": {
-        "name": "Bloqueo del modo frescor"
+        "name": "Bloqueo del modo Fresco"
       },
       "low_wine_area_c_evaporator_fault": {
         "name": "Fallo del evaporador del \u00e1rea baja c de vino"
@@ -1263,7 +1263,7 @@
         "name": "La zona 1 se apaga autom\u00e1ticamente"
       },
       "sl1_alarm_ntc_coil": {
-        "name": "Alarma NTC de la resistencia de la zona 1"
+        "name": "Alarma NTC del serpent\u00edn de la zona 1"
       },
       "sl1_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 1"
@@ -1347,7 +1347,7 @@
         "name": "La zona 2 se apaga autom\u00e1ticamente"
       },
       "sl2_alarm_ntc_coil": {
-        "name": "Alarma NTC de la resistencia de la zona 2"
+        "name": "Alarma NTC del serpent\u00edn de la zona 2"
       },
       "sl2_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 2"
@@ -1431,7 +1431,7 @@
         "name": "La zona 3 se apaga autom\u00e1ticamente"
       },
       "sl3_alarm_ntc_coil": {
-        "name": "Alarma NTC de la resistencia de la zona 3"
+        "name": "Alarma NTC del serpent\u00edn de la zona 3"
       },
       "sl3_alarm_ntc_coil_overheating": {
         "name": "Sobrecalentamiento de la bobina de la zona 3"
@@ -2028,7 +2028,7 @@
         "name": "Tiempo ajustado de la funci\u00f3n gratinar"
       },
       "greasefiltersetlifetimeinhours": {
-        "name": "Vida \u00fatil del filtro de grasa"
+        "name": "Vida \u00fatil del filtro antigrasa"
       },
       "lightbrightness": {
         "name": "Brillo de la luz"
@@ -2307,7 +2307,7 @@
         }
       },
       "feedback_volumen_setting_status": {
-        "name": "Volumen de sonido",
+        "name": "Volumen de las se\u00f1ales ac\u00fasticas",
         "state": {
           "high": "Alto",
           "low": "Bajo",
@@ -2988,10 +2988,10 @@
         "name": "Funci\u00f3n de secado al aire"
       },
       "air_dry_function_status": {
-        "name": "Estado de la funci\u00f3n de secado al aire"
+        "name": "Estado de la funci\u00f3n de secado por aire"
       },
       "air_freshness": {
-        "name": "Frescura del aire"
+        "name": "Frescor del aire"
       },
       "airdryflag": {
         "name": "Indicador de secado al aire"
@@ -3112,7 +3112,7 @@
         }
       },
       "aquapreserve": {
-        "name": "Conservaci\u00f3n de agua"
+        "name": "Conservaci\u00f3n con agua"
       },
       "aquapreserve_flag": {
         "name": "Indicador de conservaci\u00f3n de agua"
@@ -3197,7 +3197,7 @@
         "name": "Marca de tiempo BDC de fecha/hora UTC de inicio de horneado"
       },
       "bathingwaterpump_flag": {
-        "name": "Indicador de la bomba de agua de ba\u00f1o"
+        "name": "Indicador de la bomba de agua del ba\u00f1o"
       },
       "bathingwaterpump_rinse": {
         "name": "Aclarado de la bomba de agua de ba\u00f1o"
@@ -3269,7 +3269,7 @@
         "name": "Solicitud de time-lapse de la c\u00e1mara"
       },
       "can_upload_wifi_program": {
-        "name": "Puede cargar programa Wi-Fi"
+        "name": "Puede cargar el programa Wi-Fi"
       },
       "cancel_delayend_flag": {
         "name": "Indicador de cancelaci\u00f3n de fin diferido"
@@ -3540,7 +3540,7 @@
         "name": "Modo de limpieza DBD"
       },
       "debacilli_mode": {
-        "name": "Modo antibacterias"
+        "name": "Modo antibacteriano"
       },
       "default_dry_level": {
         "name": "Nivel de secado predeterminado"
@@ -3618,7 +3618,7 @@
         "name": "Dosis de detergente restantes"
       },
       "detergent_soften_settingflag": {
-        "name": "Indicador de ajustes de suavizante y detergente"
+        "name": "Indicador de ajustes de suavizado del detergente"
       },
       "detergent_totalml": {
         "name": "Total de detergente usado"
@@ -3681,7 +3681,7 @@
         "name": "Contraste de la pantalla"
       },
       "display_logotype_setting_status": {
-        "name": "Logotipo de la pantalla"
+        "name": "Mostrar logotipo"
       },
       "display_panel_ronshen": {
         "name": "Panel de la pantalla Ronshen"
@@ -3695,7 +3695,7 @@
         }
       },
       "displayboard_brand": {
-        "name": "Marca del panel de display"
+        "name": "Marca de la placa de display"
       },
       "displayboard_key_setting": {
         "name": "Ajuste de teclas del panel de visualizaci\u00f3n"
@@ -3822,16 +3822,16 @@
         "name": "Interruptor de secado"
       },
       "dryingwizzard_clothesdrylevel": {
-        "name": "Asistente de secado nivel de secado de la ropa"
+        "name": "Nivel de secado de la ropa del asistente de secado"
       },
       "dryingwizzard_clothesdrylevel1": {
         "name": "Nivel de secado 1 de la ropa del asistente de secado"
       },
       "dryingwizzard_clothesdrytarget": {
-        "name": "Objetivo de secado de ropa del asistente de secado"
+        "name": "Objetivo de secado de la ropa del asistente de secado"
       },
       "dryingwizzard_clothesdrytarget1": {
-        "name": "Objetivo de secado de ropa 1 del asistente de secado"
+        "name": "Asistente de secado: objetivo de secado de ropa 1"
       },
       "dryingwizzard_clothesmaterialcharacteristics": {
         "name": "Caracter\u00edsticas del material de la ropa del asistente de secado"
@@ -3849,7 +3849,7 @@
         "name": "Tipo de ropa del asistente de secado"
       },
       "dryingwizzard_clothingtype_eighth": {
-        "name": "Tipo de prenda (octava) del asistente de secado"
+        "name": "Asistente de secado: tipo de prenda 8"
       },
       "dryingwizzard_clothingtype_eleventh": {
         "name": "Asistente de secado: tipo de prenda 11"
@@ -3861,13 +3861,13 @@
         "name": "Tipo de prenda (primera) del asistente de secado"
       },
       "dryingwizzard_clothingtype_fourth": {
-        "name": "Tipo de prenda (cuarta) del asistente de secado"
+        "name": "Asistente de secado: tipo de prenda 4"
       },
       "dryingwizzard_clothingtype_ninth": {
         "name": "Tipo de prenda (novena) del asistente de secado"
       },
       "dryingwizzard_clothingtype_second": {
-        "name": "Tipo de prenda (segunda) del asistente de secado"
+        "name": "Asistente de secado: tipo de prenda 2"
       },
       "dryingwizzard_clothingtype_seventh": {
         "name": "Asistente de secado: tipo de prenda 7"
@@ -3882,7 +3882,7 @@
         "name": "Tipo de prenda (tercera) del asistente de secado"
       },
       "dryingwizzard_clothingtype_thirteenth": {
-        "name": "Tipo de ropa del asistente de secado, decimotercero"
+        "name": "Asistente de secado: tipo de prenda 13"
       },
       "dryingwizzard_clothingtype_twelfth": {
         "name": "Asistente de secado: tipo de prenda 12"
@@ -4479,7 +4479,7 @@
         "name": "Modo de almacenamiento r\u00e1pido activo"
       },
       "fast_store_mode_status": {
-        "name": "Estado del modo de enfriamiento r\u00e1pido"
+        "name": "Estado del modo de conservaci\u00f3n r\u00e1pida"
       },
       "favour_program_id": {
         "name": "ID de programa favorito"
@@ -4491,7 +4491,7 @@
         "name": "Estado del filtro"
       },
       "filterclean_dry": {
-        "name": "Limpieza de filtro seco"
+        "name": "Limpieza del filtro (secado)"
       },
       "filterclean_drycount": {
         "name": "Recuento de secados para limpieza del filtro"
@@ -4573,10 +4573,10 @@
         "name": "Temperatura real sensor congelador"
       },
       "freezing_powerdown_temp_alarm": {
-        "name": "Alarma de temperatura por apagado de congelaci\u00f3n"
+        "name": "Alarma de temperatura por corte de alimentaci\u00f3n en congelaci\u00f3n"
       },
       "froze_convert_to_refri_switch_status": {
-        "name": "Estado del interruptor de conversi\u00f3n de congelador a frigor\u00edfico"
+        "name": "Estado del interruptor de conversi\u00f3n de frigor\u00edfico a congelador"
       },
       "fruit_vegetables_temperature": {
         "name": "Temperatura compartimento frutas y vegetales"
@@ -4609,7 +4609,7 @@
         "name": "Saturaci\u00f3n del filtro de grasa"
       },
       "grease_filter_set_lifetime_in_hours": {
-        "name": "Vida \u00fatil del filtro de grasa"
+        "name": "Vida \u00fatil del filtro antigrasa"
       },
       "grease_filter_status": {
         "name": "Estado del filtro de grasa"
@@ -4633,7 +4633,7 @@
         "name": "Media carga"
       },
       "hard_pairing_commond": {
-        "name": "Comando de emparejamiento forzado"
+        "name": "Comando de emparejamiento por hardware"
       },
       "hard_pairing_status": {
         "name": "Estado de emparejamiento dif\u00edcil"
@@ -4798,7 +4798,7 @@
         "name": "Refresco por iones"
       },
       "iron_dry_time": {
-        "name": "Tiempo de secado plancha"
+        "name": "Tiempo de secado para plancha"
       },
       "iscloudprogramflag": {
         "name": "Indicador de programa en la nube"
@@ -5056,7 +5056,7 @@
         "name": "Estado del sensor de olores"
       },
       "once_rinse_step_time": {
-        "name": "Tiempo de la fase de un aclarado"
+        "name": "Tiempo de la fase de aclarado \u00fanico"
       },
       "once_strong_step_time": {
         "name": "Tiempo del paso potente \u00fanico"
@@ -5074,7 +5074,7 @@
         "name": "Modelo solo lavado"
       },
       "order_time_minimum_hour": {
-        "name": "Hora m\u00ednima del tiempo de orden"
+        "name": "Hora m\u00ednima del tiempo de pedido"
       },
       "ota_num1": {
         "name": "N\u00famero OTA 1"
@@ -5095,10 +5095,10 @@
         "name": "Valor de uso del horno: tiempo desde la \u00faltima limpieza"
       },
       "paidbycoinbox": {
-        "name": "Pagado con monedero"
+        "name": "Pagado con monedero de monedas"
       },
       "paidbycoinboxoreadbs": {
-        "name": "Pagado por monedero / EADBS"
+        "name": "Pagado con monedero / EADBS"
       },
       "pairing": {
         "name": "Emparejamiento"
@@ -5110,7 +5110,7 @@
         "name": "An\u00e1lisis de biblioteca OTA"
       },
       "parse_lib_ver": {
-        "name": "Versi\u00f3n de la librer\u00eda de an\u00e1lisis"
+        "name": "Versi\u00f3n de la biblioteca de an\u00e1lisis"
       },
       "party_mode_switch_status": {
         "name": "Estado del interruptor de modo fiesta"
@@ -5293,7 +5293,7 @@
         "name": "Luz del frigor\u00edfico"
       },
       "refr_key": {
-        "name": "Tecla de refresco"
+        "name": "Tecla del frigor\u00edfico"
       },
       "refr_room": {
         "name": "Compartimento frigor\u00edfico"
@@ -5443,7 +5443,7 @@
         "name": "Estado de funcionamiento 3"
       },
       "sabbath_mode_setting": {
-        "name": "Ajuste del modo sab\u00e1tico"
+        "name": "Ajuste del modo Sabbath"
       },
       "sabbath_mode_setting_activate_weekly": {
         "name": "Ajuste del modo sab\u00e1tico: activar semanalmente"
@@ -5653,7 +5653,7 @@
         "name": "Vapor inicial ecol\u00f3gico del programa seleccionado"
       },
       "selected_program_green_leaves_prewash": {
-        "name": "Prelavado ecol\u00f3gico del programa seleccionado"
+        "name": "Prelavado de hojas verdes del programa seleccionado"
       },
       "selected_program_id": {
         "name": "Programa seleccionado",
@@ -5848,7 +5848,7 @@
         "name": "Ajustar hora"
       },
       "set_time_minutes": {
-        "name": "Minutos de tiempo configurados"
+        "name": "Minutos configurados"
       },
       "settings_day": {
         "name": "D\u00eda de ajuste"
@@ -5908,7 +5908,7 @@
         "name": "Silencio a demanda permitido"
       },
       "singleairdry": {
-        "name": "Secado al aire simple"
+        "name": "Solo secado al aire"
       },
       "skipdelayprocess": {
         "name": "Omitir proceso de retardo"
@@ -5997,7 +5997,7 @@
         }
       },
       "sl1_sand_timer_utc_start_time_hours": {
-        "name": "Zona 1 horas de inicio del temporizador de arena"
+        "name": "Horas de inicio del temporizador de arena de la zona 1"
       },
       "sl1_sand_timer_utc_start_time_minutes": {
         "name": "Zona 1 minutos de inicio del temporizador de arena"
@@ -6110,7 +6110,7 @@
         "name": "Temperatura ajustada Hestan Cue de la zona 2"
       },
       "sl2_hestan_cue_temperature": {
-        "name": "Zona 2 temperatura Hestan Cue"
+        "name": "Temperatura Hestan Cue de la zona 2"
       },
       "sl2_ntc_sensor": {
         "name": "Zona 2 sensor NTC"
@@ -6138,7 +6138,7 @@
         }
       },
       "sl2_sand_timer_utc_start_time_hours": {
-        "name": "Zona 2 horas de inicio del temporizador de arena"
+        "name": "Horas de inicio del temporizador de arena de la zona 2"
       },
       "sl2_sand_timer_utc_start_time_minutes": {
         "name": "Minutos de inicio del temporizador de arena de la zona 2"
@@ -6251,7 +6251,7 @@
         "name": "Temperatura ajustada Hestan Cue de la zona 3"
       },
       "sl3_hestan_cue_temperature": {
-        "name": "Zona 3 temperatura Hestan Cue"
+        "name": "Temperatura Hestan Cue de la zona 3"
       },
       "sl3_ntc_sensor": {
         "name": "Zona 3 sensor NTC"
@@ -6279,7 +6279,7 @@
         }
       },
       "sl3_sand_timer_utc_start_time_hours": {
-        "name": "Zona 3 horas de inicio del temporizador de arena"
+        "name": "Horas de inicio del temporizador de arena de la zona 3"
       },
       "sl3_sand_timer_utc_start_time_minutes": {
         "name": "Minutos de inicio del temporizador de arena de la zona 3"
@@ -6392,7 +6392,7 @@
         "name": "Temperatura ajustada Hestan Cue de la zona 4"
       },
       "sl4_hestan_cue_temperature": {
-        "name": "Zona 4 temperatura Hestan Cue"
+        "name": "Temperatura Hestan Cue de la zona 4"
       },
       "sl4_ntc_sensor": {
         "name": "Zona 4 sensor NTC"
@@ -6420,7 +6420,7 @@
         }
       },
       "sl4_sand_timer_utc_start_time_hours": {
-        "name": "Zona 4 horas de inicio del temporizador de arena"
+        "name": "Horas de inicio del temporizador de arena de la zona 4"
       },
       "sl4_sand_timer_utc_start_time_minutes": {
         "name": "Minutos de inicio del temporizador de arena de la zona 4"
@@ -6533,7 +6533,7 @@
         "name": "Temperatura ajustada Hestan Cue de la zona 5"
       },
       "sl5_hestan_cue_temperature": {
-        "name": "Zona 5 temperatura Hestan Cue"
+        "name": "Temperatura Hestan Cue de la zona 5"
       },
       "sl5_ntc_sensor": {
         "name": "Zona 5 sensor NTC"
@@ -6561,7 +6561,7 @@
         }
       },
       "sl5_sand_timer_utc_start_time_hours": {
-        "name": "Zona 5 horas de inicio del temporizador de arena"
+        "name": "Horas de inicio del temporizador de arena de la zona 5"
       },
       "sl5_sand_timer_utc_start_time_minutes": {
         "name": "Minutos de inicio del temporizador de arena de la zona 5"
@@ -6674,7 +6674,7 @@
         "name": "Temperatura ajustada Hestan Cue de la zona 6"
       },
       "sl6_hestan_cue_temperature": {
-        "name": "Zona 6 temperatura Hestan Cue"
+        "name": "Temperatura Hestan Cue de la zona 6"
       },
       "sl6_ntc_sensor": {
         "name": "Zona 6 sensor NTC"
@@ -6702,7 +6702,7 @@
         }
       },
       "sl6_sand_timer_utc_start_time_hours": {
-        "name": "Zona 6 horas de inicio del temporizador de arena"
+        "name": "Horas de inicio del temporizador de arena de la zona 6"
       },
       "sl6_sand_timer_utc_start_time_minutes": {
         "name": "Minutos de inicio del temporizador de arena de la zona 6"
@@ -6766,7 +6766,7 @@
         "name": "Slotdry"
       },
       "slotdry_flag": {
-        "name": "Indicador de secado por ranura"
+        "name": "Indicador de secado en compartimento"
       },
       "slotdry_flag1": {
         "name": "Indicador de secado por ranura 1"
@@ -6775,7 +6775,7 @@
         "name": "Ajuste de emparejamiento suave"
       },
       "soft_pairing_status": {
-        "name": "Estado de emparejamiento suave"
+        "name": "Estado de emparejamiento por software"
       },
       "softener_buynotifyswitch": {
         "name": "Interruptor de aviso de compra de suavizante"
@@ -6817,7 +6817,7 @@
         "name": "Indicador de dosis est\u00e1ndar de suavizante"
       },
       "softpairing": {
-        "name": "Emparejamiento suave"
+        "name": "Emparejamiento por software"
       },
       "softpairingsetting": {
         "name": "Ajuste de emparejamiento suave"
@@ -6877,13 +6877,13 @@
         "name": "Estado del tipo de ropa del programa de manchas"
       },
       "stain_program_set_stain_status": {
-        "name": "Estado de mancha configurado del programa antimanchas"
+        "name": "Estado de mancha configurado del programa de manchas"
       },
       "stain_removal": {
         "name": "Eliminaci\u00f3n de manchas"
       },
       "stand_by_time": {
-        "name": "Tiempo en espera"
+        "name": "Tiempo en espera (standby)"
       },
       "standardelectricitconsumption": {
         "name": "Consumo el\u00e9ctrico est\u00e1ndar"
@@ -6898,7 +6898,7 @@
         "name": "Modo en espera v\u00e1lido"
       },
       "standbychoice": {
-        "name": "Selecci\u00f3n de espera"
+        "name": "Selecci\u00f3n de modo en espera"
       },
       "status": {
         "name": "Estado del dispositivo",
@@ -7361,7 +7361,7 @@
           "bottom_top_heat": "Calor inferior + superior",
           "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
           "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
-          "bottomfan": "Resistencia inferior + ventilador",
+          "bottomfan": "Calor inferior + ventilador",
           "broil": "Gratinar",
           "cleanair": "Limpieza aire",
           "convection_bake": "Aire caliente",
@@ -7416,7 +7416,7 @@
           "sabbath": "Sabbath",
           "self_clean": "Autolimpieza",
           "smallgrill": "Parrilla peque\u00f1a",
-          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "smallgrill_pyro": "Grill peque\u00f1o con pir\u00f3lisis",
           "sousvide": "Al vacio",
           "steam": "Vapor",
           "steamclean": "Limpieza vapor",
@@ -7459,7 +7459,7 @@
           "bottom_top_heat": "Calor inferior + superior",
           "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
           "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
-          "bottomfan": "Resistencia inferior + ventilador",
+          "bottomfan": "Calor inferior + ventilador",
           "broil": "Gratinar",
           "cleanair": "Limpieza aire",
           "convection_bake": "Aire caliente",
@@ -7514,7 +7514,7 @@
           "sabbath": "Sabbath",
           "self_clean": "Autolimpieza",
           "smallgrill": "Parrilla peque\u00f1a",
-          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "smallgrill_pyro": "Grill peque\u00f1o con pir\u00f3lisis",
           "sousvide": "Al vacio",
           "steam": "Vapor",
           "steamclean": "Limpieza vapor",
@@ -7557,7 +7557,7 @@
           "bottom_top_heat": "Calor inferior + superior",
           "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
           "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
-          "bottomfan": "Resistencia inferior + ventilador",
+          "bottomfan": "Calor inferior + ventilador",
           "broil": "Gratinar",
           "cleanair": "Limpieza aire",
           "convection_bake": "Aire caliente",
@@ -7612,7 +7612,7 @@
           "sabbath": "Sabbath",
           "self_clean": "Autolimpieza",
           "smallgrill": "Parrilla peque\u00f1a",
-          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "smallgrill_pyro": "Grill peque\u00f1o con pir\u00f3lisis",
           "sousvide": "Al vacio",
           "steam": "Vapor",
           "steamclean": "Limpieza vapor",
@@ -7663,7 +7663,7 @@
           "bottom_top_heat": "Calor inferior + superior",
           "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
           "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
-          "bottomfan": "Resistencia inferior + ventilador",
+          "bottomfan": "Calor inferior + ventilador",
           "broil": "Gratinar",
           "cleanair": "Limpieza aire",
           "convection_bake": "Aire caliente",
@@ -7718,7 +7718,7 @@
           "sabbath": "Sabbath",
           "self_clean": "Autolimpieza",
           "smallgrill": "Parrilla peque\u00f1a",
-          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "smallgrill_pyro": "Grill peque\u00f1o con pir\u00f3lisis",
           "sousvide": "Al vacio",
           "steam": "Vapor",
           "steamclean": "Limpieza vapor",
@@ -7768,7 +7768,7 @@
           "bottom_top_heat": "Calor inferior + superior",
           "bottom_top_heat_fan": "Calor inferior + superior + ventilador",
           "bottom_top_heat_fan_steam": "Calor inferior + superior + ventilador + vapor",
-          "bottomfan": "Resistencia inferior + ventilador",
+          "bottomfan": "Calor inferior + ventilador",
           "broil": "Gratinar",
           "cleanair": "Limpieza aire",
           "convection_bake": "Aire caliente",
@@ -7823,7 +7823,7 @@
           "sabbath": "Sabbath",
           "self_clean": "Autolimpieza",
           "smallgrill": "Parrilla peque\u00f1a",
-          "smallgrill_pyro": "Grill peque\u00f1o pir\u00f3lisis",
+          "smallgrill_pyro": "Grill peque\u00f1o con pir\u00f3lisis",
           "sousvide": "Al vacio",
           "steam": "Vapor",
           "steamclean": "Limpieza vapor",
@@ -7864,13 +7864,13 @@
         "name": "Estado del modo de almacenamiento bajo demanda"
       },
       "store_dry_time": {
-        "name": "Tiempo de secado para guardar"
+        "name": "Tiempo de secado para guardar en armario"
       },
       "summerwinter_timeautomatic_setting": {
         "name": "Ajuste autom\u00e1tico de horario de verano/invierno"
       },
       "super_rinse_on_demand": {
-        "name": "Superaclarado a demanda"
+        "name": "Superaclarado bajo demanda"
       },
       "super_rinse_on_demand_allowed": {
         "name": "Superaclarado bajo demanda permitido"
@@ -7879,10 +7879,10 @@
         "name": "Estado de superaclarado"
       },
       "super_water_supply_mode": {
-        "name": "Modo de suministro de agua Super"
+        "name": "Modo de suministro de agua superr\u00e1pido"
       },
       "support_preheat_state": {
-        "name": "Estado de precalentamiento compatible"
+        "name": "Estado de compatibilidad con precalentamiento"
       },
       "synchro_start_level": {
         "name": "Nivel de inicio sincronizado"
@@ -8108,7 +8108,7 @@
         "name": "Esterilizaci\u00f3n UV"
       },
       "var_room_open_2": {
-        "name": "Sala variable abierta 2"
+        "name": "Compartimento variable abierto 2"
       },
       "vari_fan_speed": {
         "name": "Velocidad variable del ventilador"
@@ -8153,7 +8153,7 @@
         "name": "Tiempo del paso de lavado: desag\u00fce, centrifugado y parada"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Horas disponibles de lavadora a secadora v"
+        "name": "Horas disponibles de lavadora a secadora"
       },
       "washer_to_dryer_program_id": {
         "name": "ID de programa de lavadora a secadora"
@@ -8231,13 +8231,13 @@
         "name": "Color de la ropa (primera) del asistente de lavado"
       },
       "washingwizzard_cloth_sensitive": {
-        "name": "Asistente de lavado ropa delicada"
+        "name": "Ropa delicada del asistente de lavado"
       },
       "washingwizzard_cloth_sensitive_first": {
         "name": "Asistente de lavado: sensibilidad de la prenda 1"
       },
       "washingwizzard_cloth_sensitive_second": {
-        "name": "Sensibilidad del tejido del asistente de lavado, segundo"
+        "name": "Asistente de lavado: sensibilidad de la prenda 2"
       },
       "washingwizzard_cloth_sensitive_third": {
         "name": "Asistente de lavado: sensibilidad de la prenda 3"
@@ -8276,7 +8276,7 @@
         "name": "Asistente de lavado: tipo de prenda 8"
       },
       "washingwizzard_clothingtype_eleventh": {
-        "name": "Tipo de ropa del asistente de lavado, und\u00e9cimo"
+        "name": "Asistente de lavado: tipo de prenda 11"
       },
       "washingwizzard_clothingtype_fifth": {
         "name": "Asistente de lavado: tipo de prenda 5"
@@ -8385,7 +8385,7 @@
         "name": "Tiempo de secado listo para usar"
       },
       "weight_runningend": {
-        "name": "Fin de la medici\u00f3n de peso"
+        "name": "Fin del pesaje"
       },
       "weight_startrunning": {
         "name": "Peso al iniciar"
@@ -8421,7 +8421,7 @@
         "name": "Estado de la luz de frescura"
       },
       "will_fress_light_exist": {
-        "name": "Existencia de luz de frescura"
+        "name": "Existe la luz de conservaci\u00f3n de frescura"
       },
       "will_light_market_mode_state": {
         "name": "Estado del modo tienda de la iluminaci\u00f3n"
@@ -8460,10 +8460,10 @@
         "name": "Temperatura zona superior"
       },
       "work_mode1": {
-        "name": "Modo de trabajo 1"
+        "name": "Modo de funcionamiento 1"
       },
       "work_mode2": {
-        "name": "Modo de trabajo 2"
+        "name": "Modo de funcionamiento 2"
       },
       "zibian_program_id": {
         "name": "ID de programa Zibian"
@@ -8582,7 +8582,7 @@
         "name": "Sensor de color"
       },
       "crisp_function_status": {
-        "name": "Estado de la funci\u00f3n crujiente"
+        "name": "Estado de la funci\u00f3n Crisp"
       },
       "demo_mode": {
         "name": "Modo demostraci\u00f3n"
@@ -8735,7 +8735,7 @@
         "name": "Sincronizaci\u00f3n inteligente"
       },
       "soft_pairing_status": {
-        "name": "Emparejamiento suave"
+        "name": "Emparejamiento por software"
       },
       "sound": {
         "name": "Sonido"


### PR DESCRIPTION
Fills in all previously-missing translation keys in `es.json` (2992 keys).

Covers appliance program names, modes, cycle phases, status and error/fault labels, and integration UI strings. Appliance-specific terminology follows the wording used on real Spanish appliance control panels and public user manuals; `{placeholders}`, units, and brand/feature names are preserved.

Verified with `uv run python -m scripts.check_translations es` (no missing keys) and re-sorted with `uv run python -m scripts.sort_translations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)