### PR TITLE
Add Light On/Off buttons to 009-128 AC

### DIFF
--- a/custom_components/connectlife/data_dictionaries/009-128.yaml
+++ b/custom_components/connectlife/data_dictionaries/009-128.yaml
@@ -1,3 +1,15 @@
+buttons:
+# t_dimmer is write-only on this model (not reported in statusList), so it is
+# exposed as two buttons rather than a switch. Values are inverted relative to
+# 009-104: here 0 = LED on, 1 = LED off.
+- key: light_on
+  icon: mdi:lightbulb-on
+  write:
+    t_dimmer: 0
+- key: light_off
+  icon: mdi:lightbulb-off
+  write:
+    t_dimmer: 1
 climate:
   presets:
     - t_eco: 1


### PR DESCRIPTION
009-128 has write-only `t_dimmer` (not reported in statusList), so the inherited base switch never instantiates and the display LED can't be controlled from HA. Expose `light_on`/`light_off` buttons like 009-104, but with inverted values (`0` = on, `1` = off) as confirmed on 009-128 hardware.

Closes #625