### PR TITLE
Add update-translations skill

### DIFF
--- a/.claude/skills/update-translations/CONVENTIONS.md
+++ b/.claude/skills/update-translations/CONVENTIONS.md
@@ -1,0 +1,43 @@
+# Translation conventions
+
+Locked rules for translating ConnectLife entity names, states, and UI strings. The goal is text that reads like it was written for a real appliance in that language, consistent with what the integration already ships.
+
+## Sourcing terminology
+
+- Use the **standard consumer-appliance term** a native speaker sees on a real control panel or in the manual — not a literal dictionary translation. E.g. Cotton → *Baumwolle / Coton / Cotone / Algodón / Katoen*; Spin → *Schleudern / Essorage / Centrifuga*.
+- **Public user manuals are an allowed source** (published Hisense/Gorenje/ASKO/Winix PDFs; the gitignored copies in `local/manuals/`). Multilingual EU manuals list the same label in several languages side by side — the best source for program/mode names.
+- The harvested term glossary is committed alongside this file as `glossary.json`: `[{en, category, de?, es?, fr?, it?, nl?, no?}, …]`. Extend it as you find new appliance terms — record only terms actually printed in a manual; when in doubt, match the term already used elsewhere in the same language file.
+- Keep commit and PR text functional — describe what an entity measures or how a label reads. Public user manuals are fine to reference.
+
+## Units
+
+- **Units and measurements belong in the data dictionary, not in the name.** Set the appropriate `device_class` + `unit` on the property's `sensor`/`number` block and Home Assistant renders the unit after the value: duration (`min`/`h`/`s`), humidity (`%`), temperature (`°C`), energy (`kWh`), etc. The entity **name must not repeat the unit** (`… in minutes`, `… used hours`, `(minuten)`, leading `Horas de …`, `%RH`). Such unit/measurement labels are **not** glossary terms — the glossary holds appliance program/mode/option/phase/status/error/setting terminology only.
+- **Exception — clock / time-of-day components.** When `hour`/`minute`/`second` names *which component of a time* (not a duration), the word is meaningful and stays: e.g. `Set time hour` + `Set time minutes` (a pair — stripping both would collide), and the Sabbath / Night-mode / `*_start_time_*` / `*_end_time_*` hour and minute fields. These are not durations; don't strip the word, and don't give them a `duration` unit. Likewise `_second` sometimes means the ordinal "2nd item" (e.g. `WashingWizzard_Cloth_stains_second`), not the unit — never treat that as a unit.
+- **RPM / spin speed** per language: `de U/min · es rpm · fr tr/min · it giri/min · nl toeren · no o/min`. Never leave English `RPM` in a translated string. (These are state *values* like `1000 U/min`, so they stay in the translations.)
+- Leave unchanged: bare numbers (`600`), pure units (`kg`, `ml`), symbols (`%`, `°C`), and brand/feature tokens (`AquaStop`, `DrumClean`, `Eco 40-60`, `AdaptTech`, `Wi-Fi`).
+
+## Formatting
+
+- Preserve exactly: `{curly_placeholders}` (`{device_name}`, `{count}`), HTML entities, markdown (`**bold**`, `\n`, backticks, links), and leading/trailing spaces. `merge_translations.py` enforces placeholder parity.
+- Match each language's UI casing (German nouns capitalized; sentence case elsewhere).
+- Write JSON `ensure_ascii=True`; run `scripts.sort_translations` after any edit.
+
+## Grammatical form (action vs state)
+
+- A **select** option value (`entity.select.<x>.state.<y>`) is something the user *picks to command* the appliance — prefer the **action / imperative** form for verb-capable labels (`Start`, `Pause`, `Cancel`, `Reset programs to default`).
+- **Exception:** value/enumeration selects whose options are quantities or noun-named modes — spin speeds, durations, temperatures, wattages, or modes like `Delay start`/`Delay end` — stay **nouns**.
+- A `sensor`/`binary_sensor` state or any `.name` is a **noun/state** describing a condition — descriptive noun form.
+
+## Language notes
+
+- **Norwegian:** `timer` means both *hours* and *timer* — never strip it mechanically. Handle `no` by hand.
+- **Dutch/Italian:** don't strip short unit substrings (`uur` inside *temperatuur*, `ore` inside *sensore*) — only remove a unit that is a separate trailing/leading token.
+
+## Garbled English source strings
+
+The English label is `pretty(property_key)`, so a typo'd or run-together **property key** shows up as a garbled English name (`Soil lever`→level, `Quiet model`→mode, `Alarmoven`→missing space). Fix the **display text** in `strings.json` + `en.json` (`gen_strings` preserves existing entries). **Do not rename the key** — it maps to an API property/device code and renaming breaks every language at once.
+
+## Reviewing
+
+- Per-language depth review (fluency + terminology) needs a native-level pass **per language** — one reviewer each, in parallel.
+- A single **cross-language** pass is right for *systematic* issues: garbled sources, inconsistent glossary terms, unit/placeholder drift — it sees the same string's translations side by side. See [workflows/review.js](workflows/review.js).

--- a/.claude/skills/update-translations/SKILL.md
+++ b/.claude/skills/update-translations/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: update-translations
+description: Fill missing translation keys in the ConnectLife language files using appliance-specific terminology, keep time units in the data dictionary (not baked into entity names), verify, and open one PR per language. Use when a language file is missing keys or when unit words need cleaning out of names.
+argument-hint: [lang ...]
+disable-model-invocation: true
+allowed-tools: Bash(uv *) Bash(git *) Bash(gh *) Bash(python3 *)
+---
+
+Add or fix translations for this ConnectLife Home Assistant integration.
+
+Read [CONVENTIONS.md](CONVENTIONS.md) first — it holds the locked terminology and formatting rules. Scripts live in [scripts/](scripts/); optional multi-agent workflow templates in [workflows/](workflows/).
+
+`$ARGUMENTS` is an optional space-separated list of language codes (`de es fr it nl no`); default to all non-English languages.
+
+## Workflow
+
+1. **Find what's missing.**
+   ```bash
+   uv run python -m scripts.check_translations [lang]
+   ```
+   `en.json` is the reference; it is generated from the data dictionaries by `scripts.gen_strings` (which only *adds* missing keys and never overwrites existing text). Never invent keys — only fill keys that `check_translations` reports.
+
+2. **Extract the work list with context.**
+   ```bash
+   python3 .claude/skills/update-translations/scripts/extract_todo.py <lang>   # -> local/i18n/<lang>_todo.json
+   ```
+   Emits each distinct missing English string plus the key path(s) it appears under (needed to disambiguate short labels like `Sl`, `Mid`, `1000 RPM`).
+
+3. **Translate** per [CONVENTIONS.md](CONVENTIONS.md), using the committed term glossary [glossary.json](glossary.json) (extend it from `local/manuals/` and public user manuals — see CONVENTIONS). Produce `local/i18n/<lang>_translations.json` (a transient work file) as a flat `{english_string: translation}` map.
+   - Small sets: translate inline.
+   - Large sets (hundreds+): use the multi-agent workflow in [workflows/translate.js](workflows/translate.js) (requires explicit opt-in — see workflows/README). Batch by file, one reviewer per language.
+
+4. **Merge, sort, verify.**
+   ```bash
+   python3 .claude/skills/update-translations/scripts/merge_translations.py <lang> --check   # dry run
+   python3 .claude/skills/update-translations/scripts/merge_translations.py <lang>           # write
+   uv run python -m scripts.sort_translations
+   uv run python -m scripts.check_translations <lang>        # must report 0 missing
+   ```
+   `merge_translations.py` fills every missing key, reuses existing in-file translations for repeated English strings, and refuses to write if any `{placeholder}` parity check fails or any key is unfilled.
+
+5. **Keep units in the mapping, not in names.** If an entity name bakes in a time unit (`… in minutes`, `… used hours`, `(minuten)`, leading `Horas de …`), set `device_class: duration` + `unit` on the property's `sensor`/`number` block in the data dictionary and drop the unit word from the name in every language. Then verify both directions:
+   ```bash
+   python3 .claude/skills/update-translations/scripts/check_name_units.py    # names vs mapping units, both ways
+   ```
+
+6. **Open one PR per language.** Branch `add-<lang>-translations`; commit only that language's file; keep the PR description functional (see CONVENTIONS). Don't push until the user asks.
+
+## Guardrails
+
+- Never rename property or state **keys** — they map to API property names / device codes. Only edit display text.
+- Write JSON with `ensure_ascii=True` and always run `scripts.sort_translations` after (repo files are ASCII-escaped and sorted).
+- Don't add unit tests asserting a mapping's content — mappings are validated by `scripts.validate_mappings` and PR review.

--- a/.claude/skills/update-translations/glossary.json
+++ b/.claude/skills/update-translations/glossary.json
@@ -1,0 +1,1780 @@
+[
+ {
+  "en": "Abnormal drying (for tumble dryer models)",
+  "category": "error",
+  "es": "Secado anormal (para modelos de secadora)"
+ },
+ {
+  "en": "Acoustic signal",
+  "category": "setting",
+  "de": "Akustisches Signal"
+ },
+ {
+  "en": "AdaptTech",
+  "category": "setting",
+  "de": "AdaptTech"
+ },
+ {
+  "en": "Add clothes",
+  "category": "option",
+  "de": "Kleidung hinzufügen",
+  "es": "Añadir ropa"
+ },
+ {
+  "en": "AddClothes",
+  "category": "option",
+  "de": "AddClothes"
+ },
+ {
+  "en": "Additional functions",
+  "category": "option",
+  "de": "Zusätzliche Funktionen"
+ },
+ {
+  "en": "Airdry function",
+  "category": "option",
+  "de": "Airdry-Funktion"
+ },
+ {
+  "en": "Allergy Care",
+  "category": "program",
+  "es": "Anti-Alergias"
+ },
+ {
+  "en": "Anti crease",
+  "category": "option",
+  "de": "Knitterschutz",
+  "es": "Anti-Arrugas"
+ },
+ {
+  "en": "Anti-Crease function",
+  "category": "option",
+  "de": "Anti-Crease function"
+ },
+ {
+  "en": "AquaStop",
+  "category": "setting",
+  "de": "AquaStop"
+ },
+ {
+  "en": "AS (Humidity sensor error)",
+  "category": "error",
+  "de": "AS (Feuchte-Sensorfehler)",
+  "es": "AS (Error del sensor de humedad)",
+  "fr": "AS (Erreur de capteur d'humidité)",
+  "it": "AS (Errore modulo sensore di umidità)",
+  "nl": "AS (Fout vochtigheidssensor)",
+  "no": "AS (Feil på luftfuktighets-sensor)"
+ },
+ {
+  "en": "Auto defrost",
+  "category": "mode",
+  "de": "Automatischer Abtaubetrieb",
+  "es": "descongelación automática",
+  "fr": "dégivrage automatique",
+  "it": "scongelamento automatico",
+  "nl": "Automatisch ontdooien",
+  "no": "Automatisk avtining"
+ },
+ {
+  "en": "Auto Dose",
+  "category": "option",
+  "es": "Dosis automática"
+ },
+ {
+  "en": "Auto restart",
+  "category": "status",
+  "de": "Automatischer Neustart",
+  "es": "Reinicio automático",
+  "fr": "Redémarrage Automatique",
+  "it": "Riavvio automatico",
+  "nl": "Automatisch herstarten",
+  "no": "Auto-restart"
+ },
+ {
+  "en": "Auto shut off",
+  "category": "status",
+  "de": "Automatische Abschaltung",
+  "es": "Autoapagado",
+  "fr": "Arrêt Automatique",
+  "it": "Spegnimento automatico",
+  "nl": "Automatisch uitschakelen",
+  "no": "Auto avstenging"
+ },
+ {
+  "en": "Auto start",
+  "category": "setting",
+  "de": "Autostart",
+  "es": "encendido automático",
+  "fr": "auto démarrage",
+  "it": "Auto start",
+  "nl": "Automatisch starten",
+  "no": "Auto start"
+ },
+ {
+  "en": "Auto stop",
+  "category": "setting",
+  "de": "Autostopp",
+  "es": "apagado automático",
+  "fr": "auto arrêt",
+  "it": "Auto Stop",
+  "nl": "Automatisch stoppen",
+  "no": "Auto stopp"
+ },
+ {
+  "en": "AUTO-RESTART",
+  "category": "option",
+  "de": "AUTO-RESTART",
+  "es": "AUTO-RESTART",
+  "fr": "AUTO-RESTART",
+  "it": "AUTO-RESTART",
+  "nl": "AUTO-RESTART"
+ },
+ {
+  "en": "Baby",
+  "category": "program",
+  "de": "Baby",
+  "es": "Baby",
+  "fr": "Bébé",
+  "nl": "Baby"
+ },
+ {
+  "en": "Baby Care",
+  "category": "program",
+  "es": "Cuidado del Bebé"
+ },
+ {
+  "en": "Baby clothes",
+  "category": "program",
+  "de": "Baby-Wäsche"
+ },
+ {
+  "en": "Bedding",
+  "category": "program",
+  "es": "Ropa de Cama"
+ },
+ {
+  "en": "Bucket full",
+  "category": "status",
+  "de": "voller Eimer",
+  "es": "depósito lleno",
+  "fr": "plein de seau",
+  "it": "serbatoio pieno",
+  "nl": "Reservoir vol",
+  "no": "Bøtte full"
+ },
+ {
+  "en": "Child Lock",
+  "category": "setting",
+  "de": "Kindersicherung",
+  "es": "Bloqueo infantil"
+ },
+ {
+  "en": "ChildLock",
+  "category": "setting",
+  "de": "Kindersicherung"
+ },
+ {
+  "en": "Clean filter",
+  "category": "status",
+  "de": "Filter reinigen",
+  "es": "limpieza de filtro",
+  "fr": "Nettoyer le filtre",
+  "it": "Pulire il filtro",
+  "nl": "Filter reinigen",
+  "no": "Rengjør filter"
+ },
+ {
+  "en": "Cold wash",
+  "category": "option",
+  "de": "Kaltwäsche",
+  "es": "Lavado en frío"
+ },
+ {
+  "en": "Colour",
+  "category": "program",
+  "de": "Bunt"
+ },
+ {
+  "en": "Comfort dehumidifying operation",
+  "category": "mode",
+  "de": "Komfortentfeuchtung",
+  "es": "deshumidificación confortable",
+  "fr": "fonctionnement sans à-coups",
+  "it": "deumidificazione comfort",
+  "nl": "comfort ontvochtiger",
+  "no": "komfortavfukting"
+ },
+ {
+  "en": "Connect",
+  "category": "setting",
+  "de": "Verbindung"
+ },
+ {
+  "en": "Connecting",
+  "category": "status",
+  "es": "Conectando"
+ },
+ {
+  "en": "Connection",
+  "category": "status",
+  "de": "Verbindung"
+ },
+ {
+  "en": "Continuous",
+  "category": "mode",
+  "de": "Dauerbetrieb",
+  "es": "continuo",
+  "fr": "continu",
+  "it": "continuo",
+  "nl": "Continue",
+  "no": "Kontinuerlig"
+ },
+ {
+  "en": "Continuous dehumidifying operation",
+  "category": "mode",
+  "de": "kontinuierlicher Entfeuchtungsbetrieb",
+  "es": "funcionamiento de deshumidificación continuo",
+  "fr": "fonctionnement continu",
+  "it": "deumidificazione continua",
+  "nl": "continue ontvochtigingswerking",
+  "no": "kontinuerlig avfukting"
+ },
+ {
+  "en": "Control pads",
+  "category": "other",
+  "de": "Bedienfeld",
+  "es": "Botones de control",
+  "fr": "Panneau de commande",
+  "it": "Tasti di controllo",
+  "nl": "Bedieningstoetsen",
+  "no": "Kontrollbrytere"
+ },
+ {
+  "en": "Control panel",
+  "category": "other",
+  "de": "Bedienfeld",
+  "es": "Panel de control",
+  "fr": "Panneau de commande",
+  "it": "Pannello di controllo",
+  "nl": "Bedieningspaneel",
+  "no": "Kontrollpanel"
+ },
+ {
+  "en": "Convection bake",
+  "category": "program",
+  "de": "Umluft",
+  "fr": "Convection forcée",
+  "it": "Ventilato"
+ },
+ {
+  "en": "Conventional (Top and Bottom Heat)",
+  "category": "program",
+  "de": "Ober- & Unterhitze",
+  "fr": "Convection naturelle",
+  "it": "Statico"
+ },
+ {
+  "en": "Cooking tables",
+  "category": "other",
+  "de": "Gartabellen",
+  "fr": "Tableaux de cuisson",
+  "it": "Tabelle di cottura"
+ },
+ {
+  "en": "Cooking time",
+  "category": "setting",
+  "de": "Garzeit",
+  "fr": "Temps de cuisson",
+  "it": "Tempo di cottura"
+ },
+ {
+  "en": "Cool",
+  "category": "mode",
+  "de": "Kühlung",
+  "es": "enfriar",
+  "it": "raffreddamento",
+  "nl": "cool modus"
+ },
+ {
+  "en": "COOL operation",
+  "category": "mode",
+  "de": "COOL-Betrieb (Kühlung)",
+  "es": "Funcionamiento COOL",
+  "fr": "Fonctionnement COOL",
+  "it": "Funzione COOL",
+  "nl": "COOL-werking"
+ },
+ {
+  "en": "Cotton",
+  "category": "program",
+  "de": "Baumwolle",
+  "es": "Algodón"
+ },
+ {
+  "en": "Cotton Dry",
+  "category": "program",
+  "es": "Algodón Seco"
+ },
+ {
+  "en": "Cotton white",
+  "category": "program",
+  "de": "Baumwolle weiß"
+ },
+ {
+  "en": "Cottons",
+  "category": "program",
+  "de": "Baumwolle",
+  "es": "Algodón",
+  "fr": "Coton",
+  "nl": "Katoen"
+ },
+ {
+  "en": "Cottons +",
+  "category": "program",
+  "de": "Baumwolle +",
+  "es": "Algodón +",
+  "fr": "Coton +",
+  "nl": "Katoen +"
+ },
+ {
+  "en": "Crease prevention",
+  "category": "option",
+  "de": "Knitterschutz"
+ },
+ {
+  "en": "Cupboard",
+  "category": "option",
+  "es": "Armario"
+ },
+ {
+  "en": "Cycle Mode",
+  "category": "mode",
+  "es": "Modo ciclo"
+ },
+ {
+  "en": "Daily use",
+  "category": "other",
+  "de": "Tägliche Verwendung",
+  "fr": "Usage quotidien",
+  "it": "Uso quotidiano"
+ },
+ {
+  "en": "Default",
+  "category": "option",
+  "de": "Standard"
+ },
+ {
+  "en": "Defrost",
+  "category": "program",
+  "de": "Auftauen",
+  "fr": "Décongélation",
+  "it": "Scongelamento"
+ },
+ {
+  "en": "Dehumidifier",
+  "category": "other",
+  "de": "Luftentfeuchter",
+  "es": "Deshumidificador",
+  "fr": "Déshumidificateur / Dessécheuse",
+  "it": "Deumidificatore",
+  "nl": "Luchtontvochtiger",
+  "no": "Avfukter"
+ },
+ {
+  "en": "Delay End",
+  "category": "option",
+  "de": "Startzeit",
+  "es": "Final. Dif."
+ },
+ {
+  "en": "Delay start",
+  "category": "option",
+  "de": "STARTZEITVORWAHL",
+  "es": "INICIO DIFERIDO",
+  "fr": "DEPART DIFFERE",
+  "nl": "UITGESTELDE START"
+ },
+ {
+  "en": "Delaying the end of the washing program",
+  "category": "option",
+  "de": "Ende verzögern"
+ },
+ {
+  "en": "Delicate",
+  "category": "program",
+  "de": "Feinwäsche",
+  "es": "Delicados",
+  "fr": "Délicat",
+  "nl": "Delicaat"
+ },
+ {
+  "en": "Description of function",
+  "category": "other",
+  "de": "Funktionsbeschreibung",
+  "fr": "Description des fonctions",
+  "it": "Descrizione Funzione"
+ },
+ {
+  "en": "Detergent",
+  "category": "setting",
+  "es": "Detergente"
+ },
+ {
+  "en": "Digital display",
+  "category": "status",
+  "es": "Display digital"
+ },
+ {
+  "en": "Dispenser 2",
+  "category": "setting",
+  "es": "Dispensador 2"
+ },
+ {
+  "en": "Display",
+  "category": "setting",
+  "de": "Anzeige",
+  "es": "Pantalla",
+  "fr": "Affichage",
+  "it": "Display",
+  "nl": "Display",
+  "no": "Display"
+ },
+ {
+  "en": "Displays error codes",
+  "category": "status",
+  "de": "Zeigt Fehlercodes an",
+  "es": "Muestra los códigos de error",
+  "fr": "Affiche les codes d'erreur",
+  "it": "Mostra i codici di errore",
+  "nl": "Toont foutcodes"
+ },
+ {
+  "en": "Displays protection code",
+  "category": "status",
+  "de": "Zeigt den Schutzcode an",
+  "es": "Muestra el código de protección",
+  "fr": "Affiche le code de protection",
+  "it": "Mostra i codici di protezione",
+  "nl": "Toont de beveiligingscode"
+ },
+ {
+  "en": "Door Lock",
+  "category": "status",
+  "es": "Bloqueo de la puerta"
+ },
+ {
+  "en": "DOOR LOCK ERROR",
+  "category": "error",
+  "de": "Fehler Lukenentriegelung"
+ },
+ {
+  "en": "Door lock lever",
+  "category": "status",
+  "es": "Palanca de bloqueo de la puerta"
+ },
+ {
+  "en": "DOOR LOCKED",
+  "category": "status",
+  "de": "TÜRVERRIEGELUNG",
+  "es": "SEGURIDAD PUERTA",
+  "fr": "PORTE SECURISEE",
+  "nl": "DEUR BEVEILIGING"
+ },
+ {
+  "en": "Door locking fault",
+  "category": "error",
+  "es": "Fallo de bloqueo de la puerta"
+ },
+ {
+  "en": "Door unlocking fault",
+  "category": "error",
+  "es": "Fallo de desbloqueo de la puerta"
+ },
+ {
+  "en": "Dose aid",
+  "category": "option",
+  "de": "DOSE AID"
+ },
+ {
+  "en": "Drain",
+  "category": "program",
+  "de": "Abpumpen"
+ },
+ {
+  "en": "Drain + Spin",
+  "category": "phase",
+  "de": "Schleudern +Abpumpen",
+  "es": "Centrifugado + Desagüe",
+  "fr": "Vidange + Essorage",
+  "nl": "Centrifugeren + Afvoeren"
+ },
+ {
+  "en": "Drum Clean",
+  "category": "program",
+  "de": "Trommelreinigung",
+  "es": "Limpieza del Tambor"
+ },
+ {
+  "en": "Drum illumination",
+  "category": "other",
+  "de": "Trommelinnenbeleuchtung"
+ },
+ {
+  "en": "DrumClean",
+  "category": "program",
+  "de": "DrumClean"
+ },
+ {
+  "en": "Dry",
+  "category": "phase",
+  "de": "Trocken",
+  "es": "secar",
+  "it": "Deumidificatore",
+  "nl": "ontvochtigen"
+ },
+ {
+  "en": "Dry Level",
+  "category": "option",
+  "es": "Nivel secado"
+ },
+ {
+  "en": "DRY operation",
+  "category": "mode",
+  "de": "DRY Betrieb (Trocken)",
+  "es": "Funcionamiento DRY",
+  "fr": "Opération DRY",
+  "it": "Funzione Deumidificatore",
+  "nl": "DRY-werking"
+ },
+ {
+  "en": "Drying",
+  "category": "phase",
+  "es": "Secado"
+ },
+ {
+  "en": "E1 - Room temperature sensor error",
+  "category": "error",
+  "de": "E1 - Fehler des Raumtemperatursensors",
+  "es": "E1 - Error del sensor de temperatura de la habitación",
+  "fr": "E1 - Erreur du capteur de température ambiante",
+  "it": "E1 - Errore del sensore della temperatura dell'ambiente",
+  "nl": "E1 - kamertemperatuursensor fout"
+ },
+ {
+  "en": "E2 - Evaporator temperature sensor error",
+  "category": "error",
+  "de": "E2 - Fehler im Temperaturfühler des Verdampfers",
+  "es": "E2 - Error del sensor de temperatura del evaporador",
+  "fr": "E2 - Erreur du capteur de température d'évaporateur",
+  "it": "E2 - Errore del sensore della temperatura dell'evaporatore",
+  "nl": "E2 - Verdamper temperatuursensor fout"
+ },
+ {
+  "en": "E4 - Display panel communication error",
+  "category": "error",
+  "de": "E4 - Kommunikationsfehler im Bedienfeld",
+  "es": "E4 - Error de comunicación del panel indicador",
+  "fr": "E4 - Erreur de communication du panneau d'affichage",
+  "it": "E4 - Errore di comunicazione del display",
+  "nl": "E4 - Displaypaneel communicatiefout"
+ },
+ {
+  "en": "Easy ironing",
+  "category": "option",
+  "de": "Einfaches Bügeln"
+ },
+ {
+  "en": "Eb (Bucket removed or not in right position)",
+  "category": "error",
+  "de": "Eb (Eimer ist entfernt oder nicht in der richtigen Position)",
+  "es": "Eb (El depósito no está en posición correcta)",
+  "fr": "Eb (Le seau est déplacé ou n'est pas mis à sa place)",
+  "it": "Eb (Il serbatoio è stato rimosso o non è nella posizione corretta)",
+  "nl": "Eb (Reservoir is verwijderd of niet in de correcte positie)",
+  "no": "Eb (Bøtten er fjernet eller ikke i riktig posisjon)"
+ },
+ {
+  "en": "EC - Refrigerant leakage detection malfunction",
+  "category": "error",
+  "de": "EC - Fehlfunktion der Erkennung von Kältemittelleckagen",
+  "es": "EC - Fallo de detección de fugas de refrigerante",
+  "fr": "EC - Dysfonctionnement de la détection de fuite de réfrigérant",
+  "it": "EC - Malfunzionamento del rilevamento di perdite di liquido refrigerante",
+  "nl": "EC - Koelmiddel lekkagedetectie storing"
+ },
+ {
+  "en": "Eco 40-60",
+  "category": "program",
+  "de": "Eco 40-60",
+  "es": "Eco 40-60",
+  "fr": "Éco 40-60",
+  "nl": "Eco 40-60"
+ },
+ {
+  "en": "Eco 40–60 °C",
+  "category": "program",
+  "de": "Eco 40–60 °C"
+ },
+ {
+  "en": "Electronic module fault",
+  "category": "error",
+  "es": "Fallo del módulo electrónico"
+ },
+ {
+  "en": "End",
+  "category": "status",
+  "de": "End",
+  "es": "Fin del programa",
+  "fr": "End",
+  "nl": "End"
+ },
+ {
+  "en": "End of washing setting",
+  "category": "option",
+  "de": "Einstellung für das Ende des Waschvorgangs"
+ },
+ {
+  "en": "Error while locking the door",
+  "category": "error",
+  "de": "Fehler Lukenverriegelung"
+ },
+ {
+  "en": "Error while unlocking the door",
+  "category": "error",
+  "de": "Fehler beim Entriegeln der Tür"
+ },
+ {
+  "en": "ES (Tube temperature sensor error)",
+  "category": "error",
+  "de": "ES (Röhrentemperatursensor des Verdampferfehlers)",
+  "es": "ES (Error del sensor de temperatura del tubo del evaporador)",
+  "fr": "ES (Erreur de capteur de température)",
+  "it": "ES (Errore del sensore di temperatura)",
+  "nl": "ES (Fout temperatuursensor van de verdamper)",
+  "no": "ES (Feil på temperatursensoren)"
+ },
+ {
+  "en": "Excessive amount of detergent",
+  "category": "error",
+  "de": "Übermäßige Menge Waschmittel"
+ },
+ {
+  "en": "Extra Dry",
+  "category": "option",
+  "es": "Secado extra"
+ },
+ {
+  "en": "Extra functions",
+  "category": "option",
+  "de": "Zusätzliche Funktionen"
+ },
+ {
+  "en": "Extra hygiene",
+  "category": "program",
+  "de": "Extra hygiene"
+ },
+ {
+  "en": "Extra water",
+  "category": "option",
+  "de": "Hoher Wasserstand"
+ },
+ {
+  "en": "ExtraHygiene",
+  "category": "program",
+  "de": "ExtraHygiene"
+ },
+ {
+  "en": "Fan",
+  "category": "mode",
+  "de": "FAN-Betrieb",
+  "es": "ventilador",
+  "fr": "Opération FAN",
+  "it": "Funzione FAN",
+  "nl": "FAN-werking"
+ },
+ {
+  "en": "FAN operation",
+  "category": "mode",
+  "de": "FAN-Betrieb",
+  "es": "Funcionamiento FAN",
+  "fr": "Opération FAN",
+  "it": "Funzione FAN",
+  "nl": "FAN-werking"
+ },
+ {
+  "en": "FAN SPEED",
+  "category": "setting",
+  "de": "Lüftergeschwindigkeit",
+  "es": "velocidad del ventilador",
+  "fr": "vitesse du ventilateur",
+  "it": "velocità della ventola",
+  "nl": "ventilatorsnelheid",
+  "no": "viftehastighet"
+ },
+ {
+  "en": "Fast",
+  "category": "option",
+  "de": "Schnell"
+ },
+ {
+  "en": "FastWashing function",
+  "category": "option",
+  "de": "FastWashing"
+ },
+ {
+  "en": "Faults",
+  "category": "error",
+  "de": "Störungen"
+ },
+ {
+  "en": "Faults and errors table",
+  "category": "error",
+  "de": "Tabelle Störungen und Fehler"
+ },
+ {
+  "en": "Filter",
+  "category": "other",
+  "de": "Filter",
+  "es": "Filter",
+  "fr": "Filtre",
+  "it": "Filtro",
+  "nl": "Filter",
+  "no": "Filter"
+ },
+ {
+  "en": "Foam sensor",
+  "category": "other",
+  "de": "Schaumsensor"
+ },
+ {
+  "en": "FOLLOW ME/TEMP SENSING",
+  "category": "option",
+  "de": "FOLLOW ME/TEMP SENSING",
+  "es": "FOLLOW ME/TEMP SENSING",
+  "fr": "FOLLOW ME/TEMP SENSING",
+  "it": "FOLLOW ME/TEMP SENSING",
+  "nl": "FOLLOW ME/TEMP SENSING"
+ },
+ {
+  "en": "Forced air",
+  "category": "program",
+  "de": "Heissluft",
+  "fr": "Chaleur pulsée",
+  "it": "Termoventilato"
+ },
+ {
+  "en": "Full",
+  "category": "status",
+  "de": "Full",
+  "es": "Full",
+  "fr": "Full",
+  "it": "Full",
+  "nl": "Full",
+  "no": "Full"
+ },
+ {
+  "en": "Full load",
+  "category": "other",
+  "de": "Nennkapazität"
+ },
+ {
+  "en": "Full load 49'",
+  "category": "program",
+  "es": "Carga completa 49'"
+ },
+ {
+  "en": "Function",
+  "category": "other",
+  "de": "Funktion",
+  "fr": "Fonction",
+  "it": "Funzione"
+ },
+ {
+  "en": "Grill",
+  "category": "program",
+  "de": "Grill",
+  "fr": "Gril",
+  "it": "Grill"
+ },
+ {
+  "en": "Grilling with fan",
+  "category": "program",
+  "de": "Grillen mit Heissluft",
+  "fr": "Gril avec ventilateur",
+  "it": "Grill con ventola"
+ },
+ {
+  "en": "high",
+  "category": "option",
+  "de": "Hoch",
+  "es": "Alta",
+  "fr": "Élevé",
+  "it": "Alto",
+  "nl": "Hoog",
+  "no": "Kraftig"
+ },
+ {
+  "en": "High fan speed",
+  "category": "option",
+  "de": "Hohe Drehzahl des Lüfters",
+  "es": "Velocidad alta de ventilador",
+  "fr": "Vitesse élevée de ventilateur",
+  "it": "Alta velocità della ventola",
+  "nl": "Hoge ventilator",
+  "no": "Kraftig vifte"
+ },
+ {
+  "en": "High water level",
+  "category": "option",
+  "de": "Hoher Wasserstand"
+ },
+ {
+  "en": "Humidity level",
+  "category": "setting",
+  "de": "Feuchtigkeitsgrad",
+  "es": "Nivel de humedad",
+  "fr": "Niveau d'humidité",
+  "it": "Livello di umidità",
+  "nl": "Vochtigheidsgraad",
+  "no": "Fuktighetsnivå"
+ },
+ {
+  "en": "INCORRECT SETTINGS",
+  "category": "error",
+  "de": "Falsche Einstellungen"
+ },
+ {
+  "en": "IntensiveCare",
+  "category": "mode",
+  "de": "IntensiveCare"
+ },
+ {
+  "en": "Iron",
+  "category": "option",
+  "es": "Plancha"
+ },
+ {
+  "en": "Jeans",
+  "category": "program",
+  "de": "Jeans",
+  "es": "Jeans",
+  "fr": "Jeans",
+  "nl": "Jeans"
+ },
+ {
+  "en": "KEY LOCK",
+  "category": "setting",
+  "de": "Tastensperre",
+  "es": "Bloqueo de tecla",
+  "fr": "Verrouillage des commandes",
+  "nl": "Knoppenvergrendeling"
+ },
+ {
+  "en": "Language",
+  "category": "setting",
+  "es": "Idioma"
+ },
+ {
+  "en": "Laundry adding",
+  "category": "option",
+  "de": "Wäsche hinzufügen"
+ },
+ {
+  "en": "LED display",
+  "category": "other",
+  "de": "LED-Anzeige",
+  "es": "Display LED",
+  "fr": "Écran LED",
+  "it": "Display a LED",
+  "nl": "LED-display"
+ },
+ {
+  "en": "LED thermostat/preheating",
+  "category": "status",
+  "de": "Kontrollleuchte Thermostat/Vorheizen",
+  "fr": "Voyant thermostat/préchauffage",
+  "it": "Spia termostato/preriscaldamento"
+ },
+ {
+  "en": "Level",
+  "category": "other",
+  "es": "Nivel"
+ },
+ {
+  "en": "Light",
+  "category": "option",
+  "de": "Lampen",
+  "fr": "Éclairage",
+  "it": "Lampada"
+ },
+ {
+  "en": "Load sensor",
+  "category": "other",
+  "de": "Load sensor"
+ },
+ {
+  "en": "Lockable control panel",
+  "category": "setting",
+  "de": "Kindersicherung"
+ },
+ {
+  "en": "Low (fan speed)",
+  "category": "option",
+  "de": "Niedrig",
+  "es": "Baja",
+  "fr": "Basse",
+  "it": "Bassa",
+  "nl": "Laag"
+ },
+ {
+  "en": "Low standby mode",
+  "category": "setting",
+  "de": "Standby-Modus"
+ },
+ {
+  "en": "Main wash",
+  "category": "phase",
+  "de": "Hauptwäsche",
+  "es": "Lavado"
+ },
+ {
+  "en": "Manual",
+  "category": "mode",
+  "de": "Manuell",
+  "fr": "Manuelle",
+  "it": "Manuale"
+ },
+ {
+  "en": "Mix 20°",
+  "category": "program",
+  "de": "Mix 20°",
+  "es": "Mix 20°",
+  "fr": "Mix 20°",
+  "nl": "Mix 20°"
+ },
+ {
+  "en": "Mix/Synthetics",
+  "category": "program",
+  "de": "Mix/Synthetics"
+ },
+ {
+  "en": "Mixed laundry/Synthetics",
+  "category": "program",
+  "de": "Pflegeleicht/Synthetik"
+ },
+ {
+  "en": "MODE",
+  "category": "setting",
+  "de": "MODUS-Taste",
+  "es": "Botón MODE",
+  "fr": "Bouton MODE",
+  "it": "Tasto MODE",
+  "nl": "MODE-toets"
+ },
+ {
+  "en": "Mode indicator light",
+  "category": "status",
+  "de": "Modusanzeige",
+  "it": "Spia della modalità"
+ },
+ {
+  "en": "Motor control error",
+  "category": "error",
+  "de": "Fehler Motorsteuerung"
+ },
+ {
+  "en": "Mute",
+  "category": "setting",
+  "es": "Silencio"
+ },
+ {
+  "en": "Neutral",
+  "category": "phase",
+  "es": "Neutro"
+ },
+ {
+  "en": "Normal",
+  "category": "option",
+  "de": "Normal",
+  "es": "Normal",
+  "fr": "Normal",
+  "it": "Normale",
+  "nl": "Normaal",
+  "no": "Normal"
+ },
+ {
+  "en": "NormalCare",
+  "category": "mode",
+  "de": "NormalCare"
+ },
+ {
+  "en": "Number of completed wash cycles",
+  "category": "status",
+  "de": "Anzahl abgeschlossener Waschgänge"
+ },
+ {
+  "en": "Number of programmes",
+  "category": "other",
+  "de": "Programmanzahl"
+ },
+ {
+  "en": "ON/OFF",
+  "category": "other",
+  "de": "Ein/Aus"
+ },
+ {
+  "en": "Options",
+  "category": "option",
+  "de": "Extras",
+  "es": "Opciones",
+  "fr": "Options",
+  "nl": "Opties"
+ },
+ {
+  "en": "Oven functions table",
+  "category": "other",
+  "de": "Übersicht Betriebsarten des Geräts",
+  "fr": "Tableau des Fonctions du four",
+  "it": "Tabella Funzioni Forno"
+ },
+ {
+  "en": "Oven off",
+  "category": "mode",
+  "de": "Backofen aus",
+  "fr": "Arrêt four",
+  "it": "Forno spento"
+ },
+ {
+  "en": "OVERFLOW",
+  "category": "error",
+  "es": "Desbordamiento"
+ },
+ {
+  "en": "Overflow protection",
+  "category": "setting",
+  "de": "Überlaufschutz"
+ },
+ {
+  "en": "P1 - Bottom tray is full",
+  "category": "error",
+  "de": "P1 - Bodenwanne ist voll",
+  "es": "P1 - La bandeja inferior está llena",
+  "fr": "P1 - Le bac inférieur est plein",
+  "it": "P1 - La vaschetta inferiore è piena",
+  "nl": "P1 - Opvangbak is vol"
+ },
+ {
+  "en": "P2 (Bucket full or not in right position)",
+  "category": "error",
+  "de": "P2 (Der Eimer ist voll oder nicht in der richtigen Position)",
+  "es": "P2 (El depósito está lleno o no está en posición correcta)",
+  "fr": "P2 (Le seau est plein ou n'est pas mis à sa place)",
+  "it": "P2 (Il serbatoio è pieno o non è nella posizione corretta)",
+  "nl": "P2 (Reservoir is vol of bevindt zich niet in de correcte positie)",
+  "no": "P2 (Bøtten er full eller satt til feil posisjon)"
+ },
+ {
+  "en": "PAUSE",
+  "category": "status",
+  "de": "Pause",
+  "es": "Pausa"
+ },
+ {
+  "en": "Pause button",
+  "category": "other",
+  "de": "Pause - Taste"
+ },
+ {
+  "en": "Personal settings",
+  "category": "setting",
+  "de": "Eigene Einstellungen"
+ },
+ {
+  "en": "Personal settings saving",
+  "category": "setting",
+  "de": "Persönliche Einstellungen speichern"
+ },
+ {
+  "en": "Pets",
+  "category": "program",
+  "de": "Pets",
+  "es": "Mascotas"
+ },
+ {
+  "en": "Pillow",
+  "category": "program",
+  "de": "Daunen"
+ },
+ {
+  "en": "Power",
+  "category": "setting",
+  "de": "Ein/Ausschaltung",
+  "es": "Encendido",
+  "fr": "Alimentation",
+  "it": "Accensione",
+  "nl": "Aan/Uit",
+  "no": "Av/på"
+ },
+ {
+  "en": "Power 30'",
+  "category": "program",
+  "es": "Potencia 30'"
+ },
+ {
+  "en": "Power 59´|32´",
+  "category": "program",
+  "de": "Power 59´|32´"
+ },
+ {
+  "en": "Power failure",
+  "category": "error",
+  "de": "Stromausfall"
+ },
+ {
+  "en": "Power indicator light",
+  "category": "status",
+  "de": "Stromanzeige",
+  "it": "Energia spia",
+  "nl": "Power controlelampje"
+ },
+ {
+  "en": "Power switch",
+  "category": "setting",
+  "de": "Netzschalter",
+  "es": "Botón de encendido",
+  "fr": "Bouton d'alimentation",
+  "it": "Tasto di accensione",
+  "nl": "Aan/Uit-knop"
+ },
+ {
+  "en": "PowerWash 59'",
+  "category": "program",
+  "de": "PowerWash 59'"
+ },
+ {
+  "en": "Preheating",
+  "category": "phase",
+  "de": "Vorheizen",
+  "fr": "Préchauffage",
+  "it": "Preriscaldamento"
+ },
+ {
+  "en": "Prewash",
+  "category": "option",
+  "de": "Vorwäsche",
+  "es": "Prelavado",
+  "fr": "Prélavage",
+  "nl": "Voorwas"
+ },
+ {
+  "en": "Program end",
+  "category": "status",
+  "es": "Fin del programa"
+ },
+ {
+  "en": "Programmable",
+  "category": "setting",
+  "de": "Programmierbar"
+ },
+ {
+  "en": "Programme selector",
+  "category": "other",
+  "de": "Programmwahlschalter",
+  "es": "Selector de programas con posición OFF"
+ },
+ {
+  "en": "Pump operation",
+  "category": "mode",
+  "de": "Pumpenbetrieb",
+  "es": "Funcionamiento de la bomba",
+  "fr": "Opération de la pompe",
+  "it": "Funzionamento della pompa",
+  "nl": "Pompwerking",
+  "no": "Pumpe operasjon"
+ },
+ {
+  "en": "Pump stop",
+  "category": "option",
+  "de": "Pumpenstopp"
+ },
+ {
+  "en": "Quick 15'",
+  "category": "program",
+  "es": "Rápido 15'"
+ },
+ {
+  "en": "Quick 20'",
+  "category": "program",
+  "de": "Speed 20'"
+ },
+ {
+  "en": "Quick wash programme",
+  "category": "option",
+  "de": "Schnellwaschprogramm"
+ },
+ {
+  "en": "Quicker",
+  "category": "option",
+  "es": "Más rápido"
+ },
+ {
+  "en": "Rapid 14'",
+  "category": "program",
+  "de": "Kurz 14'",
+  "fr": "Rapide 14'",
+  "nl": "Snel 14'"
+ },
+ {
+  "en": "Rapid 59'",
+  "category": "program",
+  "de": "Kurz 59'",
+  "es": "Rápidos 59'",
+  "fr": "Rapide 59'",
+  "nl": "Snel 59'"
+ },
+ {
+  "en": "Refresh",
+  "category": "program",
+  "es": "Refrescar"
+ },
+ {
+  "en": "Remote Control",
+  "category": "setting",
+  "de": "Fernsteuerung",
+  "es": "Control remoto"
+ },
+ {
+  "en": "Remote Control (icon)",
+  "category": "status",
+  "es": "Control remoto"
+ },
+ {
+  "en": "Remote start",
+  "category": "setting",
+  "de": "Fernbedienung Start"
+ },
+ {
+  "en": "Rinse",
+  "category": "phase",
+  "de": "Spülen",
+  "es": "Aclarados",
+  "fr": "Rinçage",
+  "nl": "Spoelen"
+ },
+ {
+  "en": "Rinse/softening",
+  "category": "program",
+  "de": "Spülen / Einweichen"
+ },
+ {
+  "en": "Rinse&Softening",
+  "category": "program",
+  "de": "Spülen&Weichspülen"
+ },
+ {
+  "en": "Rinse+Spin",
+  "category": "program",
+  "es": "Aclarado+ Centrifugado"
+ },
+ {
+  "en": "Selection knob",
+  "category": "other",
+  "de": "Auswahlknopf",
+  "fr": "Bouton de sélection",
+  "it": "Manopola di selezione"
+ },
+ {
+  "en": "Self cleaning program",
+  "category": "program",
+  "de": "Selbstreinigungs-Programm"
+ },
+ {
+  "en": "Self-cleaning programme",
+  "category": "program",
+  "de": "Selbstreinigungsprogramm"
+ },
+ {
+  "en": "Setting the timer",
+  "category": "setting",
+  "de": "Einstellen des Timers",
+  "fr": "Réglage de la minuterie",
+  "it": "Impostazione del timer"
+ },
+ {
+  "en": "Shirts",
+  "category": "program",
+  "de": "Hemden/Blusen",
+  "es": "Camisas",
+  "fr": "Chemises",
+  "nl": "Hemden"
+ },
+ {
+  "en": "Shirts with steam",
+  "category": "program",
+  "de": "Hemden mit Dampf"
+ },
+ {
+  "en": "ShirtsSteam",
+  "category": "program",
+  "de": "ShirtsSteam"
+ },
+ {
+  "en": "Skip spin",
+  "category": "option",
+  "de": "Schleudern überspringen"
+ },
+ {
+  "en": "SLEEP/ECO operation",
+  "category": "mode",
+  "de": "SLEEP/ECO-Betrieb",
+  "es": "Funcionamiento SLEEP/ECO",
+  "fr": "Opération SLEEP / ECO",
+  "it": "Funzionalità SLEEP/ECO",
+  "nl": "SLEEP/ECO-werking"
+ },
+ {
+  "en": "Softener",
+  "category": "setting",
+  "es": "Suavizante"
+ },
+ {
+  "en": "Softening",
+  "category": "phase",
+  "de": "Weichspülen"
+ },
+ {
+  "en": "Sound off",
+  "category": "setting",
+  "de": "Ton aus"
+ },
+ {
+  "en": "Sound on/off",
+  "category": "setting",
+  "de": "Ton Ein/Aus"
+ },
+ {
+  "en": "Sound signal",
+  "category": "setting",
+  "de": "Akustisches Signal"
+ },
+ {
+  "en": "Speed 20'",
+  "category": "option",
+  "de": "Speed 20'"
+ },
+ {
+  "en": "Speed 20´",
+  "category": "program",
+  "de": "Schnell 20'"
+ },
+ {
+  "en": "Spin",
+  "category": "program",
+  "de": "Schleudern",
+  "es": "Centrifugado"
+ },
+ {
+  "en": "Spin & Drain",
+  "category": "program",
+  "de": "Schleudern +Abpumpen",
+  "es": "Centrifugado + Desagüe",
+  "fr": "Vidange + Essorage",
+  "nl": "Centrifugeren + Afvoeren"
+ },
+ {
+  "en": "Spin and Dry",
+  "category": "program",
+  "es": "Centrifugar y secar"
+ },
+ {
+  "en": "Spin speed",
+  "category": "option",
+  "de": "Schleudergeschwindigkeit",
+  "es": "Selección centrifugado",
+  "fr": "Sélection essorage",
+  "nl": "Centrifuge selectie"
+ },
+ {
+  "en": "Spin/drain",
+  "category": "program",
+  "de": "Schleudern/Ablassen"
+ },
+ {
+  "en": "Spin|Drain",
+  "category": "program",
+  "de": "Schleudern | Abpumpen"
+ },
+ {
+  "en": "Spinning",
+  "category": "phase",
+  "de": "Schleudern"
+ },
+ {
+  "en": "Spinning rate",
+  "category": "option",
+  "de": "Schleuderdrehzahl"
+ },
+ {
+  "en": "Sport",
+  "category": "program",
+  "de": "Sport",
+  "es": "Sport",
+  "fr": "Sport",
+  "nl": "Sport"
+ },
+ {
+  "en": "Sports",
+  "category": "program",
+  "de": "Sportbekleidung"
+ },
+ {
+  "en": "Sportswear",
+  "category": "program",
+  "de": "Sportbekleidung"
+ },
+ {
+  "en": "SportWash",
+  "category": "program",
+  "de": "Sport"
+ },
+ {
+  "en": "STAIN LEVEL",
+  "category": "option",
+  "de": "Kurzprogramme/Verschmutzungsgrad",
+  "es": "Rápidos / Nivel de suciedad",
+  "fr": "Degré de salissure",
+  "nl": "Snel / Vuilgraad"
+ },
+ {
+  "en": "Stain Removal",
+  "category": "option",
+  "es": "Eliminación de manchas"
+ },
+ {
+  "en": "Standby",
+  "category": "status",
+  "de": "Bereitschaftszustand",
+  "es": "En espera"
+ },
+ {
+  "en": "START",
+  "category": "other",
+  "de": "Start",
+  "es": "Inicio"
+ },
+ {
+  "en": "Start/Pause",
+  "category": "status",
+  "de": "Start/Pause",
+  "es": "Inicio/Pausa",
+  "fr": "Départ/Pause",
+  "nl": "Start/Pauze"
+ },
+ {
+  "en": "Start/stop button",
+  "category": "other",
+  "de": "Start/Stopp-Taste"
+ },
+ {
+  "en": "Steam",
+  "category": "option",
+  "de": "Dampf",
+  "es": "Vapor"
+ },
+ {
+  "en": "Steam function",
+  "category": "other",
+  "de": "Dampffunktion"
+ },
+ {
+  "en": "SteamRefresh",
+  "category": "program",
+  "de": "SteamRefresh"
+ },
+ {
+  "en": "Super fast",
+  "category": "option",
+  "de": "Super schnell"
+ },
+ {
+  "en": "Synthetics",
+  "category": "program",
+  "de": "Synthetik",
+  "es": "Sintéticos",
+  "fr": "Synthétique",
+  "nl": "Synthetische stoffen"
+ },
+ {
+  "en": "Synthetics Dry",
+  "category": "program",
+  "es": "Sintéticos seco"
+ },
+ {
+  "en": "Temp.",
+  "category": "setting",
+  "es": "Temp."
+ },
+ {
+  "en": "Temperature",
+  "category": "option",
+  "de": "Temperatur",
+  "es": "Temp.",
+  "fr": "Température",
+  "it": "Temperatura"
+ },
+ {
+  "en": "TEMPERATURE SELECTION",
+  "category": "option",
+  "de": "WASCHTEMPERATURWAHL",
+  "es": "SELECCIÓN TEMPERATURA",
+  "fr": "SELECTION TEMPERATURE",
+  "nl": "TEMPERATUUR SELECTIE"
+ },
+ {
+  "en": "Temperature sensor",
+  "category": "other",
+  "de": "Temperatursensor"
+ },
+ {
+  "en": "Temperature sensor error",
+  "category": "error",
+  "de": "Temperatursensorfehler"
+ },
+ {
+  "en": "Temperature setting",
+  "category": "option",
+  "de": "Einstellen der Temperatur"
+ },
+ {
+  "en": "Thermostat knob",
+  "category": "other",
+  "de": "Thermostatregler",
+  "fr": "Bouton du thermostat",
+  "it": "Manopola del termostato"
+ },
+ {
+  "en": "Time Dry",
+  "category": "option",
+  "es": "Tiempo de secado"
+ },
+ {
+  "en": "Time knob",
+  "category": "other",
+  "de": "Zeitregler",
+  "fr": "Bouton de l'heure",
+  "it": "Manopola del timer"
+ },
+ {
+  "en": "TimeCare",
+  "category": "mode",
+  "de": "TimeCare"
+ },
+ {
+  "en": "Timer",
+  "category": "option",
+  "de": "Timer",
+  "es": "Timer",
+  "fr": "Minuterie",
+  "it": "Timer",
+  "nl": "Timer",
+  "no": "Timer"
+ },
+ {
+  "en": "Timer Off",
+  "category": "status",
+  "de": "Timer Off",
+  "es": "Timer Off",
+  "fr": "Timer Off",
+  "it": "Timer Off",
+  "nl": "Timer Off",
+  "no": "Timer Av"
+ },
+ {
+  "en": "Timer On",
+  "category": "status",
+  "de": "Timer On",
+  "es": "Timer On",
+  "fr": "Timer On",
+  "it": "Timer On",
+  "nl": "Timer On",
+  "no": "Timer På"
+ },
+ {
+  "en": "Timer on/off",
+  "category": "setting",
+  "de": "Timer Ein / Aus",
+  "es": "encender/apagar temporizador",
+  "fr": "minuterie on/off",
+  "it": "accensione/spegnimento del timer",
+  "nl": "Timer aan/uit",
+  "no": "Timer på/av"
+ },
+ {
+  "en": "Total AquaStop",
+  "category": "setting",
+  "de": "Totaler AquaStop"
+ },
+ {
+  "en": "Tumble dryers",
+  "category": "other",
+  "de": "Wäschetrockner"
+ },
+ {
+  "en": "Type of display",
+  "category": "other",
+  "de": "LED display"
+ },
+ {
+  "en": "Unbalance alarm",
+  "category": "error",
+  "es": "Alarma de desequilibrio"
+ },
+ {
+  "en": "Up (+) / Down (-) buttons",
+  "category": "setting",
+  "de": "Aufwärts (+) und Abwärts (-) Tasten",
+  "es": "botones ADJUST + / -",
+  "fr": "Touches Haut (+) et Bas (-)",
+  "it": "Tasti Su (+) e Giù (-)",
+  "nl": "ADJUST-toetsen + / -"
+ },
+ {
+  "en": "Up/Down",
+  "category": "option",
+  "de": "Auf / Ab",
+  "es": "Up/Down (Subir/Bajar)",
+  "fr": "Haut / Bas",
+  "it": "Su/giù",
+  "nl": "Omhoog/Omlaag",
+  "no": "Opp/Ned"
+ },
+ {
+  "en": "Wash",
+  "category": "phase",
+  "es": "Solo lavar"
+ },
+ {
+  "en": "Wash (mode)",
+  "category": "mode",
+  "es": "Lavar"
+ },
+ {
+  "en": "Wash & Dry 49'",
+  "category": "program",
+  "es": "Lavado y Secado 49'"
+ },
+ {
+  "en": "Wash and Dry",
+  "category": "program",
+  "es": "Lavar y secar"
+ },
+ {
+  "en": "Washer dryer",
+  "category": "other",
+  "de": "Waschtrockner"
+ },
+ {
+  "en": "Washing machine",
+  "category": "other",
+  "de": "Waschmaschine"
+ },
+ {
+  "en": "Washing temperature",
+  "category": "option",
+  "de": "Waschtemperatur"
+ },
+ {
+  "en": "Water discharge fault",
+  "category": "error",
+  "es": "Fallo de descarga de agua"
+ },
+ {
+  "en": "Water draining error",
+  "category": "error",
+  "de": "Fehler Abpumpen"
+ },
+ {
+  "en": "WATER FILLING ERROR",
+  "category": "error",
+  "de": "Fehler Wasserzulauf"
+ },
+ {
+  "en": "Water heating error",
+  "category": "error",
+  "de": "Fehler Heizung"
+ },
+ {
+  "en": "Water inflow fault",
+  "category": "error",
+  "es": "Fallo de entrada de agua"
+ },
+ {
+  "en": "Water leak detected in the washing machine area",
+  "category": "error",
+  "de": "Im Waschmaschinenbereich wurde ein Wasserleck festgestellt"
+ },
+ {
+  "en": "Water level sensor",
+  "category": "other",
+  "de": "Wasserpegelsensor"
+ },
+ {
+  "en": "WATER LEVEL SENSOR ERROR",
+  "category": "error",
+  "de": "Fehler des Wasserstandsensors"
+ },
+ {
+  "en": "Water overflow",
+  "category": "error",
+  "de": "Fehler Überlauf"
+ },
+ {
+  "en": "Water+",
+  "category": "option",
+  "de": "Wasser+"
+ },
+ {
+  "en": "WaterPlus",
+  "category": "option",
+  "de": "WaterPlus"
+ },
+ {
+  "en": "Wi-Fi menu",
+  "category": "setting",
+  "de": "Menü Wi-Fi"
+ },
+ {
+  "en": "Wireless connection mode",
+  "category": "other",
+  "de": "Kabelloser Verbindungsmodus",
+  "es": "modo de conexión inalámbrico",
+  "fr": "mode de connexion sans fil",
+  "it": "modalità di connessione wireless",
+  "nl": "draadloze verbindingsmodus",
+  "no": "trådløs tilkoblingsmodus"
+ },
+ {
+  "en": "Wool",
+  "category": "program",
+  "es": "Lana"
+ },
+ {
+  "en": "Wool / Hand wash",
+  "category": "program",
+  "de": "Wolle/Handwäsche"
+ },
+ {
+  "en": "Wool & Hand",
+  "category": "program",
+  "de": "Wolle",
+  "es": "Lana/a Mano",
+  "fr": "Laine/Lavage Main",
+  "nl": "Wol/Handwas"
+ },
+ {
+  "en": "Wool&Hand",
+  "category": "program",
+  "de": "Wolle&Handwäsche"
+ }
+]

--- a/.claude/skills/update-translations/scripts/check_name_units.py
+++ b/.claude/skills/update-translations/scripts/check_name_units.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check consistency between time-unit words in entity names and units in the mapping.
+
+Reports two problems across all language files:
+
+  A. REDUNDANT  — a property has device_class: duration + a unit in the mapping,
+     but its translated name still contains a unit word ("in minutes", "used
+     hours", "(minuten)", leading "Horas de ..."). Home Assistant already
+     renders the unit; drop the word from the name.
+
+  B. UNIT ONLY IN NAME — a name contains a unit word but the property has NO
+     unit in its sensor/number block. Either set the unit in the data dictionary
+     (preferred, so HA renders it) or the name is the only place the unit shows.
+
+Unit detection is word-boundary based and per-language, and deliberately skips
+ambiguous short tokens: Norwegian "timer" (= hours OR timer) and bare Dutch
+"uur"/Italian "ore" are only matched when clearly separate tokens.
+
+Usage:  python3 .../check_name_units.py
+Run from the repository root. Exit code 1 if any REDUNDANT issue is found.
+"""
+import glob
+import json
+import re
+import sys
+
+import yaml
+
+DD = "custom_components/connectlife/data_dictionaries"
+TR = "custom_components/connectlife/translations"
+LANGS = ["en", "de", "es", "fr", "it", "nl", "no"]
+
+# Property/state keys whose name legitimately keeps a unit word (would collide otherwise).
+KEEP = {"set_time_hour", "set_time_minutes"}
+
+DET = {
+    "en": r"\b(minutes?|hours?|seconds?)\b",
+    "de": r"\b(Minuten?|Stunden?|Sekunden?)\b",
+    "es": r"\b(minutos?|horas?|segundos?)\b",
+    "fr": r"\b(minutes?|heures?|secondes?)\b",
+    "it": r"\b(minuti|minuto|ore|ora|secondi|secondo)\b",
+    "nl": r"\b(minuten|minuut|uren|uur|seconden|seconde)\b",
+    "no": r"\b(minutter|minutt|sekunder|sekund)\b",  # 'timer' (=hours) intentionally excluded
+}
+
+
+def build_property_map():
+    pm = {}  # key -> (kind, device_class, unit)
+    for path in sorted(glob.glob(f"{DD}/*.yaml")):
+        try:
+            doc = yaml.safe_load(open(path))
+        except Exception:
+            continue
+        if not doc or not doc.get("properties"):
+            continue
+        for p in doc["properties"]:
+            if not isinstance(p, dict):
+                continue
+            key = (p.get("translation_key") or p.get("property", "")).lower()
+            for kind in ("sensor", "number"):
+                blk = p.get(kind)
+                if isinstance(blk, dict):
+                    pm.setdefault(key, (kind, blk.get("device_class"), blk.get("unit")))
+    return pm
+
+
+def name_of(data, kind, key):
+    return (((data.get("entity", {}) or {}).get(kind, {}) or {}).get(key, {}) or {}).get("name")
+
+
+def main():
+    pm = build_property_map()
+    files = {l: json.load(open(f"{TR}/{l}.json")) for l in LANGS}
+
+    redundant, unit_only = [], []
+    for lang in LANGS:
+        rx = re.compile(DET[lang], re.I)
+        for key, (kind, dc, unit) in pm.items():
+            if key in KEEP:
+                continue
+            n = name_of(files[lang], kind, key)
+            if not isinstance(n, str) or not rx.search(n):
+                continue
+            (redundant if unit else unit_only).append((lang, key, dc, unit, n))
+
+    print(f"A. REDUNDANT unit word in a name that already has a mapping unit: {len(redundant)}")
+    for lang, key, dc, unit, n in redundant:
+        print(f"   [{lang}] {key} (unit={unit}): {n!r}")
+    print(f"\nB. Unit word in a name but NO unit set in the mapping: {len(unit_only)}")
+    for lang, key, dc, unit, n in unit_only:
+        print(f"   [{lang}] {key} (device_class={dc}): {n!r}")
+
+    if redundant:
+        print("\nFix A: strip the unit word from these names (unit is rendered from the mapping).")
+        sys.exit(1)
+    print("\nOK: no redundant unit words in unit-backed names.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/update-translations/scripts/extract_todo.py
+++ b/.claude/skills/update-translations/scripts/extract_todo.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Extract the list of English strings that need translating for a language.
+
+For the given language, finds every key present in en.json but missing from
+<lang>.json, then emits the DISTINCT English strings that don't already have a
+translation elsewhere in the file (those are reused automatically at merge
+time). Each entry carries up to 3 example key paths as context, so short or
+ambiguous labels ("Sl", "Mid", "1000 RPM") can be disambiguated.
+
+Output: local/i18n/<lang>_todo.json  ->  [{"en": ..., "ctx": [key, ...]}, ...]
+
+Usage:  python3 .../extract_todo.py <lang>
+Run from the repository root.
+"""
+import json
+import os
+import sys
+from collections import defaultdict
+
+BASE = "custom_components/connectlife/translations"
+OUT_DIR = "local/i18n"
+
+
+def flatten(obj, prefix=""):
+    out = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.update(flatten(v, f"{prefix}.{k}" if prefix else k))
+    else:
+        out[prefix] = obj
+    return out
+
+
+def main(lang):
+    en = flatten(json.load(open(f"{BASE}/en.json")))
+    target = flatten(json.load(open(f"{BASE}/{lang}.json")))
+
+    val_to_keys = defaultdict(list)
+    for k, v in en.items():
+        val_to_keys[v].append(k)
+
+    # English strings already translated somewhere in the target file -> reused at merge.
+    known = {en[k] for k in target if k in en}
+
+    missing_keys = [k for k in en if k not in target]
+    need = sorted({en[k] for k in missing_keys if en[k] not in known},
+                  key=lambda s: (len(s), s))
+
+    items = [{"en": v, "ctx": val_to_keys[v][:3]} for v in need]
+    os.makedirs(OUT_DIR, exist_ok=True)
+    path = f"{OUT_DIR}/{lang}_todo.json"
+    json.dump(items, open(path, "w"), ensure_ascii=False, indent=1)
+    print(f"[{lang}] {len(missing_keys)} missing keys -> {len(items)} distinct strings to translate")
+    print(f"        wrote {path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: extract_todo.py <lang>")
+    main(sys.argv[1])

--- a/.claude/skills/update-translations/scripts/merge_translations.py
+++ b/.claude/skills/update-translations/scripts/merge_translations.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Merge a translation map into a language file, filling every missing key.
+
+Reads local/i18n/<lang>_translations.json  ->  {english_string: translation}
+For every key present in en.json but missing from <lang>.json, fills it from
+the map, or reuses an existing in-file translation of the same English string.
+
+Refuses to write unless every missing key is filled AND every filled value has
+the same {placeholders} as its English source. Writes ASCII-escaped + sorted
+(match with `uv run python -m scripts.sort_translations`).
+
+Usage:  python3 .../merge_translations.py <lang> [--check]
+Run from the repository root.
+"""
+import json
+import os
+import re
+import sys
+
+BASE = "custom_components/connectlife/translations"
+MAP_DIR = "local/i18n"
+PLACEHOLDER = re.compile(r"\{[^}]+\}")
+
+
+def flatten(obj, prefix=""):
+    out = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.update(flatten(v, f"{prefix}.{k}" if prefix else k))
+    else:
+        out[prefix] = obj
+    return out
+
+
+def set_path(root, dotted, value):
+    cur = root
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        cur = cur.setdefault(part, {})
+    cur[parts[-1]] = value
+
+
+def main(lang, check):
+    en = json.load(open(f"{BASE}/en.json"))
+    target = json.load(open(f"{BASE}/{lang}.json"))
+    en_flat = flatten(en)
+    tgt_flat = flatten(target)
+
+    known = {}
+    for k, v in tgt_flat.items():
+        if k in en_flat:
+            known.setdefault(en_flat[k], v)
+
+    map_path = f"{MAP_DIR}/{lang}_translations.json"
+    tmap = json.load(open(map_path)) if os.path.exists(map_path) else {}
+
+    missing = [k for k in en_flat if k not in tgt_flat]
+    filled = reused = 0
+    unfilled, ph_mismatch = [], []
+    for k in missing:
+        en_val = en_flat[k]
+        if tmap.get(en_val) not in (None, ""):
+            tr, src = tmap[en_val], "map"
+        elif en_val in known:
+            tr, src = known[en_val], "reuse"
+        else:
+            unfilled.append((k, en_val))
+            continue
+        if sorted(PLACEHOLDER.findall(str(en_val))) != sorted(PLACEHOLDER.findall(str(tr))):
+            ph_mismatch.append((k, en_val, tr))
+            continue
+        if not check:
+            set_path(target, k, tr)
+        filled += 1
+        reused += src == "reuse"
+
+    print(f"[{lang}] missing={len(missing)} filled={filled} (reused={reused}) "
+          f"unfilled={len(unfilled)} placeholder_mismatch={len(ph_mismatch)}")
+    for k, e, t in ph_mismatch[:20]:
+        print(f"  PLACEHOLDER MISMATCH {k}\n    en: {e!r}\n    tr: {t!r}")
+    for k, e in unfilled[:30]:
+        print(f"  UNFILLED {k}  <=  {e!r}")
+
+    if check:
+        return
+    if unfilled or ph_mismatch:
+        print("  NOT WRITTEN — resolve unfilled/placeholder issues first.")
+        sys.exit(1)
+    json.dump(target, open(f"{BASE}/{lang}.json", "w"), ensure_ascii=True, indent=2, sort_keys=True)
+    open(f"{BASE}/{lang}.json", "a").write("\n")
+    print(f"  WROTE {BASE}/{lang}.json  (run: uv run python -m scripts.sort_translations)")
+
+
+if __name__ == "__main__":
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if len(args) != 1:
+        sys.exit("usage: merge_translations.py <lang> [--check]")
+    main(args[0], "--check" in sys.argv)

--- a/.claude/skills/update-translations/workflows/README.md
+++ b/.claude/skills/update-translations/workflows/README.md
@@ -1,0 +1,28 @@
+# Translation workflows (multi-agent)
+
+Reference [Workflow-tool](https://docs.claude.com/claude-code) scripts for translating/reviewing at scale (hundreds of strings across 6 languages). They fan out one agent per batch/language and require **explicit multi-agent opt-in** — only run them when the user asks. For small jobs, translate inline instead.
+
+Both read the committed `../glossary.json` and the transient work files under `local/i18n/`.
+
+## `translate.js`
+Per language: batches the work list, translates each batch against the glossary + CONVENTIONS, then a verification pass. A failed verify falls back to the raw translation (never discards work).
+
+Prep, then launch with the Workflow tool:
+```bash
+# 1. extract todo, split into batch files of ~80
+python3 .claude/skills/update-translations/scripts/extract_todo.py <lang>
+python3 - <<'PY'
+import json,os
+lang="<lang>"; d=json.load(open(f"local/i18n/{lang}_todo.json")); os.makedirs("local/i18n",exist_ok=True)
+paths=[]
+for i in range(0,len(d),80):
+    p=f"local/i18n/{lang}_b{i//80:02d}.json"; json.dump(d[i:i+80],open(p,"w"),ensure_ascii=False); paths.append(p)
+print(json.dumps(paths))
+PY
+```
+Then `Workflow({scriptPath: ".../workflows/translate.js", args: {lang, glossaryPath: "<abs .../glossary.json>", batchPaths: [...]}})`. It returns `{lang, map}`; write the map to `local/i18n/<lang>_translations.json` and run `merge_translations.py`.
+
+## `review.js`
+Per-language depth reviewers (fluency/terminology) **plus** one cross-language pass for systematic issues (garbled sources, glossary drift, unit/placeholder drift). Returns structured findings, most-severe first. Args: `{base, counts: {lang: n_batches}, xlangCount}` — see the script header.
+
+> These are templates, not turnkey: adjust batch sizes and paths for the job. The authoritative rules they enforce live in [../CONVENTIONS.md](../CONVENTIONS.md).

--- a/.claude/skills/update-translations/workflows/review.js
+++ b/.claude/skills/update-translations/workflows/review.js
@@ -1,0 +1,112 @@
+export const meta = {
+  name: 'i18n-review',
+  description: 'Review the six translation PRs: per-language fluency/terminology depth + one cross-language pattern pass',
+  phases: [
+    { title: 'PerLanguage', detail: 'one Opus 4.8 reviewer per language, fluency + terminology' },
+    { title: 'CrossLanguage', detail: 'single reviewer over same-English rows to find systematic patterns' },
+  ],
+}
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const { base, counts, xlangCount } = A
+if (!base || !counts || !xlangCount) throw new Error(`bad args: ${JSON.stringify(A)}`)
+const glossaryPath = `${base}/glossary.json`
+const pad = n => String(n).padStart(2, '0')
+const reviewPaths = {}
+for (const [lang, n] of Object.entries(counts)) {
+  reviewPaths[lang] = Array.from({ length: n }, (_, i) => `${base}/${lang}_rev${pad(i)}.json`)
+}
+const xlangPaths = Array.from({ length: xlangCount }, (_, i) => `${base}/xlang${pad(i)}.json`)
+
+const LANG_NAME = {
+  de: 'German (Deutsch)', es: 'Spanish (Español, Spain)', fr: 'French (Français)',
+  it: 'Italian (Italiano)', nl: 'Dutch (Nederlands)', no: 'Norwegian (Bokmål)',
+}
+const RPM_UNIT = { de: 'U/min', es: 'rpm', fr: 'tr/min', it: 'giri/min', nl: 'toeren', no: 'o/min' }
+
+const FINDINGS_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['findings'],
+  properties: { findings: { type: 'array', items: {
+    type: 'object', additionalProperties: false,
+    required: ['en', 'current', 'suggested', 'severity', 'reason'],
+    properties: {
+      en: { type: 'string' },
+      current: { type: 'string' },
+      suggested: { type: 'string' },
+      severity: { type: 'string', description: 'high (wrong/misleading), medium (unnatural/inconsistent), low (nit)' },
+      reason: { type: 'string', description: 'one concise sentence' },
+    },
+  } } },
+}
+
+const XFINDINGS_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['findings'],
+  properties: { findings: { type: 'array', items: {
+    type: 'object', additionalProperties: false,
+    required: ['en', 'pattern', 'langs', 'reason'],
+    properties: {
+      en: { type: 'string' },
+      pattern: { type: 'string', description: 'the systematic issue class, e.g. "garbled English source", "RPM unit missing", "glossary term inconsistent", "placeholder drift"' },
+      langs: { type: 'string', description: 'comma-separated language codes affected' },
+      reason: { type: 'string' },
+    },
+  } } },
+}
+
+const perLangPrompt = (lang, path) => `You are a NATIVE ${LANG_NAME[lang]} speaker and a smart-home appliance domain expert, reviewing machine-produced translations for a Home Assistant integration (ConnectLife appliances: washers, dryers, dehumidifiers, air conditioners, ovens, water heaters).
+
+Read the batch at ${path} — a JSON array of {en, tr} where "en" is the English source and "tr" is the ${LANG_NAME[lang]} translation under review. Also read the authoritative glossary at ${glossaryPath} (array of {en, category, <lang codes>}).
+
+For EACH pair, judge whether "tr" is correct, natural, and uses the terminology a native speaker sees on a real ${LANG_NAME[lang]} appliance. Report ONLY the entries you would change. Skip anything that is already good — do not pad the list.
+
+Flag when:
+- The translation is wrong, misleading, or a false friend / literal mistranslation (severity high).
+- It's grammatically off, uses non-native/anglicized wording, wrong register, or wrong appliance term (severity medium).
+- It contradicts the glossary's ${lang} term for that English string (severity high).
+- Casing/spacing/diacritics are wrong for a ${LANG_NAME[lang]} UI label (severity low).
+- "RPM" appears untranslated instead of "${RPM_UNIT[lang]}" (severity medium).
+Do NOT flag: bare numbers, pure units, or brand/feature tokens (AquaStop, DrumClean, Eco 40-60, Wi-Fi) that legitimately stay unchanged; and do not flag stylistic preferences where the current wording is already idiomatic.
+
+Return {findings: [...]} with en (verbatim), current (the tr as given), suggested (your corrected ${LANG_NAME[lang]} wording), severity, and a one-sentence reason. Empty findings array if the batch is clean.`
+
+const xlangPrompt = (path) => `You are auditing appliance-UI translations across SIX languages at once (de/es/fr/it/nl/no) to find SYSTEMATIC, cross-language PATTERNS — not per-language fluency (other reviewers handle that).
+
+Read the batch at ${path} — a JSON array of rows {en, de?, es?, fr?, it?, nl?, no?}: one English source string and its translation in each language that has it. Also read the glossary at ${glossaryPath}.
+
+Look for issues that recur across languages or reveal a shared root cause:
+- GARBLED / NON-ENGLISH SOURCE: the "en" itself is junk or a code (e.g. "Darhcdq", "An creae mux", "PPU RECIPSS", "Slotdry") that most/all languages tried to translate when it should have been left verbatim. Flag so it can be reverted to the English token everywhere.
+- GLOSSARY INCONSISTENCY: the same concept rendered with different terms across languages when the glossary implies one standard, or one language deviating from its own glossary term.
+- UNIT / FORMAT DRIFT: "RPM" localized in some languages but left English in others; inconsistent handling of %, °C, kg, time formats.
+- PLACEHOLDER / MARKUP DRIFT: {placeholders}, HTML entities, or markdown present in en but dropped/added in one or more languages.
+- STRUCTURAL DIVERGENCE: same English string translated as an action (verb) in some languages and a noun/state in others, where they should agree.
+
+Report one finding per problematic English row. Return {findings: [...]} with en, pattern (the issue class), langs (comma-separated codes affected), and a one-sentence reason. Empty array if the batch shows no systematic issue. Ignore purely idiomatic per-language wording differences — those are expected and are NOT findings.`
+
+phase('PerLanguage')
+const langs = Object.keys(reviewPaths)
+const perLang = await parallel(langs.map(lang => async () => {
+  const batches = reviewPaths[lang]
+  const results = await parallel(batches.map((p, i) => () =>
+    agent(perLangPrompt(lang, p), { label: `review:${lang}#${i}`, phase: 'PerLanguage', schema: FINDINGS_SCHEMA })))
+  const findings = results.filter(Boolean).flatMap(r => r.findings || [])
+  return { lang, findings }
+}))
+
+phase('CrossLanguage')
+const xResults = await parallel(xlangPaths.map((p, i) => () =>
+  agent(xlangPrompt(p), { label: `xlang#${i}`, phase: 'CrossLanguage', schema: XFINDINGS_SCHEMA })))
+const xfindings = xResults.filter(Boolean).flatMap(r => r.findings || [])
+
+const perLanguage = {}
+for (const r of perLang.filter(Boolean)) {
+  const f = r.findings
+  perLanguage[r.lang] = {
+    total: f.length,
+    high: f.filter(x => x.severity === 'high').length,
+    medium: f.filter(x => x.severity === 'medium').length,
+    low: f.filter(x => x.severity === 'low').length,
+    findings: f,
+  }
+}
+log(`per-language findings: ${langs.map(l => `${l}=${perLanguage[l]?.total ?? 0}`).join(' ')}; cross-language patterns: ${xfindings.length}`)
+return { perLanguage, crossLanguage: xfindings }

--- a/.claude/skills/update-translations/workflows/translate.js
+++ b/.claude/skills/update-translations/workflows/translate.js
@@ -1,0 +1,93 @@
+export const meta = {
+  name: 'i18n-translate',
+  description: 'Translate missing ConnectLife HA strings for one language using a manual-sourced glossary, then verify',
+  phases: [
+    { title: 'Translate', detail: 'batched translation using locked appliance glossary' },
+    { title: 'Verify', detail: 'check placeholder parity, glossary compliance, phrasing' },
+  ],
+}
+
+const LANG_NAME = {
+  de: 'German (Deutsch)', es: 'Spanish (Español, European/Spain)', fr: 'French (Français)',
+  it: 'Italian (Italiano)', nl: 'Dutch (Nederlands)', no: 'Norwegian (Bokmål)',
+}
+
+// Localized spin-speed unit per language, matching each file's shipped convention.
+const RPM_UNIT = { de: 'U/min', es: 'rpm', fr: 'tr/min', it: 'giri/min', nl: 'toeren', no: 'o/min' }
+
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const { lang, batchPaths, glossaryPath } = A
+if (!lang || !Array.isArray(batchPaths) || !batchPaths.length || !glossaryPath) {
+  throw new Error(`bad args: lang=${lang} batchPaths=${Array.isArray(batchPaths) ? batchPaths.length : typeof batchPaths} glossaryPath=${glossaryPath}`)
+}
+const langName = LANG_NAME[lang]
+
+const PAIR_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['translations'],
+  properties: { translations: { type: 'array', items: {
+    type: 'object', additionalProperties: false, required: ['en', 'tr'],
+    properties: { en: { type: 'string' }, tr: { type: 'string' } } } } },
+}
+
+const translatePrompt = (path, idx) => `You are a professional localizer translating smart-home appliance UI strings into ${langName} for a Home Assistant integration that exposes ConnectLife appliances (washing machines, tumble dryers, heat-pump dryers, dehumidifiers, air conditioners, ovens/cookers, water heaters).
+
+Read this file: ${path} — a JSON array of {en, ctx}. Translate EVERY item in it. "en" is the English string; "ctx" lists the HA key path(s) where it is used (use it to disambiguate short/ambiguous labels).
+
+Also read the locked glossary at ${glossaryPath} — a JSON array of {en, category, <lang codes>}. This is AUTHORITATIVE appliance terminology sourced from real manuals.
+
+TRANSLATION RULES:
+- If an item's English string matches a glossary entry that has a "${lang}" value, you MUST use that exact ${lang} term (preserve its casing/diacritics). Glossary wins over your own judgment.
+- Use STANDARD CONSUMER APPLIANCE terminology as printed on real ${langName} appliance control panels and manuals — not literal dictionary translations. E.g. washer programs, AC modes (Cool/Heat/Dry/Fan/Auto), cycle phases (Wash/Rinse/Spin/Dry), options (Prewash/Extra Rinse/Steam), fault descriptions.
+- Preserve EXACTLY, unchanged: {curly_braces_placeholders} (e.g. {device_name}, {count}), HTML entities, markdown (**bold**, \\n, backticks, links), leading/trailing spaces, and units/symbols (%, °C, kg, ml, rpm, kWh).
+- SPIN SPEED / RPM: render the unit "RPM" (revolutions per minute) as "${RPM_UNIT[lang]}" in ${langName} — e.g. "1000 RPM" -> "1000 ${RPM_UNIT[lang]}", "Motor speed 800 RPM available" uses "800 ${RPM_UNIT[lang]}". Never leave the English "RPM" in a translated phrase.
+- A bare number ("5", "600"), a pure unit ("kg", "ml"), or a brand/feature token that appliances leave untranslated (e.g. AquaStop, DrumClean, Eco 40-60, AdaptTech, Wi-Fi) should be returned UNCHANGED.
+- ACTION vs STATE (use the "ctx" key path to decide the grammatical form):
+    * A "select" option value (ctx like ".select.<x>.state.<y>") is something the USER PICKS TO COMMAND the appliance. If the label is verb-capable, prefer the ACTION / imperative-command form (e.g. "Start", "Pause", "Cancel", "Reset programs to default", "Open steamer water tank door"). This is the common case for selects.
+    * EXCEPTION: value/enumeration selects whose options are quantities or noun-named modes — spin speeds ("1000 RPM"), durations/times, temperatures, wattages, or mode names like "Delay start"/"Delay end" — stay as NOUNS/values, not verbs.
+    * A "sensor"/"binary_sensor" state or any ".name" label is a NOUN/STATE describing a condition — use the descriptive noun form.
+- Keep it concise: UI labels must stay short. Match capitalization conventions of ${langName} UI (e.g. German nouns capitalized; French/Italian/Spanish/Dutch sentence case for most labels).
+- Long repair/dialog sentences: translate fully and naturally, keeping every placeholder and markdown intact.
+
+OUTPUT: Return {translations: [{en, tr}, ...]} containing EVERY item from the file, with "en" copied VERBATIM from the input (exact same string) and "tr" the ${langName} translation. Do not add, drop, or merge items.`
+
+const verifyPrompt = (pairsJson, idx) => `You are a senior ${langName} reviewer for smart-home appliance UI strings. Below are English→${langName} translation pairs produced by a translator, plus the authoritative glossary at ${glossaryPath} (read it).
+
+Check each pair and FIX where needed:
+- Placeholder/markup parity: the ${langName} text MUST contain exactly the same {placeholders}, HTML entities, \\n, markdown, and units/symbols as the English. If mismatched, fix.
+- Glossary compliance: if the English matches a glossary entry with a "${lang}" value, the translation MUST equal that term. Fix if not.
+- Terminology: ensure standard ${langName} appliance-panel wording (programs, modes, phases, options, faults). Correct anglicisms or literal mistranslations.
+- RPM unit: any "RPM" in a translated phrase MUST be rendered as "${RPM_UNIT[lang]}" (e.g. "1000 ${RPM_UNIT[lang]}"). Fix leftover English "RPM".
+- Untranslated tokens: bare numbers, pure units, and brand/feature names (AquaStop, DrumClean, Eco 40-60, Wi-Fi, etc.) must remain unchanged.
+- Casing/length appropriate for a UI label.
+
+Return {translations: [{en, tr}, ...]} with the SAME "en" values and corrected (or unchanged) "tr". Keep every item.
+
+PAIRS (JSON):
+${pairsJson}`
+
+const results = await pipeline(
+  batchPaths,
+  (path, _orig, idx) => agent(translatePrompt(path, idx), { label: `${lang} tr #${idx}`, phase: 'Translate', schema: PAIR_SCHEMA }),
+  async (res, path, idx) => {
+    const pairs = (res && res.translations) || []
+    if (!pairs.length) return { translations: [] }
+    try {
+      const v = await agent(verifyPrompt(JSON.stringify(pairs), idx), { label: `${lang} vf #${idx}`, phase: 'Verify', schema: PAIR_SCHEMA })
+      // Fall back to unverified translations if verify came back empty/short.
+      if (v && Array.isArray(v.translations) && v.translations.length >= pairs.length * 0.9) return v
+      return { translations: pairs }
+    } catch (e) {
+      return { translations: pairs } // never discard translated work on a verify failure
+    }
+  },
+)
+
+const map = {}
+for (const res of results) {
+  if (!res || !res.translations) continue
+  for (const { en, tr } of res.translations) {
+    if (en != null && tr != null) map[en] = tr
+  }
+}
+log(`${lang}: produced ${Object.keys(map).length} translations across ${batchPaths.length} batches`)
+return { lang, count: Object.keys(map).length, batches: batchPaths.length, map }


### PR DESCRIPTION
Adds a reusable `update-translations` skill under `.claude/skills/` that captures how translations are added and reviewed for this integration.

## Contents
- **SKILL.md** — the procedure: find missing keys (`check_translations`) → extract work list with key-path context → translate per conventions → merge with placeholder-parity + reuse → sort → verify 0 missing → one PR per language.
- **CONVENTIONS.md** — locked rules: appliance-specific terminology from public user manuals; units/measurements live in the mapping (`device_class` + `unit`), never baked into names (with the clock-component and ordinal exceptions); per-language RPM (`U/min`/`rpm`/`tr/min`/`giri/min`/`toeren`/`o/min`); action-vs-state form for select values; preserve `{placeholders}`; never rename property/state keys; Norwegian `timer` caveat; garbled-source handling.
- **glossary.json** — 278 appliance terms (program/mode/option/phase/status/error/setting) harvested from public manuals, per language.
- **scripts/** — `extract_todo.py`, `merge_translations.py` (placeholder-parity + reuse, refuses to write if unfilled), `check_name_units.py` (bidirectional QA: unit-in-name ↔ mapping unit).
- **workflows/** — reference multi-agent templates for translating and reviewing at scale.

Transient work files live under `local/i18n/` (gitignored). All three scripts smoke-tested against the current translation files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)