### PR TITLE
Scale f_power_consumption by 0.01 on heat pump (016)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/016.yaml
+++ b/custom_components/connectlife/data_dictionaries/016.yaml
@@ -27,6 +27,7 @@ properties:
     sensor:
       device_class: energy
       unit: kWh
+      multiplier: 0.01
       read_only: true
       state_class: total_increasing
     icon: mdi:lightning-bolt


### PR DESCRIPTION
The energy sensor `f_power_consumption` on heat pumps (device type 016) read 100x too high: the raw API value is in units of 10 Wh (0.01 kWh) but was exposed directly as `kWh`.

Adds `multiplier: 0.01` to convert the raw value to kWh, using the existing sensor-level `multiplier` support.

Reported value: device shows 1452.64 kWh, HA showed 145264 kWh (exactly 100x).

Scoped to 016 only, matching the confirmed report. The same unscaled mapping exists in 006–009 but there is no evidence yet that those share this scale.

Fixes #626