### PR TITLE
Fix program mapping for ASKO DFI777UXXL dishwasher (015-dishwasher-60.3)

### DIFF
--- a/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
+++ b/custom_components/connectlife/data_dictionaries/015-dishwasher-60.3.yaml
@@ -1,16 +1,16 @@
-# Assumed ASKO family (untested); labels copied from 015-dishwasher-60.2
+# ASKO dishwasher (DFI777UXXL family).
 properties:
   - property: Selected_program_id_status
     select:
       options:
         0: eco
         1: auto
-        2: intensive
-        3: quick_pro
-        4: time_program
-        5: hygiene
-        6: rinse_and_hold
-        7: self_cleaning
+        2: universal
+        3: intensive
+        4: quick_pro
+        5: preheated
+        6: crystal_glass
+        7: time_program
       command:
         name: Selected_program_id
   - property: Selected_program_mode

--- a/custom_components/connectlife/strings.json
+++ b/custom_components/connectlife/strings.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Baby care",
           "clean": "Clean",
           "color": "Color",
+          "crystal_glass": "Crystal glass",
           "down_feathers": "Down feathers",
           "draining": "Draining",
           "drum_clean": "Drum clean",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "No program selected",
           "one_hour": "One hour",
           "pet_hair_removal": "Pet hair removal",
+          "preheated": "Preheated",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rinse and hold",
           "rinsing_softening": "Rinsing & Softening",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Spinning & Draining",
           "sportswear": "Sportswear",
           "time_program": "Time program",
+          "universal": "Universal",
           "white_cotton": "White Cotton",
           "wool_manual": "Wool & Manual"
         }

--- a/custom_components/connectlife/translations/de.json
+++ b/custom_components/connectlife/translations/de.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Baby",
           "clean": "Reinigung",
           "color": "Farbig",
+          "crystal_glass": "Kristallglas",
           "down_feathers": "Daunenfedern",
           "draining": "Abpumpen",
           "drum_clean": "Trommelreinigung",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "Kein Programm ausgew\u00e4hlt",
           "one_hour": "1 Stunde",
           "pet_hair_removal": "Tierhaarentfernung",
+          "preheated": "Vorgew\u00e4rmt",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Sp\u00fclen & Warten",
           "rinsing_softening": "Sp\u00fclen & Weichsp\u00fclen",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Schleudern & Abpumpen",
           "sportswear": "Sport",
           "time_program": "Zeitprogramm",
+          "universal": "Universal",
           "white_cotton": "Wei\u00dfe Baumwolle",
           "wool_manual": "Wolle & Manuell"
         }

--- a/custom_components/connectlife/translations/en.json
+++ b/custom_components/connectlife/translations/en.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Baby care",
           "clean": "Clean",
           "color": "Color",
+          "crystal_glass": "Crystal glass",
           "down_feathers": "Down feathers",
           "draining": "Draining",
           "drum_clean": "Drum clean",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "No program selected",
           "one_hour": "One hour",
           "pet_hair_removal": "Pet hair removal",
+          "preheated": "Preheated",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rinse and hold",
           "rinsing_softening": "Rinsing & Softening",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Spinning & Draining",
           "sportswear": "Sportswear",
           "time_program": "Time program",
+          "universal": "Universal",
           "white_cotton": "White Cotton",
           "wool_manual": "Wool & Manual"
         }

--- a/custom_components/connectlife/translations/es.json
+++ b/custom_components/connectlife/translations/es.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Ropa beb\u00e9",
           "clean": "Limpieza",
           "color": "Color",
+          "crystal_glass": "Cristaler\u00eda",
           "down_feathers": "Plum\u00f3n",
           "draining": "Desag\u00fce",
           "drum_clean": "Limpieza Tambor",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "Ning\u00fan programa seleccionado",
           "one_hour": "1 hora",
           "pet_hair_removal": "Eliminaci\u00f3n de pelo de mascotas",
+          "preheated": "Precalentado",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Aclarar y esperar",
           "rinsing_softening": "Aclarado y suavizado",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Centrifugado y desag\u00fce",
           "sportswear": "Ropa deporte",
           "time_program": "Programa temporizado",
+          "universal": "Universal",
           "white_cotton": "Algod\u00f3n blanco",
           "wool_manual": "Lana y manual"
         }

--- a/custom_components/connectlife/translations/fr.json
+++ b/custom_components/connectlife/translations/fr.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Soin b\u00e9b\u00e9",
           "clean": "Nettoyage",
           "color": "Couleurs",
+          "crystal_glass": "Cristal",
           "down_feathers": "Duvet",
           "draining": "Vidange",
           "drum_clean": "Nettoyage du tambour",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "Aucun programme s\u00e9lectionn\u00e9",
           "one_hour": "Une heure",
           "pet_hair_removal": "\u00c9limination des poils d'animaux",
+          "preheated": "Pr\u00e9chauff\u00e9",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Rin\u00e7age et maintien",
           "rinsing_softening": "Rin\u00e7age et assouplissement",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Essorage et vidange",
           "sportswear": "V\u00eatements de sport",
           "time_program": "Programme minut\u00e9",
+          "universal": "Universel",
           "white_cotton": "Coton blanc",
           "wool_manual": "Laine et manuel"
         }

--- a/custom_components/connectlife/translations/it.json
+++ b/custom_components/connectlife/translations/it.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Bambino",
           "clean": "Pulizia",
           "color": "Colorati",
+          "crystal_glass": "Cristallo",
           "down_feathers": "Piumini d'oca",
           "draining": "Scarico",
           "drum_clean": "Pulizia cestello",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "Nessun programma selezionato",
           "one_hour": "Un'ora",
           "pet_hair_removal": "Rimozione peli di animali",
+          "preheated": "Preriscaldato",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Risciacquo e attesa",
           "rinsing_softening": "Risciacquo e ammorbidente",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Centrifuga e scarico",
           "sportswear": "Sport",
           "time_program": "Programma a tempo",
+          "universal": "Universale",
           "white_cotton": "Cotone bianco",
           "wool_manual": "Lana e Manuale"
         }

--- a/custom_components/connectlife/translations/nl.json
+++ b/custom_components/connectlife/translations/nl.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Baby",
           "clean": "Schoon",
           "color": "Kleur",
+          "crystal_glass": "Kristalglas",
           "down_feathers": "Donsveren",
           "draining": "Afpompen",
           "drum_clean": "Trommelreiniging",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "Geen programma geselecteerd",
           "one_hour": "1 uur",
           "pet_hair_removal": "Huisdierhaar verwijderen",
+          "preheated": "Voorverwarmd",
           "quick_pro": "Quick pro",
           "rinse_and_hold": "Spoelen en wachten",
           "rinsing_softening": "Spoelen & verzachten",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Centrifugeren & afpompen",
           "sportswear": "Sport",
           "time_program": "Tijdprogramma",
+          "universal": "Universeel",
           "white_cotton": "Wit katoen",
           "wool_manual": "Wol & Handmatig"
         }

--- a/custom_components/connectlife/translations/no.json
+++ b/custom_components/connectlife/translations/no.json
@@ -2484,6 +2484,7 @@
           "baby_care": "Baby",
           "clean": "Rens",
           "color": "Farge",
+          "crystal_glass": "Krystallglass",
           "down_feathers": "Dun",
           "draining": "T\u00f8mmer vann",
           "drum_clean": "Trommelrens",
@@ -2499,6 +2500,7 @@
           "no_program_selected": "Intet program valgt",
           "one_hour": "\u00c9n time",
           "pet_hair_removal": "Fjerning av kj\u00e6ledyrh\u00e5r",
+          "preheated": "Forvarmet",
           "quick_pro": "Hurtig pro",
           "rinse_and_hold": "Skyll og hold",
           "rinsing_softening": "Skylling og myking",
@@ -2508,6 +2510,7 @@
           "spinning_draining": "Sentrifugering og t\u00f8mming",
           "sportswear": "Sport",
           "time_program": "Tidsprogram",
+          "universal": "Universal",
           "white_cotton": "Hvit bomull",
           "wool_manual": "Ull og manuell"
         }


### PR DESCRIPTION
Fixes #624.

The `015-dishwasher-60.3` program list was copied from `015-dishwasher-60.2`,
but this variant enumerates its programs in a different order. Labels from
index 2 onwards were shifted, so selecting a program in HA ran the wrong cycle
on the device — and changing it on the device showed the wrong program in HA.

## Changes

Remap `Selected_program_id_status` to the order the device actually uses:

| Index | Before | After |
|-------|--------|-------|
| 0 | eco | eco |
| 1 | auto | auto |
| 2 | intensive | universal |
| 3 | quick_pro | intensive |
| 4 | time_program | quick_pro |
| 5 | hygiene | preheated |
| 6 | rinse_and_hold | crystal_glass |
| 7 | self_cleaning | time_program |

Adds the new option labels (`universal`, `preheated`, `crystal_glass`) to
`en` and translations in `no`/`de`/`es`/`fr`/`it`/`nl`.

## Not included (no reported values to confirm)

- **Program modes** `green` / `intensive` / `uv`, which this model offers but
  `015-dishwasher-60.2` did not — their `Selected_program_mode` integer values
  are unknown.
- **Programs beyond index 7** (hygiene, plastic, rinse and hold, self
  cleaning) — their indices aren't confirmed.

These can follow once the raw values are captured — either via mitmproxy, or
by changing the program/mode on the device (or in the mobile app) and reading
the reported value after HA next polls.