### PR TITLE
Apply code-review findings: away mode fix, log-spam fixes, dictionary cache safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,15 @@ uv run python -m scripts.sort_translations
 # Run the test server for local development
 uv run python -m connectlife.test_server -d <dumps_dir>
 
+# Run the test suite
+uv run pytest
+
 # Type check
 uv run pyright
 
-# CI runs hassfest only (no linter/formatter/type checker configured)
+# CI (on pull_request and push to main) runs: hassfest, HACS validation,
+# validate_mappings, gen_strings (strings/translations up to date), pytest,
+# and pyright.
 ```
 
 ## Architecture

--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from connectlife.api import LifeConnectAuthError, LifeConnectError
+from connectlife.appliance import ConnectLifeAppliance
 
 from .client import create_api
 from .const import (
@@ -40,6 +41,12 @@ PLATFORMS: list[Platform] = [
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _warm_dictionary_cache(appliances: list[ConnectLifeAppliance]) -> None:
+    """Load (and cache) the data dictionary for each appliance."""
+    for appliance in appliances:
+        Dictionaries.get_dictionary(appliance)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -81,8 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # synchronous disk I/O doesn't block the event loop when platform setup
     # (and the has_statistics check below) call Dictionaries.get_dictionary().
     await hass.async_add_executor_job(
-        lambda appliances: [Dictionaries.get_dictionary(a) for a in appliances],
-        list(coordinator.data.values()),
+        _warm_dictionary_cache, list(coordinator.data.values())
     )
 
     # Only create the statistics coordinator if some device opts into a statistics

--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -81,7 +81,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # synchronous disk I/O doesn't block the event loop when platform setup
     # (and the has_statistics check below) call Dictionaries.get_dictionary().
     await hass.async_add_executor_job(
-        lambda: [Dictionaries.get_dictionary(a) for a in coordinator.data.values()]
+        lambda appliances: [Dictionaries.get_dictionary(a) for a in appliances],
+        list(coordinator.data.values()),
     )
 
     # Only create the statistics coordinator if some device opts into a statistics

--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -76,6 +76,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
+    # Data dictionaries are loaded from packaged YAML files on first access per
+    # device type and then cached; warm the cache via the executor so that
+    # synchronous disk I/O doesn't block the event loop when platform setup
+    # (and the has_statistics check below) call Dictionaries.get_dictionary().
+    await hass.async_add_executor_job(
+        lambda: [Dictionaries.get_dictionary(a) for a in coordinator.data.values()]
+    )
+
     # Only create the statistics coordinator if some device opts into a statistics
     # endpoint with at least one sensor enabled (otherwise it would poll nothing).
     has_statistics = any(

--- a/custom_components/connectlife/__init__.py
+++ b/custom_components/connectlife/__init__.py
@@ -57,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     test_server_url = (
         entry.options.get(CONF_TEST_SERVER_URL)
-       if entry.options.get(CONF_DEVELOPMENT_MODE)
+        if entry.options.get(CONF_DEVELOPMENT_MODE)
         else None
     )
     api = create_api(

--- a/custom_components/connectlife/binary_sensor.py
+++ b/custom_components/connectlife/binary_sensor.py
@@ -89,7 +89,7 @@ class ConnectLifeBinaryStatusSensor(ConnectLifeEntity, BinarySensorEntity):
                 self._attr_is_on = self.options[value]
             else:
                 self._attr_is_on = None
-                _LOGGER.warning("Unknown value %d for %s", value, self.status)
+                self._warn_unexpected_value(self.status, value)
 
 
 class ConnectLifeOfflineStateBinarySensor(ConnectLifeEntity, BinarySensorEntity):

--- a/custom_components/connectlife/climate.py
+++ b/custom_components/connectlife/climate.py
@@ -261,19 +261,19 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
                         self._attr_fan_mode = self.fan_mode_map[value]
                     else:
                         self._attr_fan_mode = None
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 elif target == SWING_MODE:
                     if value in self.swing_mode_map:
                         self._attr_swing_mode = self.swing_mode_map[value]
                     else:
                         self._attr_swing_mode = None
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 elif target == SWING_HORIZONTAL_MODE:
                     if value in self.swing_horizontal_mode_map:
                         self._attr_swing_horizontal_mode = self.swing_horizontal_mode_map[value]
                     else:
                         self._attr_swing_horizontal_mode = None
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 elif target == TEMPERATURE_UNIT:
                     if value in self.temperature_unit_map:
                         self._attr_temperature_unit = self.temperature_unit_map[value]
@@ -282,7 +282,7 @@ class ConnectLifeClimate(ConnectLifeEntity, ClimateEntity):
                         if max_temp := self.get_temperature_limit(self.max_temperature_map):
                             self._attr_max_temp = max_temp
                     else:
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 else:
                     if value == self.unknown_values[status]:
                         value = None

--- a/custom_components/connectlife/config_flow.py
+++ b/custom_components/connectlife/config_flow.py
@@ -263,7 +263,9 @@ class OptionsFlowHandler(OptionsFlow):
         coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
         appliance = coordinator.data.get(self._device_id)
         contested = (
-            contested_climate_targets(appliance, Dictionaries.get_dictionary(appliance))
+            contested_climate_targets(
+                appliance, await Dictionaries.async_get_dictionary(self.hass, appliance)
+            )
             if appliance
             else {}
         )

--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -1,3 +1,4 @@
+import aiohttp
 import async_timeout
 import logging
 from collections.abc import Mapping
@@ -229,12 +230,15 @@ class ConnectLifeStatisticsCoordinator(DataUpdateCoordinator[dict[str, EnergyRes
         """Fetch statistics for appliances whose data dictionary opts into an endpoint."""
         result: dict[str, EnergyResult | None] = {}
         for device_id, appliance in self.appliance_coordinator.data.items():
-            dictionary = Dictionaries.get_dictionary(appliance)
+            # Async variant: an appliance of a new device type may appear after
+            # setup warmed the cache, and the YAML load must not block the loop.
+            dictionary = await Dictionaries.async_get_dictionary(self.hass, appliance)
             source = STATISTICS_SOURCES.get(dictionary.statistics_source or "")
             if source is None or not enabled_sensors(
                 dictionary.statistics_source, dictionary.statistics_sensors
             ):
                 continue
+            result[device_id] = None
             try:
                 result[device_id] = await source.fetch(self.api, appliance)
             except LifeConnectAuthError:
@@ -242,15 +246,15 @@ class ConnectLifeStatisticsCoordinator(DataUpdateCoordinator[dict[str, EnergyRes
                 # re-login) for every remaining device. Recovers on the next cycle.
                 _LOGGER.debug("Statistics auth failed; skipping remaining devices this cycle")
                 break
-            except LifeConnectError:
-                # Expected, transient API-level failure for this device; quiet by
-                # design so one flaky device doesn't spam the log every cycle.
+            except (LifeConnectError, aiohttp.ClientError, TimeoutError):
+                # Transient API or connectivity failure for this device (the
+                # library's token fetch raises raw client/timeout errors); quiet
+                # by design so an outage doesn't spam the log every cycle.
                 _LOGGER.debug(
                     "Failed to fetch statistics for %s",
                     appliance.device_nickname,
                     exc_info=True,
                 )
-                result[device_id] = None
             except Exception:
                 # Anything else is unexpected (e.g. a response shape we don't
                 # handle) and worth surfacing by default rather than hiding
@@ -260,5 +264,4 @@ class ConnectLifeStatisticsCoordinator(DataUpdateCoordinator[dict[str, EnergyRes
                     appliance.device_nickname,
                     exc_info=True,
                 )
-                result[device_id] = None
         return result

--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -90,7 +90,7 @@ class ConnectLifeCoordinator(DataUpdateCoordinator[dict[str, ConnectLifeApplianc
 
     def add_entity(self, entity_unique_id: str, platform: Platform):
         """Add known entity."""
-        self.entities[entity_unique_id] = platform;
+        self.entities[entity_unique_id] = platform
 
     async def cleanup_removed_entities(self) -> None:
         """

--- a/custom_components/connectlife/coordinator.py
+++ b/custom_components/connectlife/coordinator.py
@@ -242,9 +242,21 @@ class ConnectLifeStatisticsCoordinator(DataUpdateCoordinator[dict[str, EnergyRes
                 # re-login) for every remaining device. Recovers on the next cycle.
                 _LOGGER.debug("Statistics auth failed; skipping remaining devices this cycle")
                 break
-            except Exception:
+            except LifeConnectError:
+                # Expected, transient API-level failure for this device; quiet by
+                # design so one flaky device doesn't spam the log every cycle.
                 _LOGGER.debug(
                     "Failed to fetch statistics for %s",
+                    appliance.device_nickname,
+                    exc_info=True,
+                )
+                result[device_id] = None
+            except Exception:
+                # Anything else is unexpected (e.g. a response shape we don't
+                # handle) and worth surfacing by default rather than hiding
+                # behind debug logging.
+                _LOGGER.warning(
+                    "Unexpected error fetching statistics for %s",
                     appliance.device_nickname,
                     exc_info=True,
                 )

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -616,7 +616,14 @@ class Dictionaries:
         for prop in list(properties.values()):
             if prop.combine:
                 for source in prop.combine:
-                    properties[source[PROPERTY]].disable = True
+                    source_name = source[PROPERTY]
+                    if source_name not in raw_entries:
+                        _LOGGER.warning(
+                            "%s combine references unknown property %s",
+                            prop.name,
+                            source_name,
+                        )
+                    properties[source_name].disable = True
 
         buttons = [Button(b) for b in raw_buttons]
 

--- a/custom_components/connectlife/dictionaries.py
+++ b/custom_components/connectlife/dictionaries.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict
 
 from connectlife.appliance import ConnectLifeAppliance
 from homeassistant.const import Platform, EntityCategory
+from homeassistant.core import HomeAssistant
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.humidifier import HumidifierDeviceClass
 from homeassistant.components.number import NumberDeviceClass
@@ -616,14 +617,9 @@ class Dictionaries:
         for prop in list(properties.values()):
             if prop.combine:
                 for source in prop.combine:
-                    source_name = source[PROPERTY]
-                    if source_name not in raw_entries:
-                        _LOGGER.warning(
-                            "%s combine references unknown property %s",
-                            prop.name,
-                            source_name,
-                        )
-                    properties[source_name].disable = True
+                    # Sources normally appear only inside combine blocks (no
+                    # top-level entry); the defaultdict creates and disables them.
+                    properties[source[PROPERTY]].disable = True
 
         buttons = [Button(b) for b in raw_buttons]
 
@@ -650,5 +646,19 @@ class Dictionaries:
             statistics_source=statistics_source,
             statistics_sensors=statistics_sensors,
         )
-        cls.dictionaries[key] = dictionary
-        return dictionary
+        # get_dictionary runs both on the event loop and in executor jobs, and
+        # multiple config entries may warm the cache concurrently; setdefault
+        # keeps the first-stored instance so all consumers share one object
+        # (some Property state, e.g. learned select/sensor options, is mutated
+        # at runtime and must not be split across duplicate instances).
+        return cls.dictionaries.setdefault(key, dictionary)
+
+    @classmethod
+    async def async_get_dictionary(
+        cls, hass: HomeAssistant, appliance: ConnectLifeAppliance
+    ) -> Dictionary:
+        """Loop-safe variant: offloads the blocking YAML load on a cache miss."""
+        key = f"{appliance.device_type_code}-{appliance.device_feature_code}"
+        if key in cls.dictionaries:
+            return cls.dictionaries[key]
+        return await hass.async_add_executor_job(cls.get_dictionary, appliance)

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from abc import abstractmethod
+from collections.abc import Mapping
 
 from connectlife.api import LifeConnectError
 from homeassistant.const import Platform
@@ -121,7 +122,11 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
         self._refresh_state()
         self.async_write_ha_state()
 
-    async def async_update_device(self, command: dict[str, int], properties: dict[str, int] | None = None):
+    async def async_update_device(
+        self,
+        command: dict[str, int | str],
+        properties: Mapping[str, int | str] | None = None,
+    ):
         if properties is None:
             properties = command.copy()
         try:

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -38,6 +38,8 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
     _unavailable_status: str | None = None
     _unavailable_value: int | None = None
 
+    _warned_unexpected_values: dict[str, object]
+
     def __init__(
             self,
             coordinator: ConnectLifeCoordinator,
@@ -46,6 +48,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
             platform: Platform):
         """Initialize the entity."""
         super().__init__(coordinator)
+        self._warned_unexpected_values = {}
         self.device_id = appliance.device_id
         self.nickname = appliance.device_nickname
         self._attr_unique_id = f'{appliance.device_id}-{entity_name}'
@@ -165,6 +168,18 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
                 await self.coordinator.async_update_device(self.device_id, command, properties)
         except LifeConnectError as api_error:
             raise ServiceValidationError(str(api_error)) from api_error
+
+    def _warn_unexpected_value(self, status: str, value: object) -> None:
+        """Log an unexpected raw value for ``status``, once per distinct value.
+
+        Devices that persistently report a value we don't have a mapping for
+        would otherwise re-log the same warning on every coordinator poll
+        (every 60s). Only re-warn when the offending value actually changes.
+        """
+        if self._warned_unexpected_values.get(status, object()) == value:
+            return
+        self._warned_unexpected_values[status] = value
+        _LOGGER.warning("Got unexpected value %s for %s (%s)", value, status, self.nickname)
 
     def to_translation_key(self, property_name: str) -> str:
         return re.sub(r'_+', '_', property_name.strip().lower().replace(" ", "_"))

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -39,8 +39,6 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
     _unavailable_status: str | None = None
     _unavailable_value: int | None = None
 
-    _warned_unexpected_values: dict[str, object]
-
     def __init__(
             self,
             coordinator: ConnectLifeCoordinator,
@@ -49,7 +47,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
             platform: Platform):
         """Initialize the entity."""
         super().__init__(coordinator)
-        self._warned_unexpected_values = {}
+        self._warned_unexpected_values: dict[str, set[object]] = {}
         self.device_id = appliance.device_id
         self.nickname = appliance.device_nickname
         self._attr_unique_id = f'{appliance.device_id}-{entity_name}'
@@ -179,11 +177,12 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
 
         Devices that persistently report a value we don't have a mapping for
         would otherwise re-log the same warning on every coordinator poll
-        (every 60s). Only re-warn when the offending value actually changes.
+        (every 60s) — including devices that alternate between unmapped values.
         """
-        if self._warned_unexpected_values.get(status, object()) == value:
+        warned = self._warned_unexpected_values.setdefault(status, set())
+        if value in warned:
             return
-        self._warned_unexpected_values[status] = value
+        warned.add(value)
         _LOGGER.warning("Got unexpected value %s for %s (%s)", value, status, self.nickname)
 
     def to_translation_key(self, property_name: str) -> str:

--- a/custom_components/connectlife/entity.py
+++ b/custom_components/connectlife/entity.py
@@ -124,14 +124,14 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
 
     async def async_update_device(
         self,
-        command: dict[str, int | str],
+        command: Mapping[str, int | str],
         properties: Mapping[str, int | str] | None = None,
     ):
         if properties is None:
-            properties = command.copy()
+            properties = command
         try:
             if self._disable_beep:
-                command["t_beep"] = 0
+                command = {**command, "t_beep": 0}
                 try:
                     await self.coordinator.async_update_device(self.device_id, command, properties)
                     self._disable_beep_failure_count = 0
@@ -146,7 +146,7 @@ class ConnectLifeEntity(CoordinatorEntity[ConnectLifeCoordinator]):
                         self.nickname,
                         err,
                     )
-                    command.pop("t_beep", None)
+                    command = {k: v for k, v in command.items() if k != "t_beep"}
                     try:
                         await self.coordinator.async_update_device(self.device_id, command, properties)
                     except LifeConnectError:

--- a/custom_components/connectlife/humidifier.py
+++ b/custom_components/connectlife/humidifier.py
@@ -137,7 +137,7 @@ class ConnectLifeHumidifier(ConnectLifeEntity, HumidifierEntity):
                         self._attr_mode = self.mode_map[value]
                     else:
                         self._attr_mode = None
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 else:
                     setattr(self, f"_attr_{target}", value)
 

--- a/custom_components/connectlife/select.py
+++ b/custom_components/connectlife/select.py
@@ -1,7 +1,5 @@
 """Provides a selector for ConnectLife."""
 
-import logging
-
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -14,8 +12,6 @@ from .dictionaries import Dictionaries, Property
 from .entity import ConnectLifeEntity
 from connectlife.appliance import ConnectLifeAppliance
 from .utils import climate_bound_properties, device_target_overrides, has_platform
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -88,12 +84,7 @@ class ConnectLifeSelect(ConnectLifeEntity, SelectEntity):
             else:
                 str_value = str(value)
                 if str_value not in self._attr_options:
-                    _LOGGER.warning(
-                        "Got unexpected value %s for %s (%s)",
-                        str_value,
-                        self.status,
-                        self.nickname,
-                    )
+                    self._warn_unexpected_value(self.status, str_value)
                     self.options_map[value] = str_value
                     self.reverse_options_map[str_value] = value
                     self._attr_options = [*self._attr_options, str_value]

--- a/custom_components/connectlife/sensor.py
+++ b/custom_components/connectlife/sensor.py
@@ -166,12 +166,7 @@ class ConnectLifeStatusSensor(ConnectLifeEntity, SensorEntity):
                 elif value != self.unknown_value:
                     str_value = str(value)
                     if self._attr_options is not None and str_value not in self._attr_options:
-                        _LOGGER.warning(
-                            "Got unexpected value %s for %s (%s)",
-                            str_value,
-                            self.status,
-                            self.nickname,
-                        )
+                        self._warn_unexpected_value(self.status, str_value)
                         self.options_map[value] = str_value
                         self._attr_options = [*self._attr_options, str_value]
                     value = str_value

--- a/custom_components/connectlife/services.py
+++ b/custom_components/connectlife/services.py
@@ -1,4 +1,4 @@
-"""Services for the Fully Kiosk Browser integration."""
+"""Services for the ConnectLife integration."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
-    """Set up the services for the Fully Kiosk Browser integration."""
+    """Set up the services for the ConnectLife integration."""
 
     async def collect_coordinators(
         device_ids: list[str],

--- a/custom_components/connectlife/switch.py
+++ b/custom_components/connectlife/switch.py
@@ -84,7 +84,7 @@ class ConnectLifeSwitch(ConnectLifeEntity, SwitchEntity):
                 self._attr_is_on = False
             else:
                 self._attr_is_on = None
-                _LOGGER.warning("Unknown value %s for %s", str(value), self.status)
+                self._warn_unexpected_value(self.status, value)
 
     async def async_turn_off(self, **kwargs):
         """Turn off."""

--- a/custom_components/connectlife/water_heater.py
+++ b/custom_components/connectlife/water_heater.py
@@ -199,7 +199,7 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
                     else:
                         self._warn_unexpected_value(status, value)
                 elif target == IS_AWAY_MODE_ON:
-                    self._attr_is_away_mode_on = IS_AWAY_MODE_ON == self.is_away_mode_on
+                    self._attr_is_away_mode_on = value == self.away_mode_on
                 else:
                     if value == self.unknown_values[status]:
                         value = None

--- a/custom_components/connectlife/water_heater.py
+++ b/custom_components/connectlife/water_heater.py
@@ -177,7 +177,7 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
                         self._attr_state = self.state_map[value]  # type: ignore[assignment]
                     else:
                         self._attr_state = None
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 elif target == CURRENT_OPERATION:
                     if value in self.operation_map:
                         self._attr_current_operation = self.operation_map[value]
@@ -188,7 +188,7 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
                                 self.is_on = True
                     else:
                         self._attr_current_operation = None
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 elif target == TEMPERATURE_UNIT:
                     if value in self.temperature_unit_map:
                         self._attr_temperature_unit = self.temperature_unit_map[value]
@@ -197,7 +197,7 @@ class ConnectLifeWaterHeater(ConnectLifeEntity, WaterHeaterEntity):
                         if max_temp := self.get_temperature_limit(self.max_temperature_map):
                             self._attr_max_temp = max_temp
                     else:
-                        _LOGGER.warning("Got unexpected value %d for %s (%s)", value, status, self.nickname)
+                        self._warn_unexpected_value(status, value)
                 elif target == IS_AWAY_MODE_ON:
                     self._attr_is_away_mode_on = IS_AWAY_MODE_ON == self.is_away_mode_on
                 else:


### PR DESCRIPTION
Applies the 10 findings from a high-effort code review of the recent log-spam/error-handling work.

## Correctness

- **water_heater**: the away-mode branch compared the string constant `IS_AWAY_MODE_ON` against the entity's own bool property — always `False`, so away mode could never display as on. Now compares the reported raw value against the reverse-mapped `away_mode_on`.
- **dictionaries**: removed the new "combine references unknown property" warning. Combine sources normally appear only inside `combine:` blocks (per the data-dictionary README), so the warning fired for every valid shipped mapping (025/013/030) on first dictionary load.
- **coordinator (statistics)**: `connectlife` 0.9.1's `_fetch_energy` awaits the token fetch *outside* its internal try/except, so raw `aiohttp.ClientError`/`TimeoutError` escaped to the new `except Exception` warning branch — a transient outage logged a warning traceback per appliance every 10-minute cycle. These now land in the quiet debug branch.
- **entity**: `_warn_unexpected_value` deduped only on the *last* value per status, so a device alternating between two unmapped values re-warned every 60s poll. Now keeps a set of warned values per status (once per distinct value).
- **dictionaries**: `get_dictionary` runs on both the event loop and executor threads (and across multiple config entries) against an unlocked class-level cache; `setdefault` now guarantees all consumers share the first-stored instance, so runtime-mutated dictionary state (learned select/sensor options) can't split across duplicates.

## Cleanup

- New `Dictionaries.async_get_dictionary(hass, appliance)` offloads the blocking YAML load on a cache miss; used by the statistics coordinator and the options flow — the two paths that can hit a cold cache after setup (e.g. an appliance of a new device type added mid-session).
- sensor/select: the two remaining inline "Got unexpected value" warnings now route through the shared `_warn_unexpected_value` helper (select.py's now-unused logger removed).
- coordinator: `result[device_id] = None` is pre-seeded once before the `try` instead of duplicated in both except branches (behavior-equivalent — the sensor treats missing and `None` alike).
- `__init__`: the warm-up side-effect lambda/list comprehension became a named `_warm_dictionary_cache` helper.
- entity: `_warned_unexpected_values` is declared once, as an annotated assignment in `__init__`.

## Testing

Verified statically; `uv` isn't available on this machine, so pytest/pyright ran via CI only — please check the workflow results on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)