### PR TITLE
Fix climate preset_mode always reading "none"

### DIFF
--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -20,8 +20,6 @@ from .const import (
     HVAC_MODE,
     HVAC_ACTION,
     IS_ON,
-    PRESET,
-    PRESETS,
     SWING_MODE,
     SWING_HORIZONTAL_MODE,
     TARGET_HUMIDITY,
@@ -218,9 +216,8 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
                         _LOGGER.warning("Not mapping %d to unknown HVACAction %s", k, v)
             self.unknown_values[status] = data_dictionary.properties[status].climate.unknown_value
 
-        if data_dictionary.climate and PRESETS in data_dictionary.climate:
-            # TODO: Check that all presets have names and convert to map in Dictionaries.
-            self.preset_map = {preset.copy().pop(PRESET): preset for preset in data_dictionary.climate[PRESETS]}
+        if data_dictionary.presets:
+            self.preset_map = data_dictionary.presets
             self._attr_preset_modes = list(self.preset_map.keys())
             if PRESET_NONE not in self._attr_preset_modes:
                 self._attr_preset_modes.append(PRESET_NONE)

--- a/custom_components/connectlife/data_dictionaries/properties-schema.json
+++ b/custom_components/connectlife/data_dictionaries/properties-schema.json
@@ -64,6 +64,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "preset"
+      ],
       "additionalProperties": {
         "type": "integer"
       },

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -43,6 +43,7 @@ NAME = "name"
 OFF = "off"
 ON = "on"
 OPTIONS = "options"
+PRESET = "preset"
 PRESETS = "presets"
 PROPERTY = "property"
 PROPERTIES = "properties"
@@ -446,6 +447,9 @@ class Dictionary:
     climate: dict | None
     properties: dict[str, Property]
     buttons: list[Button]
+    # Presets parsed from the climate block, keyed by preset name with the name
+    # stripped from the value so it can be matched against a device status list.
+    presets: dict[str, dict[str, int]] = field(default_factory=dict)
     # Cloud statistics endpoint for this device family (None = none): "air_duct_energy"
     # (air conditioners) or "energy_consumption_curve" (appliances). Dispatched via the
     # statistics_sources registry.
@@ -624,10 +628,18 @@ class Dictionaries:
             if sensor_key != SOURCE
         }
 
+        # Parse presets into a name -> values map. The preset name is stripped
+        # from the value so it can be matched against a device status list.
+        presets = {
+            preset[PRESET]: {k: v for k, v in preset.items() if k != PRESET}
+            for preset in _val(climate or {}, PRESETS, [])
+        }
+
         dictionary = Dictionary(
             climate=climate,
             properties=properties,
             buttons=buttons,
+            presets=presets,
             statistics_source=statistics_source,
             statistics_sensors=statistics_sensors,
         )

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from homeassistant.components.climate import ClimateEntityFeature, HVACMode
+from homeassistant.components.climate import (
+    ClimateEntityFeature,
+    HVACMode,
+    PRESET_NONE,
+)
 
 from custom_components.connectlife.climate import (
     ConnectLifeClimate,
@@ -146,6 +150,69 @@ def test_contested_targets_reports_only_multi_candidate_targets() -> None:
 
     single = _swing_appliance({"t_power": 1, "t_up_down": 0})
     assert contested_climate_targets(single, dictionary) == {}
+
+
+# Presets as parsed by Dictionaries: keyed by name, name stripped from the value
+# (see test_dictionaries for the parsing itself). Mirrors 009-100.yaml.
+_PRESETS = {
+    "eco": {"t_eco": 1, "t_fan_mute": 0, "t_power": 1, "t_sleep": 0, "t_super": 0},
+    "mute": {"t_eco": 0, "t_fan_mute": 1, "t_power": 1},
+}
+
+
+def _preset_dictionary() -> Dictionary:
+    """A climate device exposing `eco` and `mute` presets."""
+    return Dictionary(
+        climate=None,
+        properties={
+            "t_power": Property(
+                {"property": "t_power", "climate": {"target": "is_on"}}
+            ),
+        },
+        buttons=[],
+        presets=_PRESETS,
+    )
+
+
+def _preset_appliance(status_list: dict[str, int]) -> SimpleNamespace:
+    return SimpleNamespace(
+        device_id="dev1",
+        device_nickname="AC",
+        device_feature_name="100",
+        device_type_code="009",
+        device_feature_code="100",
+        room_name="Bedroom",
+        status_list=status_list,
+    )
+
+
+def test_preset_mode_reads_back_active_preset() -> None:
+    """When the status list matches a preset's values, `preset_mode` reflects it.
+
+    Regression test for issue #627: `preset_mode` previously always read `none`
+    because the preset name key leaked into the value and never matched the
+    device status list.
+    """
+    dictionary = _preset_dictionary()
+    # Status list matching the `eco` preset exactly.
+    appliance = _preset_appliance(
+        {"t_power": 1, "t_eco": 1, "t_fan_mute": 0, "t_sleep": 0, "t_super": 0}
+    )
+    climate = ConnectLifeClimate(_coordinator(appliance), appliance, dictionary)
+
+    assert climate._attr_preset_mode == "eco"
+
+
+def test_preset_modes_expose_parsed_names_plus_none() -> None:
+    """The entity offers the parsed preset names plus PRESET_NONE, and enables
+    the PRESET_MODE feature."""
+    dictionary = _preset_dictionary()
+    appliance = _preset_appliance({"t_power": 1, "t_eco": 0, "t_fan_mute": 0})
+    climate = ConnectLifeClimate(_coordinator(appliance), appliance, dictionary)
+
+    assert climate.preset_map is dictionary.presets
+    assert set(climate._attr_preset_modes) == {"eco", "mute", PRESET_NONE}
+    assert climate._attr_supported_features & ClimateEntityFeature.PRESET_MODE
 
 
 def test_hvac_mode_alias_does_not_override_canonical_reverse_mapping() -> None:

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -401,6 +401,48 @@ def test_statistics_block_inherited_by_feature_override(build_dictionary):
     }
 
 
+def test_presets_parsed_into_name_keyed_map(build_dictionary):
+    """A climate `presets` block is parsed into a name -> values map, with the
+    `preset` name stripped from the value so it can be matched against a device
+    status list (issue #627)."""
+    d = build_dictionary(
+        sub={
+            "climate": {
+                "presets": [
+                    {"t_eco": 1, "t_power": 1, "preset": "eco"},
+                    {"t_eco": 0, "t_fan_mute": 1, "t_power": 1, "preset": "mute"},
+                ]
+            },
+            "properties": _MINIMAL_PROPS,
+        }
+    )
+    assert d.presets == {
+        "eco": {"t_eco": 1, "t_power": 1},
+        "mute": {"t_eco": 0, "t_fan_mute": 1, "t_power": 1},
+    }
+
+
+def test_presets_absent_defaults_to_empty(build_dictionary):
+    """No climate/presets block -> an empty preset map."""
+    d = build_dictionary(sub={"properties": _MINIMAL_PROPS})
+    assert d.presets == {}
+
+
+def test_presets_parse_does_not_mutate_source(build_dictionary):
+    """Parsing must not strip the name from the source presets, so a second
+    parse (as on reload) still resolves the names (issue #77 reload)."""
+    sub = {
+        "climate": {"presets": [{"t_eco": 1, "t_power": 1, "preset": "eco"}]},
+        "properties": _MINIMAL_PROPS,
+    }
+    build_dictionary(sub=sub)
+    # Source presets still carry the name.
+    assert sub["climate"]["presets"][0]["preset"] == "eco"
+    # A second parse still resolves it.
+    d = build_dictionary(sub=sub)
+    assert set(d.presets) == {"eco"}
+
+
 def test_statistics_block_replaced_by_feature_override(build_dictionary):
     # A feature override with its own statistics block replaces the base's entirely.
     d = build_dictionary(


### PR DESCRIPTION
## Problem

`preset_mode` on climate entities always read back as `none`, even when the appliance was in a preset (e.g. `eco`) — see #627. Setting a preset still worked, so only the read-back was affected.

## Cause

The preset lookup keyed each preset by name but stored the *whole* preset dict — including the `preset` name key — as the value:

```python
self.preset_map = {preset.copy().pop(PRESET): preset for preset in ...]}
```

`preset.copy().pop(PRESET)` pops the name off a throwaway copy for the key, but the value is the untouched original, so it still carries `"preset": "eco"`. Read-back tests `preset_map[name].items() <= status_list.items()`, and the device status list never contains a `preset` key, so the match always failed.

This regressed in #77, which added `.copy()` to fix a reload `KeyError` — but that also stopped the name being stripped from the stored value.

## Fix

- Parse presets once in `Dictionaries` into a name → values map with the name stripped, and have the climate entity consume it directly. This removes the per-entity parsing and the now-unnecessary `.copy()` reload guard (parsing never mutates the cached source).
- Require a `preset` name on each preset in the schema, so a nameless preset fails validation instead of crashing entity setup.

## Tests

- Parse-layer (`test_dictionaries.py`): name stripped, absent → empty, no source mutation on reparse.
- Entity-layer (`test_climate.py`): `preset_mode` reads back the active preset (#627), and the entity exposes the parsed names plus `PRESET_NONE`.
- Verified end-to-end against the real `009-100.yaml`: an `eco` status list reads back `preset_mode = eco`.