### PR TITLE
Set duration units in mapping and drop unit words from names

### DIFF
--- a/custom_components/connectlife/data_dictionaries/013.yaml
+++ b/custom_components/connectlife/data_dictionaries/013.yaml
@@ -313,6 +313,9 @@ properties:
   optional: true
 - property: Automatic_door_open_at_program_end_after_time_settingTimer_in_minutes
   optional: true
+  sensor:
+    device_class: duration
+    unit: min
 - property: Automatic_door_open_at_program_end_setting
   optional: true
 - property: Automatic_water_tank_opening_setting
@@ -1364,6 +1367,9 @@ properties:
   optional: true
 - property: Step4Steam_assistSet_time_in_minutes
   optional: true
+  sensor:
+    device_class: duration
+    unit: min
 - property: Step4Steam_assist_intensity
   optional: true
 - property: Step4_bake_mode
@@ -1406,6 +1412,9 @@ properties:
   optional: true
 - property: Step5Steam_assistSet_time_in_minutes
   optional: true
+  sensor:
+    device_class: duration
+    unit: min
 - property: Step5Steam_assist_intensity
   optional: true
 - property: Step5_bake_mode

--- a/custom_components/connectlife/data_dictionaries/032.yaml
+++ b/custom_components/connectlife/data_dictionaries/032.yaml
@@ -493,6 +493,10 @@ properties:
         name: Volume_setting_set
   - property: Washer_to_Dryer_available_for_hours_v
     hide: true
+    entity_category: diagnostic
+    sensor:
+      device_class: duration
+      unit: h
     # Example value: 1
   - property: Washer_to_Dryer_program_ID
     hide: true

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -303,10 +303,10 @@
         "name": "Alarm almost finished"
       },
       "alarmchild_lockoff": {
-        "name": "Alarmchild lockoff"
+        "name": "Alarm child lock off"
       },
       "alarmchild_lockon": {
-        "name": "Alarmchild lockon"
+        "name": "Alarm child lock on"
       },
       "alarmcleanairended": {
         "name": "Alarm clean air ended"
@@ -378,13 +378,13 @@
         "name": "Option not available"
       },
       "alarmoven_system_finished": {
-        "name": "Alarmoven system finished"
+        "name": "Alarm oven system finished"
       },
       "alarmpoptankopened": {
         "name": "Alarm pop tank opened"
       },
       "alarmpower_failure_running": {
-        "name": "Alarmpower failure running"
+        "name": "Alarm power failure running"
       },
       "alarmpowerfail": {
         "name": "Power failure"
@@ -2040,10 +2040,10 @@
         "name": "Interior light brightness"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Start delay hours"
+        "name": "Start delay"
       },
       "programtimesstartdelayhours": {
-        "name": "Start delay hours"
+        "name": "Start delay"
       },
       "refrigerator_max_temperature": {
         "name": "Refrigerator max temperature"
@@ -3075,7 +3075,7 @@
         "name": "Almost finished notification setting"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Almost finished notification settingtimer in minutes"
+        "name": "Almost finished notification setting timer"
       },
       "ambient_sound_setting": {
         "name": "Ambient sound setting"
@@ -3173,7 +3173,7 @@
         "name": "Automatic door open at program end after time setting"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Automatic door open at program end after time setting timer in minutes"
+        "name": "Automatic door open at program end delay"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Automatic door open at program end setting"
@@ -3296,19 +3296,19 @@
         "name": "Clean mode switch status"
       },
       "cleanairactivepassedhours": {
-        "name": "Clean air active passed hours"
+        "name": "Clean air active elapsed time"
       },
       "cleanairactivetotalhours": {
-        "name": "Clean air active total hours"
+        "name": "Clean air active total time"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Clean air duration of cycle in minutes"
+        "name": "Clean air duration of cycle"
       },
       "cleanairmotorlevel": {
         "name": "Clean air motor level"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Clean air run cycle every number of minutes"
+        "name": "Clean air cycle interval"
       },
       "cleanairstarttime": {
         "name": "Clean air start time"
@@ -3420,7 +3420,7 @@
         }
       },
       "current_programphase": {
-        "name": "Current programphase",
+        "name": "Current program phase",
         "state": {
           "running": "Running"
         }
@@ -3561,7 +3561,7 @@
         "name": "Delay start remaining time"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Delay start remaining time in minutes"
+        "name": "Delay start remaining time"
       },
       "delay_start_set_time": {
         "name": "Delay start set time"
@@ -4594,10 +4594,10 @@
         "name": "Get current city info flag"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Gratin total allowed time in minutes"
+        "name": "Gratin total allowed time"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Gratin total passed time in minutes"
+        "name": "Gratin total passed time"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Grease filter cleaning interval"
@@ -4618,13 +4618,13 @@
         "name": "Grease filter timer active"
       },
       "grease_filter_used_hours": {
-        "name": "Grease filter used hours"
+        "name": "Grease filter usage"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Grease filter cleaning interval in hours"
+        "name": "Grease filter cleaning interval"
       },
       "greasefilterusedhours": {
-        "name": "Grease filter used hours"
+        "name": "Grease filter usage"
       },
       "grill_plate_measured_temperature": {
         "name": "Grill plate measured temperature"
@@ -4711,7 +4711,7 @@
         "name": "Hood status"
       },
       "hood_total_used_hours": {
-        "name": "Hood runtime hours"
+        "name": "Hood runtime"
       },
       "hottime": {
         "name": "Hot time"
@@ -5074,7 +5074,7 @@
         "name": "Only wash model"
       },
       "order_time_minimum_hour": {
-        "name": "Order time minimum hour"
+        "name": "Order time minimum"
       },
       "ota_num1": {
         "name": "OTA number 1"
@@ -5179,7 +5179,7 @@
         "name": "Prewash step finish notify switch"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Program end to shutdown time in minutes"
+        "name": "Program end to shutdown time"
       },
       "program_settingsdefault": {
         "name": "Program settings default"
@@ -5230,7 +5230,7 @@
         "name": "Quicker mode"
       },
       "quiet_model": {
-        "name": "Quiet model"
+        "name": "Quiet mode"
       },
       "real_humidity": {
         "name": "Real humidity"
@@ -5263,10 +5263,10 @@
         "name": "Recirculation filter 1 type"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Recirculation filter 1 used hours"
+        "name": "Recirculation filter 1 usage"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Recirculation filter 1 lifetime in hours"
+        "name": "Recirculation filter 1 lifetime"
       },
       "recirculationfilter1status": {
         "name": "Recirculation filter 1 status"
@@ -5275,10 +5275,10 @@
         "name": "Recirculation filter 1 type"
       },
       "recirculationfilter1usedhours": {
-        "name": "Recirculation filter 1 used hours"
+        "name": "Recirculation filter 1 usage"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Recirculation filter 2 lifetime in hours"
+        "name": "Recirculation filter 2 lifetime"
       },
       "recirculationfilter2status": {
         "name": "Recirculation filter 2 status"
@@ -5287,7 +5287,7 @@
         "name": "Recirculation filter 2 type"
       },
       "recirculationfilter2usedhours": {
-        "name": "Recirculation filter 2 used hours"
+        "name": "Recirculation filter 2 usage"
       },
       "ref_light": {
         "name": "Ref light"
@@ -6805,7 +6805,7 @@
         "name": "Softener compartment flag"
       },
       "softer_flag": {
-        "name": "Softer flag"
+        "name": "Softener flag"
       },
       "softner_useindex": {
         "name": "Softener use index"
@@ -6823,10 +6823,10 @@
         "name": "Soft pairing setting"
       },
       "soil_lever": {
-        "name": "Soil lever"
+        "name": "Soil level"
       },
       "soilleverflag": {
-        "name": "Soil lever flag"
+        "name": "Soil level flag"
       },
       "sound_setting": {
         "name": "Sound setting"
@@ -6841,7 +6841,7 @@
         "name": "Speed on demand"
       },
       "spend_on_demand_allowed": {
-        "name": "Spend on demand allowed"
+        "name": "Speed on demand allowed"
       },
       "spin_speed_rpm": {
         "name": "Spin speed RPM"
@@ -6907,7 +6907,7 @@
           "delay_time_waiting": "Delay time waiting",
           "error": "Error",
           "idle": "Idle",
-          "not_avaliable": "Not avaliable",
+          "not_avaliable": "Not available",
           "pause": "Pause",
           "production": "Production",
           "program_select": "Program select",
@@ -7274,7 +7274,7 @@
         "name": "Step 4 steam assist intensity"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "Step 4 steam assist set time in minutes"
+        "name": "Step 4 steam assist set time"
       },
       "step5_bake_mode": {
         "name": "Step 5 bake mode"
@@ -7337,7 +7337,7 @@
         "name": "Step 5 steam assist intensity"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "Step 5 steam assist set time in minutes"
+        "name": "Step 5 steam assist set time"
       },
       "step_1_duration": {
         "name": "Step 1 duration"
@@ -7945,7 +7945,7 @@
         "name": "Temperature 9 default main wash time"
       },
       "temperature_default_defaultmainwashtime": {
-        "name": "Temperature default default main wash time"
+        "name": "Temperature default main wash time"
       },
       "temperature_reached_notification_setting": {
         "name": "Temperature reached notification setting"
@@ -8015,7 +8015,7 @@
         "name": "Timer paused time"
       },
       "timerpausedtotalseconds": {
-        "name": "Timer paused total seconds"
+        "name": "Timer paused total"
       },
       "timerstarttime": {
         "name": "Timer start time"
@@ -8153,7 +8153,7 @@
         "name": "Wash step time drain water spin and stop"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Washer to dryer available for hours v"
+        "name": "Washer to dryer available"
       },
       "washer_to_dryer_program_id": {
         "name": "Washer to dryer program ID"

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -2040,10 +2040,10 @@
         "name": "Helligkeit Innenbeleuchtung"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Startverz\u00f6gerung in Stunden"
+        "name": "Startverz\u00f6gerung"
       },
       "programtimesstartdelayhours": {
-        "name": "Startverz\u00f6gerung in Stunden"
+        "name": "Startverz\u00f6gerung"
       },
       "refrigerator_max_temperature": {
         "name": "Maximale K\u00fchlschranktemperatur"
@@ -3173,7 +3173,7 @@
         "name": "Einstellung automatisches T\u00fcr\u00f6ffnen bei Programmende nach Zeitablauf"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Einstellung automatisches T\u00fcr\u00f6ffnen bei Programmende nach Zeitablauf Timer in Minuten"
+        "name": "Verz\u00f6gerung f\u00fcr automatische T\u00fcr\u00f6ffnung bei Programmende"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Einstellung automatisches T\u00fcr\u00f6ffnen bei Programmende"
@@ -3296,19 +3296,19 @@
         "name": "Reinigungsmodus-Schalter-Status"
       },
       "cleanairactivepassedhours": {
-        "name": "Reinluft aktiv vergangene Stunden"
+        "name": "Reinluft aktiv \u2013 verstrichene Zeit"
       },
       "cleanairactivetotalhours": {
-        "name": "Reinluft aktiv Gesamtstunden"
+        "name": "Reinluft aktiv \u2013 Gesamtzeit"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Dauer des Frischluftzyklus in Minuten"
+        "name": "Dauer des Frischluftzyklus"
       },
       "cleanairmotorlevel": {
         "name": "Luftreinigung Motorstufe"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Frischluftzyklus alle Anzahl Minuten ausf\u00fchren"
+        "name": "Reinluft-Zyklusintervall"
       },
       "cleanairstarttime": {
         "name": "Startzeit Luftreinigung"
@@ -4618,13 +4618,13 @@
         "name": "Fettfilter-Timer aktiv"
       },
       "grease_filter_used_hours": {
-        "name": "Fettfilter-Betriebsstunden"
+        "name": "Fettfilternutzung"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Fettfilter-Reinigungsintervall in Stunden"
+        "name": "Fettfilter-Reinigungsintervall"
       },
       "greasefilterusedhours": {
-        "name": "Fettfilter-Betriebsstunden"
+        "name": "Fettfilternutzung"
       },
       "grill_plate_measured_temperature": {
         "name": "Grillplatte gemessene Temperatur"
@@ -5074,7 +5074,7 @@
         "name": "Nur-Waschen-Modell"
       },
       "order_time_minimum_hour": {
-        "name": "Mindestbestellzeit in Stunden"
+        "name": "Mindestbestellzeit"
       },
       "ota_num1": {
         "name": "OTA-Nummer 1"
@@ -5179,7 +5179,7 @@
         "name": "Benachrichtigungsschalter Vorw\u00e4scheende"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Zeit bis zum Herunterfahren nach Programmende (Minuten)"
+        "name": "Zeit bis zum Herunterfahren nach Programmende"
       },
       "program_settingsdefault": {
         "name": "Programmeinstellungen Standard"
@@ -5263,10 +5263,10 @@
         "name": "Umluftfilter 1 Typ"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Betriebsstunden Umluftfilter 1"
+        "name": "Nutzung Umluftfilter 1"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Umluftfilter 1 Lebensdauer in Stunden"
+        "name": "Umluftfilter 1 Lebensdauer"
       },
       "recirculationfilter1status": {
         "name": "Status Umluftfilter 1"
@@ -5275,10 +5275,10 @@
         "name": "Umluftfilter 1 Typ"
       },
       "recirculationfilter1usedhours": {
-        "name": "Betriebsstunden Umluftfilter 1"
+        "name": "Nutzung Umluftfilter 1"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Umluftfilter 2 Lebensdauer in Stunden"
+        "name": "Umluftfilter 2 Lebensdauer"
       },
       "recirculationfilter2status": {
         "name": "Status Umluftfilter 2"
@@ -5287,7 +5287,7 @@
         "name": "Umluftfilter 2 Typ"
       },
       "recirculationfilter2usedhours": {
-        "name": "Betriebsstunden Umluftfilter 2"
+        "name": "Nutzung Umluftfilter 2"
       },
       "ref_light": {
         "name": "K\u00fchlraumbeleuchtung"
@@ -5482,7 +5482,7 @@
         "name": "Sabbatmodus-Status"
       },
       "sand_timer1_duration_in_seconds": {
-        "name": "Sanduhr 1 Dauer in Sekunden"
+        "name": "Sanduhr 1 Dauer"
       },
       "sand_timer1_start_utc_datetime_bdc_timestamp": {
         "name": "Timer 1 Startzeit UTC"
@@ -7274,7 +7274,7 @@
         "name": "Schritt 4 Intensit\u00e4t der Dampfunterst\u00fctzung"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "Schritt 4 Dampfunterst\u00fctzung Zeit in Minuten festlegen"
+        "name": "Schritt 4 Dampfunterst\u00fctzung Zeit festlegen"
       },
       "step5_bake_mode": {
         "name": "Schritt 5 Backmodus"
@@ -7337,7 +7337,7 @@
         "name": "Schritt 5 Intensit\u00e4t der Dampfunterst\u00fctzung"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "Schritt 5 Dampfunterst\u00fctzung Zeit in Minuten festlegen"
+        "name": "Schritt 5 Dampfunterst\u00fctzung Zeit festlegen"
       },
       "step_1_duration": {
         "name": "Schritt 1 Dauer"
@@ -8015,7 +8015,7 @@
         "name": "Timer-Pausenzeit"
       },
       "timerpausedtotalseconds": {
-        "name": "Timer-Pause Sekunden gesamt"
+        "name": "Timer-Pause gesamt"
       },
       "timerstarttime": {
         "name": "Timer-Startzeit"
@@ -8153,7 +8153,7 @@
         "name": "Waschschritt Zeit Wasser abpumpen, schleudern und stoppen"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Waschen-zu-Trocknen f\u00fcr Stunden verf\u00fcgbar"
+        "name": "Waschen-zu-Trocknen verf\u00fcgbar"
       },
       "washer_to_dryer_program_id": {
         "name": "Programm-ID Waschmaschine zu Trockner"

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -303,10 +303,10 @@
         "name": "Alarm almost finished"
       },
       "alarmchild_lockoff": {
-        "name": "Alarmchild lockoff"
+        "name": "Alarm child lock off"
       },
       "alarmchild_lockon": {
-        "name": "Alarmchild lockon"
+        "name": "Alarm child lock on"
       },
       "alarmcleanairended": {
         "name": "Alarm clean air ended"
@@ -378,13 +378,13 @@
         "name": "Option not available"
       },
       "alarmoven_system_finished": {
-        "name": "Alarmoven system finished"
+        "name": "Alarm oven system finished"
       },
       "alarmpoptankopened": {
         "name": "Alarm pop tank opened"
       },
       "alarmpower_failure_running": {
-        "name": "Alarmpower failure running"
+        "name": "Alarm power failure running"
       },
       "alarmpowerfail": {
         "name": "Power failure"
@@ -2040,10 +2040,10 @@
         "name": "Interior light brightness"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Start delay hours"
+        "name": "Start delay"
       },
       "programtimesstartdelayhours": {
-        "name": "Start delay hours"
+        "name": "Start delay"
       },
       "refrigerator_max_temperature": {
         "name": "Refrigerator max temperature"
@@ -3075,7 +3075,7 @@
         "name": "Almost finished notification setting"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Almost finished notification settingtimer in minutes"
+        "name": "Almost finished notification setting timer"
       },
       "ambient_sound_setting": {
         "name": "Ambient sound setting"
@@ -3173,7 +3173,7 @@
         "name": "Automatic door open at program end after time setting"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Automatic door open at program end after time setting timer in minutes"
+        "name": "Automatic door open at program end delay"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Automatic door open at program end setting"
@@ -3296,19 +3296,19 @@
         "name": "Clean mode switch status"
       },
       "cleanairactivepassedhours": {
-        "name": "Clean air active passed hours"
+        "name": "Clean air active elapsed time"
       },
       "cleanairactivetotalhours": {
-        "name": "Clean air active total hours"
+        "name": "Clean air active total time"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Clean air duration of cycle in minutes"
+        "name": "Clean air duration of cycle"
       },
       "cleanairmotorlevel": {
         "name": "Clean air motor level"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Clean air run cycle every number of minutes"
+        "name": "Clean air cycle interval"
       },
       "cleanairstarttime": {
         "name": "Clean air start time"
@@ -3420,7 +3420,7 @@
         }
       },
       "current_programphase": {
-        "name": "Current programphase",
+        "name": "Current program phase",
         "state": {
           "running": "Running"
         }
@@ -3561,7 +3561,7 @@
         "name": "Delay start remaining time"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Delay start remaining time in minutes"
+        "name": "Delay start remaining time"
       },
       "delay_start_set_time": {
         "name": "Delay start set time"
@@ -4594,10 +4594,10 @@
         "name": "Get current city info flag"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Gratin total allowed time in minutes"
+        "name": "Gratin total allowed time"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Gratin total passed time in minutes"
+        "name": "Gratin total passed time"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Grease filter cleaning interval"
@@ -4618,13 +4618,13 @@
         "name": "Grease filter timer active"
       },
       "grease_filter_used_hours": {
-        "name": "Grease filter used hours"
+        "name": "Grease filter usage"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Grease filter cleaning interval in hours"
+        "name": "Grease filter cleaning interval"
       },
       "greasefilterusedhours": {
-        "name": "Grease filter used hours"
+        "name": "Grease filter usage"
       },
       "grill_plate_measured_temperature": {
         "name": "Grill plate measured temperature"
@@ -4711,7 +4711,7 @@
         "name": "Hood status"
       },
       "hood_total_used_hours": {
-        "name": "Hood runtime hours"
+        "name": "Hood runtime"
       },
       "hottime": {
         "name": "Hot time"
@@ -5074,7 +5074,7 @@
         "name": "Only wash model"
       },
       "order_time_minimum_hour": {
-        "name": "Order time minimum hour"
+        "name": "Order time minimum"
       },
       "ota_num1": {
         "name": "OTA number 1"
@@ -5179,7 +5179,7 @@
         "name": "Prewash step finish notify switch"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Program end to shutdown time in minutes"
+        "name": "Program end to shutdown time"
       },
       "program_settingsdefault": {
         "name": "Program settings default"
@@ -5230,7 +5230,7 @@
         "name": "Quicker mode"
       },
       "quiet_model": {
-        "name": "Quiet model"
+        "name": "Quiet mode"
       },
       "real_humidity": {
         "name": "Real humidity"
@@ -5263,10 +5263,10 @@
         "name": "Recirculation filter 1 type"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Recirculation filter 1 used hours"
+        "name": "Recirculation filter 1 usage"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Recirculation filter 1 lifetime in hours"
+        "name": "Recirculation filter 1 lifetime"
       },
       "recirculationfilter1status": {
         "name": "Recirculation filter 1 status"
@@ -5275,10 +5275,10 @@
         "name": "Recirculation filter 1 type"
       },
       "recirculationfilter1usedhours": {
-        "name": "Recirculation filter 1 used hours"
+        "name": "Recirculation filter 1 usage"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Recirculation filter 2 lifetime in hours"
+        "name": "Recirculation filter 2 lifetime"
       },
       "recirculationfilter2status": {
         "name": "Recirculation filter 2 status"
@@ -5287,7 +5287,7 @@
         "name": "Recirculation filter 2 type"
       },
       "recirculationfilter2usedhours": {
-        "name": "Recirculation filter 2 used hours"
+        "name": "Recirculation filter 2 usage"
       },
       "ref_light": {
         "name": "Ref light"
@@ -6805,7 +6805,7 @@
         "name": "Softener compartment flag"
       },
       "softer_flag": {
-        "name": "Softer flag"
+        "name": "Softener flag"
       },
       "softner_useindex": {
         "name": "Softener use index"
@@ -6823,10 +6823,10 @@
         "name": "Soft pairing setting"
       },
       "soil_lever": {
-        "name": "Soil lever"
+        "name": "Soil level"
       },
       "soilleverflag": {
-        "name": "Soil lever flag"
+        "name": "Soil level flag"
       },
       "sound_setting": {
         "name": "Sound setting"
@@ -6841,7 +6841,7 @@
         "name": "Speed on demand"
       },
       "spend_on_demand_allowed": {
-        "name": "Spend on demand allowed"
+        "name": "Speed on demand allowed"
       },
       "spin_speed_rpm": {
         "name": "Spin speed RPM"
@@ -6907,7 +6907,7 @@
           "delay_time_waiting": "Delay time waiting",
           "error": "Error",
           "idle": "Idle",
-          "not_avaliable": "Not avaliable",
+          "not_avaliable": "Not available",
           "pause": "Pause",
           "production": "Production",
           "program_select": "Program select",
@@ -7274,7 +7274,7 @@
         "name": "Step 4 steam assist intensity"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "Step 4 steam assist set time in minutes"
+        "name": "Step 4 steam assist set time"
       },
       "step5_bake_mode": {
         "name": "Step 5 bake mode"
@@ -7337,7 +7337,7 @@
         "name": "Step 5 steam assist intensity"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "Step 5 steam assist set time in minutes"
+        "name": "Step 5 steam assist set time"
       },
       "step_1_duration": {
         "name": "Step 1 duration"
@@ -7945,7 +7945,7 @@
         "name": "Temperature 9 default main wash time"
       },
       "temperature_default_defaultmainwashtime": {
-        "name": "Temperature default default main wash time"
+        "name": "Temperature default main wash time"
       },
       "temperature_reached_notification_setting": {
         "name": "Temperature reached notification setting"
@@ -8015,7 +8015,7 @@
         "name": "Timer paused time"
       },
       "timerpausedtotalseconds": {
-        "name": "Timer paused total seconds"
+        "name": "Timer paused total"
       },
       "timerstarttime": {
         "name": "Timer start time"
@@ -8153,7 +8153,7 @@
         "name": "Wash step time drain water spin and stop"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Washer to dryer available for hours v"
+        "name": "Washer to dryer available"
       },
       "washer_to_dryer_program_id": {
         "name": "Washer to dryer program ID"

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -2040,10 +2040,10 @@
         "name": "Brillo de la luz interior"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Horas de inicio diferido"
+        "name": "Inicio diferido"
       },
       "programtimesstartdelayhours": {
-        "name": "Horas de inicio diferido"
+        "name": "Inicio diferido"
       },
       "refrigerator_max_temperature": {
         "name": "Frigorifico temperatura m\u00e1xima"
@@ -3075,7 +3075,7 @@
         "name": "Ajuste de notificaci\u00f3n de casi finalizado"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Ajuste de notificaci\u00f3n de casi finalizado: temporizador en minutos"
+        "name": "Ajuste de notificaci\u00f3n de casi finalizado: temporizador"
       },
       "ambient_sound_setting": {
         "name": "Ajuste de sonido ambiente"
@@ -3173,7 +3173,7 @@
         "name": "Ajuste de apertura autom\u00e1tica de la puerta al finalizar el programa tras un tiempo"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Ajuste de apertura autom\u00e1tica de la puerta al finalizar el programa tras un tiempo: temporizador en minutos"
+        "name": "Retardo de apertura autom\u00e1tica de la puerta al final del programa"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Ajuste de apertura autom\u00e1tica de la puerta al final del programa"
@@ -3296,19 +3296,19 @@
         "name": "Estado del interruptor de modo de limpieza"
       },
       "cleanairactivepassedhours": {
-        "name": "Horas transcurridas de aire limpio activo"
+        "name": "Tiempo transcurrido de aire limpio activo"
       },
       "cleanairactivetotalhours": {
-        "name": "Horas totales de aire limpio activo"
+        "name": "Tiempo total de aire limpio activo"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Duraci\u00f3n del ciclo de aire limpio en minutos"
+        "name": "Duraci\u00f3n del ciclo de aire limpio"
       },
       "cleanairmotorlevel": {
         "name": "Nivel del motor de aire limpio"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Ejecutar ciclo de aire limpio cada cierto n\u00famero de minutos"
+        "name": "Intervalo del ciclo de aire limpio"
       },
       "cleanairstarttime": {
         "name": "Hora de inicio de aire limpio"
@@ -3561,10 +3561,10 @@
         "name": "Tiempo restrante inicio retrasado"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Tiempo restante de inicio diferido en minutos"
+        "name": "Tiempo restante de inicio diferido"
       },
       "delay_start_set_time": {
-        "name": "Hora ajustada de inicio diferido"
+        "name": "Tiempo ajustado de inicio diferido"
       },
       "delay_time_hour_min": {
         "name": "Tiempo de retardo (h:min)"
@@ -3573,7 +3573,7 @@
         "name": "Indicador de cierre diferido"
       },
       "delayendtime": {
-        "name": "Hora de finalizaci\u00f3n diferida"
+        "name": "Finalizaci\u00f3n diferida"
       },
       "delayendtime_minute": {
         "name": "Minuto de hora de fin diferido"
@@ -4594,10 +4594,10 @@
         "name": "Indicador de obtenci\u00f3n de informaci\u00f3n de la ciudad actual"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Tiempo total permitido de gratinado en minutos"
+        "name": "Tiempo total permitido de gratinado"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Tiempo total transcurrido de gratinado en minutos"
+        "name": "Tiempo total transcurrido de gratinado"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Intervalo de limpieza del filtro de grasa"
@@ -4618,13 +4618,13 @@
         "name": "Temporizador del filtro de grasa activo"
       },
       "grease_filter_used_hours": {
-        "name": "Horas de uso del filtro de grasa"
+        "name": "Uso del filtro de grasa"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Intervalo de limpieza del filtro de grasa en horas"
+        "name": "Intervalo de limpieza del filtro de grasa"
       },
       "greasefilterusedhours": {
-        "name": "Horas de uso del filtro de grasa"
+        "name": "Uso del filtro de grasa"
       },
       "grill_plate_measured_temperature": {
         "name": "Temperatura medida de la placa de grill"
@@ -4711,7 +4711,7 @@
         "name": "Estado de la campana"
       },
       "hood_total_used_hours": {
-        "name": "Horas de funcionamiento de la campana"
+        "name": "Tiempo de funcionamiento de la campana"
       },
       "hottime": {
         "name": "Tiempo en caliente"
@@ -5074,7 +5074,7 @@
         "name": "Modelo solo lavado"
       },
       "order_time_minimum_hour": {
-        "name": "Hora m\u00ednima del tiempo de pedido"
+        "name": "Tiempo m\u00ednimo de pedido"
       },
       "ota_num1": {
         "name": "N\u00famero OTA 1"
@@ -5179,7 +5179,7 @@
         "name": "Interruptor de aviso de fin del paso de prelavado"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Tiempo del fin del programa al apagado en minutos"
+        "name": "Tiempo del fin del programa al apagado"
       },
       "program_settingsdefault": {
         "name": "Ajustes del programa por defecto"
@@ -5263,10 +5263,10 @@
         "name": "Tipo de filtro de recirculaci\u00f3n 1"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Horas de uso del filtro de recirculaci\u00f3n 1"
+        "name": "Uso del filtro de recirculaci\u00f3n 1"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 1 en horas"
+        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 1"
       },
       "recirculationfilter1status": {
         "name": "Estado del filtro de recirculaci\u00f3n 1"
@@ -5275,10 +5275,10 @@
         "name": "Tipo de filtro de recirculaci\u00f3n 1"
       },
       "recirculationfilter1usedhours": {
-        "name": "Horas de uso del filtro de recirculaci\u00f3n 1"
+        "name": "Uso del filtro de recirculaci\u00f3n 1"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 2 en horas"
+        "name": "Vida \u00fatil del filtro de recirculaci\u00f3n 2"
       },
       "recirculationfilter2status": {
         "name": "Estado del filtro de recirculaci\u00f3n 2"
@@ -5287,7 +5287,7 @@
         "name": "Tipo de filtro de recirculaci\u00f3n 2"
       },
       "recirculationfilter2usedhours": {
-        "name": "Horas de uso del filtro de recirculaci\u00f3n 2"
+        "name": "Uso del filtro de recirculaci\u00f3n 2"
       },
       "ref_light": {
         "name": "Luz del frigor\u00edfico"
@@ -7274,7 +7274,7 @@
         "name": "Intensidad de asistencia de vapor del paso 4"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "Tiempo de asistencia de vapor paso 4 en minutos"
+        "name": "Tiempo de asistencia de vapor paso 4"
       },
       "step5_bake_mode": {
         "name": "Modo de cocci\u00f3n del paso 5"
@@ -7337,7 +7337,7 @@
         "name": "Intensidad de asistencia de vapor del paso 5"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "Tiempo de asistencia de vapor paso 5 en minutos"
+        "name": "Tiempo de asistencia de vapor paso 5"
       },
       "step_1_duration": {
         "name": "Duraci\u00f3n del paso 1"
@@ -8015,7 +8015,7 @@
         "name": "Tiempo de pausa del temporizador"
       },
       "timerpausedtotalseconds": {
-        "name": "Total de segundos de pausa del temporizador"
+        "name": "Pausa total del temporizador"
       },
       "timerstarttime": {
         "name": "Hora de inicio del temporizador"
@@ -8153,7 +8153,7 @@
         "name": "Tiempo del paso de lavado: desag\u00fce, centrifugado y parada"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Horas disponibles de lavadora a secadora"
+        "name": "Lavadora a secadora disponible"
       },
       "washer_to_dryer_program_id": {
         "name": "ID de programa de lavadora a secadora"

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -2040,10 +2040,10 @@
         "name": "Luminosit\u00e9 de l'\u00e9clairage int\u00e9rieur"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Heures de d\u00e9part diff\u00e9r\u00e9"
+        "name": "D\u00e9part diff\u00e9r\u00e9"
       },
       "programtimesstartdelayhours": {
-        "name": "Heures de d\u00e9part diff\u00e9r\u00e9"
+        "name": "D\u00e9part diff\u00e9r\u00e9"
       },
       "refrigerator_max_temperature": {
         "name": "Temp\u00e9rature max frigo"
@@ -3075,7 +3075,7 @@
         "name": "R\u00e9glage de la notification de fin imminente"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "R\u00e9glage de la notification de fin proche, minuteur en minutes"
+        "name": "R\u00e9glage de la notification de fin proche, minuteur"
       },
       "ambient_sound_setting": {
         "name": "R\u00e9glage du son ambiant"
@@ -3173,7 +3173,7 @@
         "name": "R\u00e9glage d'ouverture automatique de la porte \u00e0 la fin du programme apr\u00e8s un d\u00e9lai"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "R\u00e9glage d'ouverture automatique de la porte \u00e0 la fin du programme apr\u00e8s un d\u00e9lai, minuteur en minutes"
+        "name": "D\u00e9lai d'ouverture automatique de la porte en fin de programme"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "R\u00e9glage d'ouverture automatique de la porte en fin de programme"
@@ -3296,19 +3296,19 @@
         "name": "\u00c9tat mode nettoyage"
       },
       "cleanairactivepassedhours": {
-        "name": "Heures \u00e9coul\u00e9es air pur actif"
+        "name": "Temps \u00e9coul\u00e9 air pur actif"
       },
       "cleanairactivetotalhours": {
-        "name": "Heures totales air pur actif"
+        "name": "Temps total air pur actif"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Dur\u00e9e du cycle d'air pur en minutes"
+        "name": "Dur\u00e9e du cycle d'air pur"
       },
       "cleanairmotorlevel": {
         "name": "Niveau du moteur de purification de l'air"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Cycle d'air pur ex\u00e9cut\u00e9 toutes les X minutes"
+        "name": "Intervalle du cycle d'air pur"
       },
       "cleanairstarttime": {
         "name": "Heure de d\u00e9marrage air pur"
@@ -3561,10 +3561,10 @@
         "name": "Temps restant avant d\u00e9part diff\u00e9r\u00e9"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Temps restant avant d\u00e9part diff\u00e9r\u00e9 en minutes"
+        "name": "Temps restant avant d\u00e9part diff\u00e9r\u00e9"
       },
       "delay_start_set_time": {
-        "name": "Heure r\u00e9gl\u00e9e du d\u00e9part diff\u00e9r\u00e9"
+        "name": "Dur\u00e9e r\u00e9gl\u00e9e du d\u00e9part diff\u00e9r\u00e9"
       },
       "delay_time_hour_min": {
         "name": "D\u00e9lai (h:min)"
@@ -4594,10 +4594,10 @@
         "name": "Indicateur d'obtention des infos de la ville actuelle"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Temps total autoris\u00e9 du gratin (minutes)"
+        "name": "Temps total autoris\u00e9 du gratin"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Temps total \u00e9coul\u00e9 du gratin (minutes)"
+        "name": "Temps total \u00e9coul\u00e9 du gratin"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Intervalle de nettoyage du filtre \u00e0 graisse"
@@ -4618,13 +4618,13 @@
         "name": "Minuterie du filtre \u00e0 graisse active"
       },
       "grease_filter_used_hours": {
-        "name": "Heures d'utilisation du filtre \u00e0 graisse"
+        "name": "Utilisation du filtre \u00e0 graisse"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Intervalle de nettoyage du filtre \u00e0 graisse en heures"
+        "name": "Intervalle de nettoyage du filtre \u00e0 graisse"
       },
       "greasefilterusedhours": {
-        "name": "Heures d'utilisation du filtre \u00e0 graisse"
+        "name": "Utilisation du filtre \u00e0 graisse"
       },
       "grill_plate_measured_temperature": {
         "name": "Temp\u00e9rature mesur\u00e9e de la plaque de gril"
@@ -4711,7 +4711,7 @@
         "name": "\u00c9tat de la hotte"
       },
       "hood_total_used_hours": {
-        "name": "Heures de fonctionnement de la hotte"
+        "name": "Dur\u00e9e de fonctionnement de la hotte"
       },
       "hottime": {
         "name": "Dur\u00e9e de chauffe"
@@ -5074,7 +5074,7 @@
         "name": "Mod\u00e8le lavage seul"
       },
       "order_time_minimum_hour": {
-        "name": "Heure minimale de commande"
+        "name": "Temps minimum de commande"
       },
       "ota_num1": {
         "name": "Num\u00e9ro OTA 1"
@@ -5179,7 +5179,7 @@
         "name": "Notification de fin d'\u00e9tape de pr\u00e9lavage"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Temps entre fin de programme et arr\u00eat en minutes"
+        "name": "Temps entre fin de programme et arr\u00eat"
       },
       "program_settingsdefault": {
         "name": "R\u00e9glages du programme par d\u00e9faut"
@@ -5263,10 +5263,10 @@
         "name": "Type du filtre de recyclage 1"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Heures d'utilisation du filtre de recirculation 1"
+        "name": "Utilisation du filtre de recirculation 1"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Dur\u00e9e de vie du filtre de recirculation 1 en heures"
+        "name": "Dur\u00e9e de vie du filtre de recirculation 1"
       },
       "recirculationfilter1status": {
         "name": "\u00c9tat du filtre de recirculation 1"
@@ -5275,10 +5275,10 @@
         "name": "Type du filtre de recyclage 1"
       },
       "recirculationfilter1usedhours": {
-        "name": "Heures d'utilisation du filtre de recirculation 1"
+        "name": "Utilisation du filtre de recirculation 1"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Dur\u00e9e de vie du filtre de recirculation 2 en heures"
+        "name": "Dur\u00e9e de vie du filtre de recirculation 2"
       },
       "recirculationfilter2status": {
         "name": "\u00c9tat du filtre de recirculation 2"
@@ -5287,7 +5287,7 @@
         "name": "Type du filtre de recyclage 2"
       },
       "recirculationfilter2usedhours": {
-        "name": "Heures d'utilisation du filtre de recirculation 2"
+        "name": "Utilisation du filtre de recirculation 2"
       },
       "ref_light": {
         "name": "Voyant frigo"
@@ -7274,7 +7274,7 @@
         "name": "\u00c9tape 4 intensit\u00e9 de l'assistance vapeur"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "\u00c9tape 4 dur\u00e9e r\u00e9gl\u00e9e de l'assistance vapeur en minutes"
+        "name": "\u00c9tape 4 dur\u00e9e r\u00e9gl\u00e9e de l'assistance vapeur"
       },
       "step5_bake_mode": {
         "name": "Mode de cuisson \u00e9tape 5"
@@ -7337,7 +7337,7 @@
         "name": "\u00c9tape 5 intensit\u00e9 de l'assistance vapeur"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "\u00c9tape 5 dur\u00e9e r\u00e9gl\u00e9e de l'assistance vapeur en minutes"
+        "name": "\u00c9tape 5 dur\u00e9e r\u00e9gl\u00e9e de l'assistance vapeur"
       },
       "step_1_duration": {
         "name": "Dur\u00e9e \u00e9tape 1"
@@ -8015,7 +8015,7 @@
         "name": "Dur\u00e9e de pause de la minuterie"
       },
       "timerpausedtotalseconds": {
-        "name": "Secondes totales de pause de la minuterie"
+        "name": "Pause totale de la minuterie"
       },
       "timerstarttime": {
         "name": "Heure de d\u00e9but de la minuterie"
@@ -8153,7 +8153,7 @@
         "name": "Dur\u00e9e d'\u00e9tape de lavage vidange essorage et arr\u00eat"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Lavage vers s\u00e9chage disponible pendant heures v"
+        "name": "Lavage vers s\u00e9chage disponible"
       },
       "washer_to_dryer_program_id": {
         "name": "ID de programme lavage vers s\u00e9chage"

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -2040,10 +2040,10 @@
         "name": "Luminosit\u00e0 luce interna"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Ore ritardo avvio"
+        "name": "Ritardo avvio"
       },
       "programtimesstartdelayhours": {
-        "name": "Ore ritardo avvio"
+        "name": "Ritardo avvio"
       },
       "refrigerator_max_temperature": {
         "name": "Temperatura massima frigorifero"
@@ -3075,7 +3075,7 @@
         "name": "Impostazione notifica quasi terminato"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Impostazione notifica quasi terminato timer in minuti"
+        "name": "Impostazione notifica quasi terminato timer"
       },
       "ambient_sound_setting": {
         "name": "Impostazione suono ambiente"
@@ -3173,7 +3173,7 @@
         "name": "Impostazione apertura automatica porta a fine programma dopo il tempo"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Apertura automatica dello sportello a fine programma dopo il tempo impostato (timer in minuti)"
+        "name": "Ritardo apertura automatica porta a fine programma"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Impostazione apertura automatica porta a fine programma"
@@ -3296,19 +3296,19 @@
         "name": "Stato modalit\u00e0 pulizia"
       },
       "cleanairactivepassedhours": {
-        "name": "Ore trascorse aria pulita attiva"
+        "name": "Tempo trascorso aria pulita attiva"
       },
       "cleanairactivetotalhours": {
-        "name": "Ore totali aria pulita attiva"
+        "name": "Tempo totale aria pulita attiva"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Durata ciclo aria pulita in minuti"
+        "name": "Durata ciclo aria pulita"
       },
       "cleanairmotorlevel": {
         "name": "Livello motore aria pulita"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Ciclo aria pulita ogni numero di minuti"
+        "name": "Intervallo ciclo aria pulita"
       },
       "cleanairstarttime": {
         "name": "Ora avvio aria pulita"
@@ -3561,7 +3561,7 @@
         "name": "Tempo rimanente avvio ritardato"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Tempo residuo avvio ritardato in minuti"
+        "name": "Tempo residuo avvio ritardato"
       },
       "delay_start_set_time": {
         "name": "Orario impostato avvio ritardato"
@@ -4594,10 +4594,10 @@
         "name": "Flag richiesta info citt\u00e0 attuale"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Tempo totale consentito gratin in minuti"
+        "name": "Tempo totale consentito gratin"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Tempo totale trascorso gratin in minuti"
+        "name": "Tempo totale trascorso gratin"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Intervallo pulizia filtro grassi"
@@ -4618,13 +4618,13 @@
         "name": "Timer filtro grassi attivo"
       },
       "grease_filter_used_hours": {
-        "name": "Ore di utilizzo filtro antigrasso"
+        "name": "Utilizzo filtro antigrasso"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Intervallo pulizia filtro grassi in ore"
+        "name": "Intervallo pulizia filtro grassi"
       },
       "greasefilterusedhours": {
-        "name": "Ore di utilizzo filtro antigrasso"
+        "name": "Utilizzo filtro antigrasso"
       },
       "grill_plate_measured_temperature": {
         "name": "Temperatura misurata piastra grill"
@@ -4711,7 +4711,7 @@
         "name": "Stato cappa"
       },
       "hood_total_used_hours": {
-        "name": "Ore di funzionamento cappa"
+        "name": "Tempo di funzionamento cappa"
       },
       "hottime": {
         "name": "Tempo di riscaldamento"
@@ -5074,7 +5074,7 @@
         "name": "Modello solo lavaggio"
       },
       "order_time_minimum_hour": {
-        "name": "Ora minima programmazione"
+        "name": "Tempo minimo di ordine"
       },
       "ota_num1": {
         "name": "Numero OTA 1"
@@ -5179,7 +5179,7 @@
         "name": "Notifica fine fase prelavaggio"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Tempo da fine programma a spegnimento in minuti"
+        "name": "Tempo da fine programma a spegnimento"
       },
       "program_settingsdefault": {
         "name": "Impostazioni programma predefinite"
@@ -5263,10 +5263,10 @@
         "name": "Tipo filtro ricircolo 1"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Ore d'uso filtro ricircolo 1"
+        "name": "Utilizzo filtro ricircolo 1"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Durata filtro ricircolo 1 in ore"
+        "name": "Durata filtro ricircolo 1"
       },
       "recirculationfilter1status": {
         "name": "Stato filtro di ricircolo 1"
@@ -5275,10 +5275,10 @@
         "name": "Tipo filtro ricircolo 1"
       },
       "recirculationfilter1usedhours": {
-        "name": "Ore d'uso filtro ricircolo 1"
+        "name": "Utilizzo filtro ricircolo 1"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Durata filtro ricircolo 2 in ore"
+        "name": "Durata filtro ricircolo 2"
       },
       "recirculationfilter2status": {
         "name": "Stato filtro di ricircolo 2"
@@ -5287,7 +5287,7 @@
         "name": "Tipo filtro ricircolo 2"
       },
       "recirculationfilter2usedhours": {
-        "name": "Ore d'uso filtro ricircolo 2"
+        "name": "Utilizzo filtro ricircolo 2"
       },
       "ref_light": {
         "name": "Luce frigorifero"
@@ -7274,7 +7274,7 @@
         "name": "Fase 4 intensit\u00e0 assistenza vapore"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "Fase 4 impostazione tempo assistenza vapore in minuti"
+        "name": "Fase 4 impostazione tempo assistenza vapore"
       },
       "step5_bake_mode": {
         "name": "Modalit\u00e0 cottura fase 5"
@@ -7337,7 +7337,7 @@
         "name": "Fase 5 intensit\u00e0 assistenza vapore"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "Fase 5 impostazione tempo assistenza vapore in minuti"
+        "name": "Fase 5 impostazione tempo assistenza vapore"
       },
       "step_1_duration": {
         "name": "Durata fase 1"
@@ -8015,7 +8015,7 @@
         "name": "Tempo timer in pausa"
       },
       "timerpausedtotalseconds": {
-        "name": "Secondi totali timer in pausa"
+        "name": "Pausa totale timer"
       },
       "timerstarttime": {
         "name": "Ora di avvio timer"
@@ -8153,7 +8153,7 @@
         "name": "Tempo fase lavaggio scarico acqua centrifuga e arresto"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Passaggio da lavatrice ad asciugatrice disponibile per ore v"
+        "name": "Passaggio da lavatrice ad asciugatrice disponibile"
       },
       "washer_to_dryer_program_id": {
         "name": "ID programma lavatrice-asciugatrice"

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -2040,10 +2040,10 @@
         "name": "Helderheid binnenverlichting"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Uren startuitstel"
+        "name": "Startuitstel"
       },
       "programtimesstartdelayhours": {
-        "name": "Uren startuitstel"
+        "name": "Startuitstel"
       },
       "refrigerator_max_temperature": {
         "name": "Koelkast max temperatuur"
@@ -3075,7 +3075,7 @@
         "name": "Bijna voltooid notificatie"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Bijna voltooid notificatie timer in minuten"
+        "name": "Bijna voltooid notificatie timer"
       },
       "ambient_sound_setting": {
         "name": "Instelling omgevingsgeluid"
@@ -3173,7 +3173,7 @@
         "name": "Instelling automatisch openen deur na programmaverloop"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Timer automatisch openen deur na programmaverloop (minuten)"
+        "name": "Vertraging automatische deuropening bij programma-einde"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Instelling automatisch openen deur na programma"
@@ -3296,19 +3296,19 @@
         "name": "Reinigingsmodus schakelaar status"
       },
       "cleanairactivepassedhours": {
-        "name": "Verstreken uren schone lucht actief"
+        "name": "Verstreken tijd schone lucht actief"
       },
       "cleanairactivetotalhours": {
-        "name": "Totale uren schone lucht actief"
+        "name": "Totale tijd schone lucht actief"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Duur schone-luchtcyclus in minuten"
+        "name": "Duur schone-luchtcyclus"
       },
       "cleanairmotorlevel": {
         "name": "Motorniveau schone lucht"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Schone-luchtcyclus elke x minuten"
+        "name": "Interval schone-luchtcyclus"
       },
       "cleanairstarttime": {
         "name": "Starttijd schone lucht"
@@ -3561,7 +3561,7 @@
         "name": "Resterende tijd uitgestelde start"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Resterende tijd uitgestelde start in minuten"
+        "name": "Resterende tijd uitgestelde start"
       },
       "delay_start_set_time": {
         "name": "Ingestelde tijd uitgestelde start"
@@ -3573,7 +3573,7 @@
         "name": "Uitstel sluiten"
       },
       "delayendtime": {
-        "name": "Eindtijd uitstel"
+        "name": "Uitgestelde eindtijd"
       },
       "delayendtime_minute": {
         "name": "Eindtijd uitstel minuten"
@@ -4594,10 +4594,10 @@
         "name": "Indicator huidige stadsinfo ophalen"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Maximale gratineertijd (minuten)"
+        "name": "Maximale gratineertijd"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Verstreken gratineertijd (minuten)"
+        "name": "Verstreken gratineertijd"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Reinigingsinterval vetfilter"
@@ -4618,13 +4618,13 @@
         "name": "Vetfilter timer actief"
       },
       "grease_filter_used_hours": {
-        "name": "Vetfilter gebruikte uren"
+        "name": "Vetfiltergebruik"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Vetfilter reinigingsinterval in uren"
+        "name": "Vetfilter reinigingsinterval"
       },
       "greasefilterusedhours": {
-        "name": "Vetfilter gebruikte uren"
+        "name": "Vetfiltergebruik"
       },
       "grill_plate_measured_temperature": {
         "name": "Gemeten temperatuur grillplaat"
@@ -5074,7 +5074,7 @@
         "name": "Only wash model"
       },
       "order_time_minimum_hour": {
-        "name": "Order time minimum (uur)"
+        "name": "Minimale besteltijd"
       },
       "ota_num1": {
         "name": "OTA nummer 1"
@@ -5179,7 +5179,7 @@
         "name": "Voorwas stap voltooid melding schakelaar"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Tijd programma-einde tot uitschakelen (in minuten)"
+        "name": "Tijd programma-einde tot uitschakelen"
       },
       "program_settingsdefault": {
         "name": "Program settings default"
@@ -5242,7 +5242,7 @@
         "name": "Werkelijke vochtigheid c"
       },
       "recirculation_filter_1_lifetime_in_hours": {
-        "name": "Recirculatie filter 1 levensduur in uren"
+        "name": "Recirculatie filter 1 levensduur"
       },
       "recirculation_filter_1_reset_counter": {
         "name": "Recirculatie filter 1 reset teller"
@@ -5263,10 +5263,10 @@
         "name": "Recirculatie filter 1 type"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Recirculatie filter 1 gebruikte uren"
+        "name": "Gebruik recirculatiefilter 1"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Recirculatie filter 1 levensduur in uren"
+        "name": "Recirculatie filter 1 levensduur"
       },
       "recirculationfilter1status": {
         "name": "Recirculatie filter 1 status"
@@ -5275,10 +5275,10 @@
         "name": "Recirculatie filter 1 type"
       },
       "recirculationfilter1usedhours": {
-        "name": "Recirculatie filter 1 gebruikte uren"
+        "name": "Gebruik recirculatiefilter 1"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Recirculatie filter 2 levensduur in uren"
+        "name": "Recirculatie filter 2 levensduur"
       },
       "recirculationfilter2status": {
         "name": "Recirculatie filter 2 status"
@@ -5287,7 +5287,7 @@
         "name": "Recirculatie filter 2 type"
       },
       "recirculationfilter2usedhours": {
-        "name": "Recirculatie filter 2 gebruikte uren"
+        "name": "Gebruik recirculatiefilter 2"
       },
       "ref_light": {
         "name": "Ref light"
@@ -5482,7 +5482,7 @@
         "name": "Sabbatmodus status"
       },
       "sand_timer1_duration_in_seconds": {
-        "name": "Zandloper 1 duur (seconden)"
+        "name": "Zandloper 1 duur"
       },
       "sand_timer1_start_utc_datetime_bdc_timestamp": {
         "name": "Sand timer 1 start UTC datetime BDC timestamp"
@@ -5496,7 +5496,7 @@
         }
       },
       "sand_timer2_duration_in_seconds": {
-        "name": "Zandloper 2 duur (seconden)"
+        "name": "Zandloper 2 duur"
       },
       "sand_timer2_start_utc_datetime_bdc_timestamp": {
         "name": "Sand timer 2 start UTC datetime BDC timestamp"
@@ -5510,7 +5510,7 @@
         }
       },
       "sand_timer3_duration_in_seconds": {
-        "name": "Zandloper 3 duur (seconden)"
+        "name": "Zandloper 3 duur"
       },
       "sand_timer3_start_utc_datetime_bdc_timestamp": {
         "name": "Sand timer 3 start UTC datetime BDC timestamp"
@@ -5530,7 +5530,7 @@
         "name": "Zandloper 1 einde (UTC tijdstip)"
       },
       "sand_timer_1_paused_total_seconds": {
-        "name": "Totaal gepauzeerde tijd zandloper 1 (seconden)"
+        "name": "Totaal gepauzeerde tijd zandloper 1"
       },
       "sand_timer_1_start_utc_datetime_bdc_timestamp": {
         "name": "Zandloper 1 start (UTC tijdstip)"
@@ -5552,7 +5552,7 @@
         "name": "Zandloper 2 einde (UTC tijdstip)"
       },
       "sand_timer_2_paused_total_seconds": {
-        "name": "Totaal gepauzeerde tijd zandloper 2 (seconden)"
+        "name": "Totaal gepauzeerde tijd zandloper 2"
       },
       "sand_timer_2_start_utc_datetime_bdc_timestamp": {
         "name": "Zandloper 2 start (UTC tijdstip)"
@@ -5574,7 +5574,7 @@
         "name": "Zandloper 3 einde (UTC tijdstip)"
       },
       "sand_timer_3_paused_total_seconds": {
-        "name": "Totaal gepauzeerde tijd zandloper 3 (seconden)"
+        "name": "Totaal gepauzeerde tijd zandloper 3"
       },
       "sand_timer_3_start_utc_datetime_bdc_timestamp": {
         "name": "Zandloper 3 start (UTC tijdstip)"
@@ -5730,13 +5730,13 @@
         "name": "Totale looptijd geselecteerd programma"
       },
       "selected_program_total_running_time_in_minutes": {
-        "name": "Totale looptijd geselecteerd programma (minuten)"
+        "name": "Totale looptijd geselecteerd programma"
       },
       "selected_program_total_time": {
         "name": "Totale tijd geselecteerd programma"
       },
       "selected_program_total_time_in_minutes": {
-        "name": "Totale tijd geselecteerd programma (minuten)"
+        "name": "Totale tijd geselecteerd programma"
       },
       "selected_program_upper_wash_function": {
         "name": "Selected program upper wash function"
@@ -8015,7 +8015,7 @@
         "name": "Timer paused time"
       },
       "timerpausedtotalseconds": {
-        "name": "Timer paused total seconds"
+        "name": "Totale pauzetijd timer"
       },
       "timerstarttime": {
         "name": "Timer start time"
@@ -8051,13 +8051,13 @@
         "name": "Totale verstreken tijd"
       },
       "total_passed_time_seconds": {
-        "name": "Totaal verstreken tijd in seconden"
+        "name": "Totaal verstreken tijd"
       },
       "total_remaining_time": {
         "name": "Totale resterende tijd"
       },
       "total_remaining_time_seconds": {
-        "name": "Totaal resterende tijd in seconden"
+        "name": "Totaal resterende tijd"
       },
       "total_run_time": {
         "name": "Totale looptijd"

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -2040,10 +2040,10 @@
         "name": "Innvendig lysstyrke"
       },
       "programoptiontimestartdelayhour": {
-        "name": "Utsatt start (timer)"
+        "name": "Utsatt start"
       },
       "programtimesstartdelayhours": {
-        "name": "Utsatt start (timer)"
+        "name": "Utsatt start"
       },
       "refrigerator_max_temperature": {
         "name": "Maks kj\u00f8leskapstemperatur"
@@ -3075,7 +3075,7 @@
         "name": "Varselinnstilling for nesten ferdig"
       },
       "almost_finished_notification_settingtimer_in_minutes": {
-        "name": "Varseltidur for nesten ferdig (minutter)"
+        "name": "Varseltidur for nesten ferdig"
       },
       "ambient_sound_setting": {
         "name": "Lydinnstilling for omgivelser"
@@ -3173,7 +3173,7 @@
         "name": "Automatisk d\u00f8r\u00e5pning etter tid ved programslutt"
       },
       "automatic_door_open_at_program_end_after_time_settingtimer_in_minutes": {
-        "name": "Automatisk d\u00f8r\u00e5pning etter tid ved programslutt \u2013 tidsur (minutter)"
+        "name": "Forsinkelse for automatisk d\u00f8r\u00e5pning ved programslutt"
       },
       "automatic_door_open_at_program_end_setting": {
         "name": "Automatisk d\u00f8r\u00e5pning ved programslutt"
@@ -3296,19 +3296,19 @@
         "name": "Bryterstatus for rensmodus"
       },
       "cleanairactivepassedhours": {
-        "name": "Ren luft \u2013 aktive timer brukt"
+        "name": "Ren luft \u2013 aktiv tid forl\u00f8pt"
       },
       "cleanairactivetotalhours": {
-        "name": "Ren luft \u2013 aktive timer totalt"
+        "name": "Ren luft \u2013 total aktiv tid"
       },
       "cleanairdurationofcycleinminutes": {
-        "name": "Ren luft \u2013 syklusvarighet (minutter)"
+        "name": "Ren luft \u2013 syklusvarighet"
       },
       "cleanairmotorlevel": {
         "name": "Ren luft \u2013 motorniv\u00e5"
       },
       "cleanairruncycleeverynumberofminutes": {
-        "name": "Ren luft \u2013 kj\u00f8r syklus hvert antall minutter"
+        "name": "Ren luft \u2013 syklusintervall"
       },
       "cleanairstarttime": {
         "name": "Starttid for ren luft"
@@ -3561,7 +3561,7 @@
         "name": "Gjenst\u00e5ende tid for utsatt start"
       },
       "delay_start_remaining_time_in_minutes": {
-        "name": "Gjenst\u00e5ende tid for utsatt start (minutter)"
+        "name": "Gjenst\u00e5ende tid for utsatt start"
       },
       "delay_start_set_time": {
         "name": "Innstilt tid for utsatt start"
@@ -4594,10 +4594,10 @@
         "name": "Hent flagg for byinfo"
       },
       "gratin_total_allowed_time_in_minutes": {
-        "name": "Total tillatt gratineringstid (minutter)"
+        "name": "Total tillatt gratineringstid"
       },
       "gratin_total_passed_time_in_minutes": {
-        "name": "Total brukt gratineringstid (minutter)"
+        "name": "Total brukt gratineringstid"
       },
       "grease_filter_cleaning_interval_in_hours": {
         "name": "Rengj\u00f8ringsintervall for fettfilter"
@@ -4618,13 +4618,13 @@
         "name": "Tidsur for fettfilter aktivt"
       },
       "grease_filter_used_hours": {
-        "name": "Brukte timer for fettfilter"
+        "name": "Bruk av fettfilter"
       },
       "greasefiltercleaningintervalinhours": {
-        "name": "Rengj\u00f8ringsintervall for fettfilter (timer)"
+        "name": "Rengj\u00f8ringsintervall for fettfilter"
       },
       "greasefilterusedhours": {
-        "name": "Brukte timer for fettfilter"
+        "name": "Bruk av fettfilter"
       },
       "grill_plate_measured_temperature": {
         "name": "M\u00e5lt temperatur for grillplate"
@@ -5074,7 +5074,7 @@
         "name": "Kun vaskemodell"
       },
       "order_time_minimum_hour": {
-        "name": "Bestillingstid minimum time"
+        "name": "Bestillingstid minimum"
       },
       "ota_num1": {
         "name": "OTA-nummer 1"
@@ -5179,7 +5179,7 @@
         "name": "Varselbryter for ferdig forvasketrinn"
       },
       "program_end_to_shutdown_time_in_minutes": {
-        "name": "Tid fra programslutt til avslag (minutter)"
+        "name": "Tid fra programslutt til avslag"
       },
       "program_settingsdefault": {
         "name": "Standard programinnstillinger"
@@ -5263,10 +5263,10 @@
         "name": "Type for resirkuleringsfilter 1"
       },
       "recirculation_filter_1_used_hours": {
-        "name": "Brukte timer for resirkuleringsfilter 1"
+        "name": "Bruk av resirkuleringsfilter 1"
       },
       "recirculationfilter1lifetimeinhours": {
-        "name": "Levetid for resirkuleringsfilter 1 (timer)"
+        "name": "Levetid for resirkuleringsfilter 1"
       },
       "recirculationfilter1status": {
         "name": "Status for resirkuleringsfilter 1"
@@ -5275,10 +5275,10 @@
         "name": "Type for resirkuleringsfilter 1"
       },
       "recirculationfilter1usedhours": {
-        "name": "Brukte timer for resirkuleringsfilter 1"
+        "name": "Bruk av resirkuleringsfilter 1"
       },
       "recirculationfilter2lifetimeinhours": {
-        "name": "Levetid for resirkuleringsfilter 2 (timer)"
+        "name": "Levetid for resirkuleringsfilter 2"
       },
       "recirculationfilter2status": {
         "name": "Status for resirkuleringsfilter 2"
@@ -5287,7 +5287,7 @@
         "name": "Type for resirkuleringsfilter 2"
       },
       "recirculationfilter2usedhours": {
-        "name": "Brukte timer for resirkuleringsfilter 2"
+        "name": "Bruk av resirkuleringsfilter 2"
       },
       "ref_light": {
         "name": "Kj\u00f8lelys"
@@ -7274,7 +7274,7 @@
         "name": "Trinn 4 \u2013 dampintensitet"
       },
       "step4steam_assistset_time_in_minutes": {
-        "name": "Trinn 4 \u2013 innstilt damptid (minutter)"
+        "name": "Trinn 4 \u2013 innstilt damptid"
       },
       "step5_bake_mode": {
         "name": "Trinn 5 \u2013 stekemodus"
@@ -7337,7 +7337,7 @@
         "name": "Trinn 5 \u2013 dampintensitet"
       },
       "step5steam_assistset_time_in_minutes": {
-        "name": "Trinn 5 \u2013 innstilt damptid (minutter)"
+        "name": "Trinn 5 \u2013 innstilt damptid"
       },
       "step_1_duration": {
         "name": "Trinn 1 \u2013 varighet"
@@ -8015,7 +8015,7 @@
         "name": "Tidsur \u2013 pausetid"
       },
       "timerpausedtotalseconds": {
-        "name": "Tidsur \u2013 totale pausesekunder"
+        "name": "Tidsur \u2013 total pausetid"
       },
       "timerstarttime": {
         "name": "Tidsur \u2013 starttid"
@@ -8153,7 +8153,7 @@
         "name": "Vasketrinntid \u2013 t\u00f8m, sentrifuger og stopp"
       },
       "washer_to_dryer_available_for_hours_v": {
-        "name": "Vasker \u2192 t\u00f8rker tilgjengelig (timer)"
+        "name": "Vasker \u2192 t\u00f8rker tilgjengelig"
       },
       "washer_to_dryer_program_id": {
         "name": "Vasker \u2192 t\u00f8rker program-ID"


### PR DESCRIPTION
Moves time-unit information out of entity names and into the data dictionaries, and fixes garbled English source strings.

## Mapping
- Add `device_class: duration` + `unit` to sensors that carried the unit only in their name: Step 4/5 steam-assist set time, automatic-door open delay, washer-to-dryer availability (matching the existing Step 1–3 pattern).

## Names
- Remove the now-redundant unit words from entity names across `en`/`de`/`es`/`fr`/`it`/`nl`/`no` — trailing (`in minutes`), embedded/leading (`Horas de…`, `Heures de…`, `Ore…`, `Uren…`), and parenthesized (`(minuten)`) forms — so Home Assistant renders the unit from the mapping instead.
- Rename the automatic-door timer duration sensor to `Automatic door open at program end delay`; it was only one trailing word away from its sibling setting.
- `Set time hour` / `Set time minutes` intentionally left as-is (they'd collapse to the same name).

## English source
- Fix garbled source strings in `strings.json`/`en.json` (typos like `Soil lever`→`level`, `Quiet model`→`mode`; run-together words like `Alarmoven`→`Alarm oven`).

No property/state keys were renamed and no translation keys were added or removed; `check_translations` reports all languages complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)