### PR TITLE
Make Spanish delay end time name consistent

### DIFF
--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -2007,7 +2007,7 @@
         "name": "Tiempo del filtro de carb\u00f3n"
       },
       "delayendtime": {
-        "name": "Hora de finalizaci\u00f3n diferida"
+        "name": "Finalizaci\u00f3n diferida"
       },
       "delayendtime_hour": {
         "name": "Hora de finalizaci\u00f3n diferida"
@@ -2186,7 +2186,7 @@
         "name": "Intensidad de cocci\u00f3n"
       },
       "delayendtime": {
-        "name": "Hora de finalizaci\u00f3n diferida",
+        "name": "Finalizaci\u00f3n diferida",
         "state": {
           "10_hours": "10 horas",
           "11_hours": "11 horas",


### PR DESCRIPTION
The delayed-end-time entity is a duration (Home Assistant renders the hour unit from the mapping), but its Spanish name was translated three different ways across the number, select, and sensor platforms — two of which redundantly led with "Hora de".

Align all three to "Finalización diferida", matching the sensor platform's existing translation and the French/Italian/Norwegian names. No keys renamed; display text only.